### PR TITLE
fix duplicated declaration

### DIFF
--- a/src/lang/src/func_basic.js
+++ b/src/lang/src/func_basic.js
@@ -51,10 +51,6 @@ var NakoBasicFunc = {
     josi: [["が"],["と"]],
     fn: function (a, b) { return a == b; },
   },
-  "等": {
-    josi: [["が"],["と"]],
-    fn: function (a, b) { return a == b; },
-  },
   /* --- */
   __print_log: "",
   __print: function (s) {


### PR DESCRIPTION
`"等"` の定義が重複しているので、片方を取り除きました。

FYI: strict modeであれば、重複したプロパティ定義はsyntax errorとなります。