### PR TITLE
文字列の変換において、改行やクオーテーションが全て変換されないバグを修正

### DIFF
--- a/src/editor/index.php
+++ b/src/editor/index.php
@@ -1,3 +1,2 @@
 <?php
-echo "todo : editor"
-
+echo "todo : editor";

--- a/src/lang/demo/basic.css
+++ b/src/lang/demo/basic.css
@@ -1,0 +1,3 @@
+.sbox {
+    border: 1px solid gray;
+}

--- a/src/lang/demo/basic.html
+++ b/src/lang/demo/basic.html
@@ -1,86 +1,105 @@
 <!DOCTYPE html>
 <html>
-  <head>
+<head>
     <meta charset="utf-8">
     <title>なでしこ3</title>
     <!-- なでしこを使う準備 -->
     <script src="../release/nako3.js"></script>
     <script>
-      var display_id = "info";
-      // なでしこの関数をカスタマイズ
-      navigator.nako3.getFunc("言").fn = function(msg){ alert(msg); };
-      navigator.nako3.getFunc("表示").fn = function(s) {
-        $(display_id).innerHTML += tohtml(s) + "<br>";
-      };
-      // なでしこにオリジナル関数をJSで追加
-      navigator.nako3.addFunc("色変更", 
-        [["に","へ"]],
-        function (s) { $("info").style.color = s; });
-      // 簡易DOMアクセス関数など
-      function $(id) { return document.getElementById(id); }
-      function tohtml(s) {
-        s = "" + s;
-        return s.replace('&','&amp;').replace('<','&lt;').replace('>','&gt;');
-      }
+        var display_id = "info";
+
+        // なでしこの関数をカスタマイズ
+        navigator.nako3.getFunc("言").fn = function (msg) {
+            alert(msg);
+        };
+
+        navigator.nako3.getFunc("表示").fn = function (s) {
+            $(display_id).innerHTML += to_html(s) + "<br>";
+        };
+
+        // なでしこにオリジナル関数をJSで追加
+        navigator.nako3.addFunc("色変更",
+            [["に", "へ"]],
+            function (s) {
+                $("info").style.color = s;
+            });
+
+        // 簡易DOMアクセス関数など
+        function $(id) {
+            return document.getElementById(id);
+        }
+
+        function to_html(s) {
+            s = "" + s;
+            return s.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;');
+        }
     </script>
     <style>
-      .info {
-        font-size:1em;
-        border: 1px solid gray;
-        padding:8px;
-        background-color: #f0fff0; }
-      #err {
-        font-size:1em;
-        border: 1px solid gray;
-        padding:8px;
-        background-color: #fff0f0; }
-      #srcbox {
-        font-size:1em;
-        background-color: #fffff0;
-        width: 99%; }
-      .src {
-        font-size:1em;
-        background-color: #f0f0f0;
-        width: 99%; }
-      .sbox {
-        border-bottom: 1px solid silver;
-        margin: 8px;
-        padding: 8px; }
+        .info {
+            font-size: 1em;
+            border: 1px solid gray;
+            padding: 8px;
+            background-color: #f0fff0;
+        }
+
+        #err {
+            font-size: 1em;
+            border: 1px solid gray;
+            padding: 8px;
+            background-color: #fff0f0;
+        }
+
+        #srcbox {
+            font-size: 1em;
+            background-color: #fffff0;
+            width: 99%;
+        }
+
+        .src {
+            font-size: 1em;
+            background-color: #f0f0f0;
+            width: 99%;
+        }
+
+        .sbox {
+            border-bottom: 1px solid silver;
+            margin: 8px;
+            padding: 8px;
+        }
     </style>
-  </head>
-  <body>
-    <h1>なでしこ3デモ</h1>
-    <hr>
-    <h3>試してみよう！</h3>
-    <div class="sbox">
-      <h4>簡単な計算</h4>
-      <textarea id="calc_txt" class="src" rows="5">
+</head>
+<body>
+<h1>なでしこ3デモ</h1>
+<hr>
+<h3>試してみよう！</h3>
+<div class="sbox">
+    <h4>簡単な計算</h4>
+    <textarea id="calc_txt" class="src" rows="5">
 1+2を表示。
 100÷5を表示。
-(1 + 2)×3を表示。
-      </textarea><br>
-      <button onclick="runbox('calc_txt')">実行</button>
-      <div><p id="calc_txt_info" class="info"></p></div>
-    </div>
+(1 + 2)×3を表示。</textarea><br>
+    <button onclick="run_box('calc_txt')">実行</button>
+    <div><p id="calc_txt_info" class="info"></p></div>
+</div>
 
-    <div class="sbox">
-      <h4>変数を使った計算</h4>
-      <textarea id="var_txt" class="src" rows="10">
+<div class="sbox">
+    <h4>変数を使った計算</h4>
+    <textarea id="var_txt" class="src" rows="10">
 価格=500円
 個数＝3個
 税率=0.08
 合計額=価格×個数
 税額＝合計額×税率
 支払い＝合計額＋税額
-「お支払いは、{支払い}円です！」と表示。
-      </textarea><br>
-      <div><p id="var_txt_info" class="info"></p></div>
-      <button onclick="runbox('var_txt')">実行</button><br>
-    </div>
-    
-    <div class="sbox">
-      <h4>BMIの計算</h4>
-      <textarea id="bmi_txt" class="src" rows="13">
+「お支払いは、{支払い}円です！」と表示。</textarea><br>
+    <div><p id="var_txt_info" class="info"></p></div>
+    <button onclick="run_box('var_txt')">実行</button>
+    <br>
+</div>
+
+<div class="sbox">
+    <h4>BMIの計算</h4>
+    <textarea id="bmi_txt" class="src" rows="13">
 身長＝160
 体重＝50
 身長M=身長÷100
@@ -89,28 +108,31 @@ BMI=体重÷(身長M×身長M)
 肥満度=(体重/適正体重) 
 「BMI ... {BMI}」を表示。
 「肥満度 ... {肥満度}」を表示。
-「適正体重 ... {適正体重}」を表示。
-      </textarea><br>
-      <div><p id="bmi_txt_info" class="info"></p></div>
-      <button onclick="runbox('bmi_txt')">実行</button><br>
-    </div>
-    
-<script>
-function runbox(id) {
-  if (id == null) { alert('idが設定されていません。'); return; }
-  var src = $(id).value;
-  display_id = id + "_info";
-  $(display_id).innerHTML = "";
-  try {
-    navigator.nako3.run(src);
-  } catch (e) {
-    console.log(e);
-  }
-}
-function resetbox() {
-  $("info").innerHTML = "";
-}
-</script>
-  </body>
-</html>
+「適正体重 ... {適正体重}」を表示。</textarea><br>
+    <div><p id="bmi_txt_info" class="info"></p></div>
+    <button onclick="run_box('bmi_txt')">実行</button>
+    <br>
+</div>
 
+<script>
+    function run_box(id) {
+        if (id == null) {
+            alert('idが設定されていません。');
+            return;
+        }
+        var src = $(id).value;
+        display_id = id + "_info";
+        $(display_id).innerHTML = "";
+        try {
+            navigator.nako3.run(src);
+        } catch (e) {
+            console.log(e);
+        }
+    }
+
+    function reset_box() {
+        $("info").innerHTML = "";
+    }
+</script>
+</body>
+</html>

--- a/src/lang/demo/basic.html
+++ b/src/lang/demo/basic.html
@@ -34,39 +34,8 @@
             return s.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;');
         }
     </script>
-    <style>
-        .info {
-            font-size: 1em;
-            border: 1px solid gray;
-            padding: 8px;
-            background-color: #f0fff0;
-        }
-
-        #err {
-            font-size: 1em;
-            border: 1px solid gray;
-            padding: 8px;
-            background-color: #fff0f0;
-        }
-
-        #srcbox {
-            font-size: 1em;
-            background-color: #fffff0;
-            width: 99%;
-        }
-
-        .src {
-            font-size: 1em;
-            background-color: #f0f0f0;
-            width: 99%;
-        }
-
-        .sbox {
-            border-bottom: 1px solid silver;
-            margin: 8px;
-            padding: 8px;
-        }
-    </style>
+    <link rel="stylesheet" type="text/css" href="common.css">
+    <link rel="stylesheet" type="text/css" href="basic.css">
 </head>
 <body>
 <h1>なでしこ3デモ</h1>

--- a/src/lang/demo/basic.html
+++ b/src/lang/demo/basic.html
@@ -5,35 +5,8 @@
     <title>なでしこ3</title>
     <!-- なでしこを使う準備 -->
     <script src="../release/nako3.js"></script>
-    <script>
-        var display_id = "info";
-
-        // なでしこの関数をカスタマイズ
-        navigator.nako3.getFunc("言").fn = function (msg) {
-            alert(msg);
-        };
-
-        navigator.nako3.getFunc("表示").fn = function (s) {
-            $(display_id).innerHTML += to_html(s) + "<br>";
-        };
-
-        // なでしこにオリジナル関数をJSで追加
-        navigator.nako3.addFunc("色変更",
-            [["に", "へ"]],
-            function (s) {
-                $("info").style.color = s;
-            });
-
-        // 簡易DOMアクセス関数など
-        function $(id) {
-            return document.getElementById(id);
-        }
-
-        function to_html(s) {
-            s = "" + s;
-            return s.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;');
-        }
-    </script>
+    <script src="common.js"></script>
+    <script src="basic_flow.js"></script>
     <link rel="stylesheet" type="text/css" href="common.css">
     <link rel="stylesheet" type="text/css" href="basic.css">
 </head>
@@ -82,26 +55,5 @@ BMI=体重÷(身長M×身長M)
     <button onclick="run_box('bmi_txt')">実行</button>
     <br>
 </div>
-
-<script>
-    function run_box(id) {
-        if (id == null) {
-            alert('idが設定されていません。');
-            return;
-        }
-        var src = $(id).value;
-        display_id = id + "_info";
-        $(display_id).innerHTML = "";
-        try {
-            navigator.nako3.run(src);
-        } catch (e) {
-            console.log(e);
-        }
-    }
-
-    function reset_box() {
-        $("info").innerHTML = "";
-    }
-</script>
 </body>
 </html>

--- a/src/lang/demo/basic_flow.js
+++ b/src/lang/demo/basic_flow.js
@@ -1,0 +1,22 @@
+var display_id = "info";
+
+// なでしこの関数をカスタマイズ
+navigator.nako3.getFunc("表示").fn = function (s) {
+    $(display_id).innerHTML += to_html(s) + "<br>";
+};
+
+// 簡易DOMアクセス関数など
+function run_box(id) {
+    if (id == null) {
+        alert('idが設定されていません。');
+        return;
+    }
+    var src = $(id).value;
+    display_id = id + "_info";
+    $(display_id).innerHTML = "";
+    try {
+        navigator.nako3.run(src);
+    } catch (e) {
+        console.log(e);
+    }
+}

--- a/src/lang/demo/common.css
+++ b/src/lang/demo/common.css
@@ -1,0 +1,33 @@
+.info, #err, #src_box, .src {
+    font-size: 1em;
+}
+
+.info, #err {
+    border: 1px solid gray;
+    padding: 8px;
+}
+
+.info {
+    background-color: #f0fff0;
+}
+
+#err {
+    background-color: #fff0f0;
+}
+
+#src_box, .src {
+    width: 99%;
+}
+
+#src_box {
+    background-color: #fffff0;
+}
+
+.src {
+    background-color: #f0f0f0;
+}
+
+.sbox {
+    border-bottom: 1px solid silver;
+    margin: 8px;
+}

--- a/src/lang/demo/common.js
+++ b/src/lang/demo/common.js
@@ -1,0 +1,25 @@
+// なでしこの関数をカスタマイズ
+navigator.nako3.getFunc("言").fn = function (msg) {
+    alert(msg);
+};
+
+// なでしこにオリジナル関数をJSで追加
+navigator.nako3.addFunc("色変更",
+    [["に", "へ"]],
+    function (s) {
+        $("info").style.color = s;
+    });
+
+// 簡易DOMアクセス関数など
+function $(id) {
+    return document.getElementById(id);
+}
+
+function to_html(s) {
+    s = "" + s;
+    return s.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;');
+}
+
+function reset_box() {
+    $("info").innerHTML = "";
+}

--- a/src/lang/demo/flow.css
+++ b/src/lang/demo/flow.css
@@ -1,0 +1,3 @@
+.sbox {
+    padding: 8px;
+}

--- a/src/lang/demo/flow.html
+++ b/src/lang/demo/flow.html
@@ -1,64 +1,79 @@
 <!DOCTYPE html>
 <html>
-  <head>
+<head>
     <meta charset="utf-8">
     <title>なでしこ3</title>
     <!-- なでしこを使う準備 -->
     <script src="../release/nako3.js"></script>
     <script>
-      var display_id = "info";
-      // なでしこの関数をカスタマイズ
-      navigator.nako3.getFunc("言").fn = function(msg){ alert(msg); };
-      navigator.nako3.getFunc("表示").fn = function(s) {
-        $(display_id).innerHTML += tohtml(s) + "<br>";
-      };
-      // なでしこにオリジナル関数をJSで追加
-      navigator.nako3.addFunc("色変更", 
-        [["に","へ"]],
-        function (s) { $("info").style.color = s; });
-      // 簡易DOMアクセス関数など
-      function $(id) { return document.getElementById(id); }
-      function tohtml(s) {
-        s = "" + s;
-        return s.replace('&','&amp;').replace('<','&lt;').replace('>','&gt;');
-      }
+        var display_id = "info";
+
+        // なでしこの関数をカスタマイズ
+        navigator.nako3.getFunc("言").fn = function (msg) {
+            alert(msg);
+        };
+
+        navigator.nako3.getFunc("表示").fn = function (s) {
+            $(display_id).innerHTML += to_html(s) + "<br>";
+        };
+
+        // なでしこにオリジナル関数をJSで追加
+        navigator.nako3.addFunc("色変更",
+            [["に", "へ"]],
+            function (s) {
+                $("info").style.color = s;
+            });
+
+        // 簡易DOMアクセス関数など
+        function $(id) {
+            return document.getElementById(id);
+        }
+
+        function to_html(s) {
+            s = "" + s;
+            return s.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;');
+        }
     </script>
     <style>
-      .info {
-        font-size:1em;
-        border: 1px solid gray;
-        padding:8px;
-        background-color: #f0fff0; }
-      .src {
-        font-size:1em;
-        background-color: #f0f0f0;
-        width: 99%; }
-      .sbox {
-        border-bottom: 1px solid silver;
-        margin: 8px;
-        padding: 8px; }
+        .info {
+            font-size: 1em;
+            border: 1px solid gray;
+            padding: 8px;
+            background-color: #f0fff0;
+        }
+
+        .src {
+            font-size: 1em;
+            background-color: #f0f0f0;
+            width: 99%;
+        }
+
+        .sbox {
+            border-bottom: 1px solid silver;
+            margin: 8px;
+            padding: 8px;
+        }
     </style>
-  </head>
-  <body>
-    <h1>なでしこ3デモ</h1>
-    <hr>
-    <h3>試してみよう！</h3>
-    <div class="sbox">
-      <h4>単純な繰り返し</h4>
-      <textarea id="calc_txt" class="src" rows="8">
+</head>
+<body>
+<h1>なでしこ3デモ</h1>
+<hr>
+<h3>試してみよう！</h3>
+<div class="sbox">
+    <h4>単純な繰り返し</h4>
+    <textarea id="calc_txt" class="src" rows="8">
 # --- 単純な繰り返し ---
 3回「ワン」と表示。
 # --- 変数を指定する場合 ---
 N=5
-(N)回「にゃーん」と表示。
-      </textarea><br>
-      <button onclick="runbox('calc_txt')">実行</button>
-      <div><p id="calc_txt_info" class="info"></p></div>
-    </div>
+(N)回「にゃーん」と表示。</textarea><br>
+    <button onclick="run_box('calc_txt')">実行</button>
+    <div><p id="calc_txt_info" class="info"></p></div>
+</div>
 
-    <div class="sbox">
-      <h4>条件分岐</h4>
-      <textarea id="var_txt" class="src" rows="10">
+<div class="sbox">
+    <h4>条件分岐</h4>
+    <textarea id="var_txt" class="src" rows="10">
 --------------
 A=50
 もし、A＝50ならば
@@ -72,28 +87,27 @@ B=30
 　　「Bは50」と表示。
 違えば
 　　「Bは50ではない」と表示。
---------------
-      </textarea><br>
-      <div><p id="var_txt_info" class="info"></p></div>
-      <button onclick="runbox('var_txt')">実行</button>
-      <p>※インデントによるブロック表現は廃止されました。
-      ブロックの末尾には、「ここまで」または「ーーー」や「---」と書きます。「-」の数は3つ以上ならいくつでも大丈夫です。</p>
-    </div>
-    
-    <div class="sbox">
-      <h4>ループ変数を用いた繰り返し</h4>
-      <textarea id="bmi_txt" class="src" rows="5">
+--------------</textarea><br>
+    <div><p id="var_txt_info" class="info"></p></div>
+    <button onclick="run_box('var_txt')">実行</button>
+    <p>※インデントによるブロック表現は廃止されました。
+        ブロックの末尾には、「ここまで」または「ーーー」や「---」と書きます。「-」の数は3つ以上ならいくつでも大丈夫です。</p>
+</div>
+
+<div class="sbox">
+    <h4>ループ変数を用いた繰り返し</h4>
+    <textarea id="bmi_txt" class="src" rows="5">
 Nを１から５まで繰り返す
 　　Ｎを表示。
-ここまで。
-      </textarea><br>
-      <div><p id="bmi_txt_info" class="info"></p></div>
-      <button onclick="runbox('bmi_txt')">実行</button><br>
-    </div>
-    
-    <div class="sbox">
-      <h4>指定条件付きの繰り返し</h4>
-      <textarea id="while_txt" class="src" rows="8">
+ここまで。</textarea><br>
+    <div><p id="bmi_txt_info" class="info"></p></div>
+    <button onclick="run_box('bmi_txt')">実行</button>
+    <br>
+</div>
+
+<div class="sbox">
+    <h4>指定条件付きの繰り返し</h4>
+    <textarea id="while_txt" class="src" rows="8">
 A=1
 (A≦3)の間
 　　「{A}回目」を表示
@@ -103,15 +117,15 @@ B=3
 (B>0)の間
 　　「B={B}」を表示。
 　　B=B-1
-------
-      </textarea><br>
-      <div><p id="while_txt_info" class="info"></p></div>
-      <button onclick="runbox('while_txt')">実行</button><br>
-    </div>
-    
-    <div class="sbox">
-      <h4>簡易条件文</h4>
-      <textarea id="if2_txt" class="src" rows="10">
+------</textarea><br>
+    <div><p id="while_txt_info" class="info"></p></div>
+    <button onclick="run_box('while_txt')">実行</button>
+    <br>
+</div>
+
+<div class="sbox">
+    <h4>簡易条件文</h4>
+    <textarea id="if2_txt" class="src" rows="10">
 --------------
 N=10
 もしNが100未満ならば「OK1」と表示。
@@ -121,27 +135,29 @@ N=10
 N=30
 もしNが10以下ならば「NG」と表示。
 違えば「OK4」と表示。
---------------
-      </textarea><br>
-      <div><p id="if2_txt_info" class="info"></p></div>
-      <button onclick="runbox('if2_txt')">実行</button>
-    </div>
+--------------</textarea><br>
+    <div><p id="if2_txt_info" class="info"></p></div>
+    <button onclick="run_box('if2_txt')">実行</button>
+</div>
 <script>
-function runbox(id) {
-  if (id == null) { alert('idが設定されていません。'); return; }
-  var src = $(id).value;
-  display_id = id + "_info";
-  $(display_id).innerHTML = "";
-  try {
-    navigator.nako3.run(src);
-  } catch (e) {
-    console.log(e);
-  }
-}
-function resetbox() {
-  $("info").innerHTML = "";
-}
-</script>
-  </body>
-</html>
+    function run_box(id) {
+        if (id == null) {
+            alert('idが設定されていません。');
+            return;
+        }
+        var src = $(id).value;
+        display_id = id + "_info";
+        $(display_id).innerHTML = "";
+        try {
+            navigator.nako3.run(src);
+        } catch (e) {
+            console.log(e);
+        }
+    }
 
+    function reset_box() {
+        $("info").innerHTML = "";
+    }
+</script>
+</body>
+</html>

--- a/src/lang/demo/flow.html
+++ b/src/lang/demo/flow.html
@@ -5,35 +5,8 @@
     <title>なでしこ3</title>
     <!-- なでしこを使う準備 -->
     <script src="../release/nako3.js"></script>
-    <script>
-        var display_id = "info";
-
-        // なでしこの関数をカスタマイズ
-        navigator.nako3.getFunc("言").fn = function (msg) {
-            alert(msg);
-        };
-
-        navigator.nako3.getFunc("表示").fn = function (s) {
-            $(display_id).innerHTML += to_html(s) + "<br>";
-        };
-
-        // なでしこにオリジナル関数をJSで追加
-        navigator.nako3.addFunc("色変更",
-            [["に", "へ"]],
-            function (s) {
-                $("info").style.color = s;
-            });
-
-        // 簡易DOMアクセス関数など
-        function $(id) {
-            return document.getElementById(id);
-        }
-
-        function to_html(s) {
-            s = "" + s;
-            return s.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;');
-        }
-    </script>
+    <script src="common.js"></script>
+    <script src="basic_flow.js"></script>
     <link rel="stylesheet" type="text/css" href="common.css">
     <link rel="stylesheet" type="text/css" href="flow.css">
 </head>
@@ -121,25 +94,5 @@ N=30
     <div><p id="if2_txt_info" class="info"></p></div>
     <button onclick="run_box('if2_txt')">実行</button>
 </div>
-<script>
-    function run_box(id) {
-        if (id == null) {
-            alert('idが設定されていません。');
-            return;
-        }
-        var src = $(id).value;
-        display_id = id + "_info";
-        $(display_id).innerHTML = "";
-        try {
-            navigator.nako3.run(src);
-        } catch (e) {
-            console.log(e);
-        }
-    }
-
-    function reset_box() {
-        $("info").innerHTML = "";
-    }
-</script>
 </body>
 </html>

--- a/src/lang/demo/flow.html
+++ b/src/lang/demo/flow.html
@@ -34,26 +34,8 @@
             return s.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;');
         }
     </script>
-    <style>
-        .info {
-            font-size: 1em;
-            border: 1px solid gray;
-            padding: 8px;
-            background-color: #f0fff0;
-        }
-
-        .src {
-            font-size: 1em;
-            background-color: #f0f0f0;
-            width: 99%;
-        }
-
-        .sbox {
-            border-bottom: 1px solid silver;
-            margin: 8px;
-            padding: 8px;
-        }
-    </style>
+    <link rel="stylesheet" type="text/css" href="common.css">
+    <link rel="stylesheet" type="text/css" href="flow.css">
 </head>
 <body>
 <h1>なでしこ3デモ</h1>

--- a/src/lang/demo/index.css
+++ b/src/lang/demo/index.css
@@ -1,0 +1,7 @@
+#editor, #progress {
+    margin-left: 12px;
+}
+
+#err {
+    display: none;
+}

--- a/src/lang/demo/index.html
+++ b/src/lang/demo/index.html
@@ -5,33 +5,8 @@
     <title>なでしこ3 ベータ1</title>
     <!-- なでしこを使う準備 -->
     <script src="../release/nako3.js"></script>
-    <script>
-        // なでしこの関数をカスタマイズ
-        navigator.nako3.getFunc("言").fn = function (msg) {
-            alert(msg);
-        };
-
-        navigator.nako3.getFunc("表示").fn = function (s) {
-            $("info").innerHTML += to_html(s) + "<br>";
-        };
-
-        // なでしこにオリジナル関数をJSで追加
-        navigator.nako3.addFunc("色変更",
-            [["に", "へ"]],
-            function (s) {
-                $("info").style.color = s;
-            });
-
-        // 簡易DOMアクセス関数など
-        function $(id) {
-            return document.getElementById(id);
-        }
-
-        function to_html(s) {
-            s = "" + s;
-            return s.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;');
-        }
-    </script>
+    <script src="common.js"></script>
+    <script src="index.js"></script>
     <link rel="stylesheet" type="text/css" href="common.css">
     <link rel="stylesheet" type="text/css" href="index.css">
 </head>
@@ -63,31 +38,5 @@
 <div id="progress">
     詳しくは、<a href="http://nadesi.com/dev/wiki/go.php?351">こちらを</a>ご覧ください。
 </div>
-
-<script>
-    function run_box(id) {
-        if (id != null) {
-            $('src_box').value = $(id).value;
-            reset_box();
-        }
-        var src = $("src_box").value;
-        $("err").style.display = "none";
-        try {
-            navigator.nako3.run(src);
-        } catch (e) {
-            let msg = e.message;
-            msg = msg.replace('Expected', '期待する字句は...');
-            msg = msg.replace('but', '。しかし...');
-            msg = msg.replace('found', 'がありました');
-            $("err").style.display = "block";
-            $("err").innerHTML = msg;
-            console.log(e);
-        }
-    }
-
-    function reset_box() {
-        $("info").innerHTML = "";
-    }
-</script>
 </body>
 </html>

--- a/src/lang/demo/index.html
+++ b/src/lang/demo/index.html
@@ -32,42 +32,23 @@
             return s.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;');
         }
     </script>
-    <style>
-        #info {
-            font-size: 1em;
-            border: 1px solid gray;
-            padding: 8px;
-            background-color: #f0fff0;
-        }
-
-        #err {
-            font-size: 1em;
-            border: 1px solid gray;
-            padding: 8px;
-            background-color: #fff0f0;
-        }
-
-        #srcbox {
-            font-size: 1em;
-            background-color: #fffff0;
-            width: 99%;
-        }
-    </style>
+    <link rel="stylesheet" type="text/css" href="common.css">
+    <link rel="stylesheet" type="text/css" href="index.css">
 </head>
 <body>
 <h1>なでしこ3 ベータ1 デモ</h1>
-<div style="margin-left:12px;">
+<div id="editor">
     <p>簡易エディタ:</p>
-    <textarea id="srcbox" rows="8">
+    <textarea id="src_box" rows="8">
 「こんにちは！」と表示。
 (1 + 2)×3を表示。</textarea><br>
     <div>
         <button onclick="run_box(null)">実行</button>
         <button onclick="reset_box()">クリア</button>
     </div>
-    <div><p id="err" style="display:none;"></p></div>
+    <div><p id="err"></p></div>
     <div><p>実行結果:</p>
-        <p id="info"></p></div>
+        <p id="info" class="info"></p></div>
 </div>
 <hr>
 <h3>試してみよう！</h3>
@@ -79,17 +60,17 @@
     </ul>
 </div>
 <h3>どこまで実装されてる？</h3>
-<div style="margin-left:12px;">
+<div id="progress">
     詳しくは、<a href="http://nadesi.com/dev/wiki/go.php?351">こちらを</a>ご覧ください。
 </div>
 
 <script>
     function run_box(id) {
         if (id != null) {
-            $('srcbox').value = $(id).value;
+            $('src_box').value = $(id).value;
             reset_box();
         }
-        var src = $("srcbox").value;
+        var src = $("src_box").value;
         $("err").style.display = "none";
         try {
             navigator.nako3.run(src);

--- a/src/lang/demo/index.html
+++ b/src/lang/demo/index.html
@@ -1,96 +1,112 @@
 <!DOCTYPE html>
 <html>
-  <head>
+<head>
     <meta charset="utf-8">
     <title>なでしこ3 ベータ1</title>
     <!-- なでしこを使う準備 -->
     <script src="../release/nako3.js"></script>
     <script>
-      // なでしこの関数をカスタマイズ
-      navigator.nako3.getFunc("言").fn = function(msg){ alert(msg); };
-      navigator.nako3.getFunc("表示").fn = function(s) {
-        $("info").innerHTML += tohtml(s) + "<br>";
-      };
-      // なでしこにオリジナル関数をJSで追加
-      navigator.nako3.addFunc("色変更", 
-        [["に","へ"]],
-        function (s) { $("info").style.color = s; });
-      // 簡易DOMアクセス関数など
-      function $(id) { return document.getElementById(id); }
-      function tohtml(s) {
-        s = "" + s;
-        return s.replace('&','&amp;').replace('<','&lt;').replace('>','&gt;');
-      }
+        // なでしこの関数をカスタマイズ
+        navigator.nako3.getFunc("言").fn = function (msg) {
+            alert(msg);
+        };
+
+        navigator.nako3.getFunc("表示").fn = function (s) {
+            $("info").innerHTML += to_html(s) + "<br>";
+        };
+
+        // なでしこにオリジナル関数をJSで追加
+        navigator.nako3.addFunc("色変更",
+            [["に", "へ"]],
+            function (s) {
+                $("info").style.color = s;
+            });
+
+        // 簡易DOMアクセス関数など
+        function $(id) {
+            return document.getElementById(id);
+        }
+
+        function to_html(s) {
+            s = "" + s;
+            return s.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;');
+        }
     </script>
     <style>
-      #info {
-        font-size:1em;
-        border: 1px solid gray;
-        padding:8px;
-        background-color: #f0fff0; }
-      #err {
-        font-size:1em;
-        border: 1px solid gray;
-        padding:8px;
-        background-color: #fff0f0; }
-      #srcbox {
-        font-size:1em;
-        background-color: #fffff0;
-        width: 99%; }
+        #info {
+            font-size: 1em;
+            border: 1px solid gray;
+            padding: 8px;
+            background-color: #f0fff0;
+        }
+
+        #err {
+            font-size: 1em;
+            border: 1px solid gray;
+            padding: 8px;
+            background-color: #fff0f0;
+        }
+
+        #srcbox {
+            font-size: 1em;
+            background-color: #fffff0;
+            width: 99%;
+        }
     </style>
-  </head>
-  <body>
-    <h1>なでしこ3 ベータ1 デモ</h1>
-    <div style="margin-left:12px;">
-      <p>簡易エディタ:</p>
-      <textarea id="srcbox" rows="8">
+</head>
+<body>
+<h1>なでしこ3 ベータ1 デモ</h1>
+<div style="margin-left:12px;">
+    <p>簡易エディタ:</p>
+    <textarea id="srcbox" rows="8">
 「こんにちは！」と表示。
-(1 + 2)×3を表示。
-      </textarea><br>
-      <div>
-        <button onclick="runbox(null)">実行</button>
-        <button onclick="resetbox()">クリア</button>
-      </div>
-      <div><p id="err" style="display:none;"></p></div>
-      <div><p>実行結果:</p><p id="info"></p></div>
-    </div>
-    <hr>
-    <h3>試してみよう！</h3>
+(1 + 2)×3を表示。</textarea><br>
     <div>
-      <ul>
+        <button onclick="run_box(null)">実行</button>
+        <button onclick="reset_box()">クリア</button>
+    </div>
+    <div><p id="err" style="display:none;"></p></div>
+    <div><p>実行結果:</p>
+        <p id="info"></p></div>
+</div>
+<hr>
+<h3>試してみよう！</h3>
+<div>
+    <ul>
         <li><a href="basic.html">基本計算</a></li>
         <li><a href="flow.html">制御構文</a></li>
         <li><a href="runscript.html">スクリプトタグになでしこを書く</a></li>
-      </ul>
-    </div>
-    <h3>どこまで実装されてる？</h3>
-    <div style="margin-left:12px;">
-      詳しくは、<a href="http://nadesi.com/dev/wiki/go.php?351">こちらを</a>ご覧ください。
-    </div>
-      
-<script>
-function runbox(id) {
-  if (id != null) {
-    $('srcbox').value = $(id).value;
-    resetbox();
-  }
-  var src = $("srcbox").value;
-  $("err").style.display = "none";
-  try {
-    navigator.nako3.run(src);
-  } catch (e) {
-    let msg = e.message;
-    msg = msg.replace('Expected', '期待する字句は...');
-    msg = msg.replace('but', '。しかし...');
-    msg = msg.replace('found', 'がありました');
-    $("err").style.display = "block";
-    $("err").innerHTML = msg;
-    console.log(e);
-  }
-}
-function resetbox() {
-  $("info").innerHTML = "";
-}
-</script></body>
-</html>
+    </ul>
+</div>
+<h3>どこまで実装されてる？</h3>
+<div style="margin-left:12px;">
+    詳しくは、<a href="http://nadesi.com/dev/wiki/go.php?351">こちらを</a>ご覧ください。
+</div>
 
+<script>
+    function run_box(id) {
+        if (id != null) {
+            $('srcbox').value = $(id).value;
+            reset_box();
+        }
+        var src = $("srcbox").value;
+        $("err").style.display = "none";
+        try {
+            navigator.nako3.run(src);
+        } catch (e) {
+            let msg = e.message;
+            msg = msg.replace('Expected', '期待する字句は...');
+            msg = msg.replace('but', '。しかし...');
+            msg = msg.replace('found', 'がありました');
+            $("err").style.display = "block";
+            $("err").innerHTML = msg;
+            console.log(e);
+        }
+    }
+
+    function reset_box() {
+        $("info").innerHTML = "";
+    }
+</script>
+</body>
+</html>

--- a/src/lang/demo/index.js
+++ b/src/lang/demo/index.js
@@ -1,0 +1,25 @@
+// なでしこの関数をカスタマイズ
+navigator.nako3.getFunc("表示").fn = function (s) {
+    $("info").innerHTML += to_html(s) + "<br>";
+};
+
+// 簡易DOMアクセス関数など
+function run_box(id) {
+    if (id != null) {
+        $('src_box').value = $(id).value;
+        reset_box();
+    }
+    var src = $("src_box").value;
+    $("err").style.display = "none";
+    try {
+        navigator.nako3.run(src);
+    } catch (e) {
+        let msg = e.message;
+        msg = msg.replace('Expected', '期待する字句は...');
+        msg = msg.replace('but', '。しかし...');
+        msg = msg.replace('found', 'がありました');
+        $("err").style.display = "block";
+        $("err").innerHTML = msg;
+        console.log(e);
+    }
+}

--- a/src/lang/demo/runscript.html
+++ b/src/lang/demo/runscript.html
@@ -1,46 +1,52 @@
 <!DOCTYPE html>
 <html>
-  <head>
+<head>
     <meta charset="utf-8">
     <title>なでしこ3</title>
     <!-- なでしこを使う準備 -->
     <script src="../release/nako3.js"></script>
-    <script>
-    </script>
     <script type="なでしこ" id="main_program">
-「#00F」に色変更。
-「こんにちは。なでしこでメッセージを表示しています！」と表示。
-「画面を右クリックして
-[ページのソースを表示]で
-プログラムを見てください。」を表示。
+        「#00F」に色変更。
+        「こんにちは。なでしこでメッセージを表示しています！」と表示。
+        「画面を右クリックして
+        [ページのソースを表示]で
+        プログラムを見てください。」を表示。
     </script>
-  </head>
-  <body>
-    <h1>なでしこ3デモ - script要素を実行する方法</h1>
-    <div><p id="info"></p></div>
+</head>
+<body>
+<h1>なでしこ3デモ - script要素を実行する方法</h1>
+<div><p id="info"></p></div>
 <script>
+    // --- なでしこのカスタマイズ例 ---
+    // 必要に応じて なでしこの関数を カスタマイズ
+    navigator.nako3.getFunc("言").fn = function (msg) {
+        alert(msg);
+    };
 
-// --- なでしこのカスタマイズ例 ---
-// 必要に応じて なでしこの関数を カスタマイズ
-navigator.nako3.getFunc("言").fn = function(msg){ alert(msg); };
-navigator.nako3.getFunc("表示").fn = function(s) {
-  $("info").innerHTML += tohtml(s) + "<br>";
-};
-// なでしこにオリジナル関数をJSで追加
-navigator.nako3.addFunc("色変更", 
-  [["に","へ"]],
-  function (s) { $("info").style.color = s; });
-// --- ここまで ---
+    navigator.nako3.getFunc("表示").fn = function (s) {
+        $("info").innerHTML += to_html(s) + "<br>";
+    };
 
-// --- スクリプトを実行するには、以下を一行書くだけ！ ---
-navigator.nako3.runNakoScript();
+    // なでしこにオリジナル関数をJSで追加
+    navigator.nako3.addFunc("色変更",
+        [["に", "へ"]],
+        function (s) {
+            $("info").style.color = s;
+        });
+    // --- ここまで ---
 
+    // --- スクリプトを実行するには、以下を一行書くだけ！ ---
+    navigator.nako3.runNakoScript();
 
-// 簡易DOMアクセス関数など
-function $(id) { return document.getElementById(id); }
-function tohtml(s) {
-  s = "" + s;
-  return s.replace('&','&amp;').replace('<','&lt;').replace('>','&gt;');
-}
-</script></body></html>
+    // 簡易DOMアクセス関数など
+    function $(id) {
+        return document.getElementById(id);
+    }
 
+    function to_html(s) {
+        s = "" + s;
+        return s.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;');
+    }
+</script>
+</body>
+</html>

--- a/src/lang/src/nako3.js
+++ b/src/lang/src/nako3.js
@@ -6,98 +6,116 @@ const NakoGen = require('./nako_gen.js');
 const PluginSystem = require('./plugin_system.js');
 
 class NakoCompiler {
-  constructor() {
-    this.debug = false;
-    this.gen = new NakoGen();
-    this.reset();
-  }
-  useDebug() { this.debug = true; }
-  reset() {
-    this.gen.clearPlugin();
-    this.gen.addPlugin(PluginSystem);
-    this.gen.clearLog();
-  }
-  addFunc(key, josi, fn) {
-    this.gen.addFunc(key, josi, fn);
-  }
-  getFunc(key) {
-    return this.gen.getFunc(key);
-  }
-  parse(code) {
-    // trim
-    code = code.replace(/^\s+/, '')
-               .replace(/\s+$/, '');
-    // convert
-    const ast = NakoPeg.parse(code + "\n");
-    return ast;
-  }
-  generate(ast) {
-    const js = this.gen.c_gen(ast);
-    if (this.debug) {
-      console.log("--- generate ---");
-      console.log(js);
+    constructor() {
+        this.debug = false;
+        this.gen = new NakoGen();
+        this.reset();
     }
-    return js;
-  }
-  compile(code) {
-    const ast = this.parse(code);
-    if (this.debug) {
-      console.log("--- ast ---");
-      console.log(JSON.stringify(ast, null, 2));
+
+    useDebug() {
+        this.debug = true;
     }
-    const js = this.generate(ast);
-    return js;
-  }
-  /** eval()実行前に直接JSのオブジェクトを取得する場合 */
-  getVarsList() {
-    return this.gen.getVarsList();
-  }
-  /** 完全にJSのコードを取得する場合 */
-  getVarsCode() {
-    return this.gen.getVarsCode();
-  }
-  getHeader() {
-    return this.gen.getHeader();
-  }
-  _run(code, is_reset) {
-    if (is_reset) this.reset();
-    const js = 
-      // "console.log('__varslist=',__varslist);\n" +
-      // "__varslist[0]['表示']('hogehoge');\n"+ 
-      this.compile(code);
-      //"console.log('__varslist=',__varslist);\n";
-    var __varslist = this.getVarsList();
-    var __vars = __varslist[1];
-    eval(js);
-    return this;
-  }
-  run(code) {
-    return this._run(code, false);
-  }
-  run_reset(code) {
-    return this._run(code, true);
-  }
-  get log() {
-    let s = this.getFunc("__print_log").value;
-    s = s.replace(/\s+$/, '');
-    return s;
-  }
-  /** ブラウザでtype="なでしこ"というスクリプトを得て実行する */
-  runNakoScript() {
-    // スクリプトタグの中身を得る
-    let scripts = document.querySelectorAll("script");
-    for (let i = 0; i < scripts.length; i++) {
-      let script = scripts[i];
-      let type = script.type;
-      if (type == "nako" || type =="なでしこ") {
-        this.run(script.text);
-      }
+
+    reset() {
+        this.gen.clearPlugin();
+        this.gen.addPlugin(PluginSystem);
+        this.gen.clearLog();
     }
-  }
-  addPlugin(obj) {
-    // なでしこのシステムにプラグインを登録
-    this.gen.addPlugin(obj);
-  }
+
+    addFunc(key, josi, fn) {
+        this.gen.addFunc(key, josi, fn);
+    }
+
+    getFunc(key) {
+        return this.gen.getFunc(key);
+    }
+
+    parse(code) {
+        // trim
+        code = code.replace(/^\s+/, '')
+            .replace(/\s+$/, '');
+        // convert
+        const ast = NakoPeg.parse(code + "\n");
+        return ast;
+    }
+
+    generate(ast) {
+        const js = this.gen.c_gen(ast);
+        if (this.debug) {
+            console.log("--- generate ---");
+            console.log(js);
+        }
+        return js;
+    }
+
+    compile(code) {
+        const ast = this.parse(code);
+        if (this.debug) {
+            console.log("--- ast ---");
+            console.log(JSON.stringify(ast, null, 2));
+        }
+        const js = this.generate(ast);
+        return js;
+    }
+
+    /** eval()実行前に直接JSのオブジェクトを取得する場合 */
+    getVarsList() {
+        return this.gen.getVarsList();
+    }
+
+    /** 完全にJSのコードを取得する場合 */
+    getVarsCode() {
+        return this.gen.getVarsCode();
+    }
+
+    getHeader() {
+        return this.gen.getHeader();
+    }
+
+    _run(code, is_reset) {
+        if (is_reset) this.reset();
+        const js =
+            // "console.log('__varslist=',__varslist);\n" +
+            // "__varslist[0]['表示']('hogehoge');\n"+
+            this.compile(code);
+        //"console.log('__varslist=',__varslist);\n";
+        var __varslist = this.getVarsList();
+        var __vars = __varslist[1];
+        eval(js);
+        return this;
+    }
+
+    run(code) {
+        return this._run(code, false);
+    }
+
+    run_reset(code) {
+        return this._run(code, true);
+    }
+
+    get log() {
+        let s = this.getFunc("__print_log").value;
+        s = s.replace(/\s+$/, '');
+        return s;
+    }
+
+    /** ブラウザでtype="なでしこ"というスクリプトを得て実行する */
+    runNakoScript() {
+        // スクリプトタグの中身を得る
+        let scripts = document.querySelectorAll("script");
+        for (let i = 0; i < scripts.length; i++) {
+            let script = scripts[i];
+            let type = script.type;
+            if (type == "nako" || type == "なでしこ") {
+                this.run(script.text);
+            }
+        }
+    }
+
+    addPlugin(obj) {
+        // なでしこのシステムにプラグインを登録
+        this.gen.addPlugin(obj);
+    }
 }
 
 // モジュールなら外部から参照できるように
@@ -105,9 +123,5 @@ module.exports = NakoCompiler;
 
 // ブラウザなら navigator.nako3 になでしこを登録
 if (typeof(navigator) == "object") {
-  navigator.nako3 = new NakoCompiler();
+    navigator.nako3 = new NakoCompiler();
 }
-
-
-
-

--- a/src/lang/src/nako_gen.js
+++ b/src/lang/src/nako_gen.js
@@ -459,9 +459,9 @@ class NakoGen {
     c_string(node) {
         let value = "" + node.value;
         let mode = node.mode;
-        value = value.replace('"', '\\\"');
-        value = value.replace('\r', '\\r');
-        value = value.replace('\n', '\\n');
+        value = value.replace(/"/g, '\\\"');
+        value = value.replace(/\r/g, '\\r');
+        value = value.replace(/\n/g, '\\n');
         if (mode == "ex") {
             let rf = (a, m) => {
                 return "\"+" + this.varname(m) + "+\"";

--- a/src/lang/src/nako_gen.js
+++ b/src/lang/src/nako_gen.js
@@ -3,434 +3,474 @@
 //
 
 "use strict";
-class NakoGenError extends Error { }
+class NakoGenError extends Error {
+}
 
 /**
  * 構文木からJSのコードを生成するクラス
  */
 class NakoGen {
-  
-  constructor() {
-    this.header = this.getHeader();
-    this.plugins = {}; /** プラグインで定義された関数の一覧 */
-    this.nako_func = {}; /** なでしこで定義した関数の一覧 */
-    this.used_func = {}; /** JS関数でなでしこ内で利用された関数 */
-    this.loop_id = 1;
-    this.sore = this.varname('それ');
-    //
-    this.__vars = {};
-    this.__varslist = [{}, this.__vars];
-    this.clearPlugin();
-  }
-  getHeader() {
-    return "" + 
-      "var __vars = {};\n" +
-      "var __varslist = [{}, __vars];\n" +
-      "var __print = (s)=>{ console.log(s); };\n";
-  }
-  getVarsCode() {
-    let code = "";
-    // プログラム中で使った関数を列挙
-    for (const key in this.used_func) {
-      const f = this.used_func[key];
-      const name = `__varslist[0]["${key}"]`;
-      if (typeof(f) == "function") {
-        code += name + "=" + f.toString() + ";\n";
-      } else {
-        code += name + "=" + JSON.stringify(f) + ";\n";
-      }
+    constructor() {
+        this.header = this.getHeader();
+
+        /** プラグインで定義された関数の一覧 */
+        this.plugins = {};
+
+        /** なでしこで定義した関数の一覧 */
+        this.nako_func = {};
+
+        /** JS関数でなでしこ内で利用された関数 */
+        this.used_func = {};
+
+        this.loop_id = 1;
+        this.sore = this.varname('それ');
+
+        this.__vars = {};
+        this.__varslist = [{}, this.__vars];
+        this.clearPlugin();
     }
-    return code;
-  }
-  getVarsList() {
-    return this.__varslist;
-  }
-  clearLog() {
-    this.plugins["__print_log"].value = "";
-  }
-  clearPlugin() {
-    this.plugins = {};
-    this.vars = {};
-    this.__varslist = [{}, this.__vars];
-    this.used_func = {};
-  }
-  /**
-   * プラグイン・オブジェクトを追加
-   */
-  addPlugin(po) {
-    // プラグインの値をオブジェクトにコピー
-    for (let key in po) {
-      const v = po[key];
-      this.plugins[key] =v;
-      this.__varslist[0][key] = (typeof(v.fn) == "function") ? v.fn : v.value;
+
+    getHeader() {
+        return "" +
+            "var __vars = {};\n" +
+            "var __varslist = [{}, __vars];\n" +
+            "var __print = (s)=>{ console.log(s); };\n";
     }
-  }
-  /** 単体で関数を追加する場合 */
-  addFunc(key, josi, fn) {
-    this.plugins[key] = { "josi": josi, "fn": fn };
-  }
-  /** プラグイン関数を参照したい場合 */
-  getFunc(key) {
-    return this.plugins[key];
-  }
-  c_gen(node) {
-    let code = "";
-    if (node == undefined) return "";
-    if (node instanceof Array) {
-      for (let i = 0; i < node.length; i++) {
-        const n = node[i];
-        code += this.c_gen(n);
-      }
-      return code;
-    }
-    if (typeof(node) != "object") return "" + node;
-    // switch
-    switch (node.type) {
-      case "nop": break;
-      case "EOS":
-        code += "\n";
-        break;
-      case "break":
-        code += "break;";
-        break;
-      case "continue":
-        code += "continue;";
-        break;
-      case "end": // TODO: どう処理するか?
-        code += "quit();";
-        break;
-      case "number":
-        code += node.value;
-        break;
-      case "string":
-        code += this.c_string(node);
-        break;
-      case "let":
-        code += this.c_let(node) + "\n";
-        break;
-      case "variable":
-        code += this.c_get_var(node);
-        break;
-      case "calc":
-        code += this.c_op(node);
-        break;
-      case "func":
-        code += this.c_func(node, true);
-        break;
-      case "calc_func":
-        code += this.c_func(node, false);
-        break;
-      case "if":
-        code += this.c_if(node);
-        break;
-      case "for":
-        code += this.c_for(node);
-        break;
-      case "repeat_times":
-        code += this.c_repeat_times(node);
-        break;
-      case "while":
-        code += this.c_while(node);
-        break;
-      case "let_array":
-        code += this.c_let_array(node);
-        break;
-      case "ref_array":
-        code += this.c_ref_array(node);
-        break;
-      case "json_array":
-        code += this.c_json_array(node);
-        break;
-      case "json_obj":
-        code += this.c_json_obj(node);
-        break;
-      case "bool":
-        code += (node.value) ? "true" : "false";
-        break;
-      case "null":
-        code += "null";
-        break;
-      case "def_func":
-        code += this.c_def_func(node);
-        break;
-    }
-    return code;
-  }
-  varname(name) {
-    return `__vars["${name}"]`;
-  }
-  find_var(name) {
-    // __vars ?
-    if (this.__vars[name] !== undefined) {
-      return {i:this.__varslist.length-1, "name":name, isTop:true};
-    }
-    // __varslist ?
-    for (let i = this.__varslist.length - 2; i >= 0; i--) {
-      const vlist = this.__varslist[i];
-      if (vlist[name] !== undefined) {
-        return {"i":i, "name":name, isTop:false};
-      }
-    }
-    return null;
-  }  
-  c_get_var(node) {
-    const name = node.value;
-    const res = this.find_var(name);
-    if (res == null) {
-      return `__vars["${name}"]/*?*/`;
-    }
-    const i = res.i;
-    if (i == 0) {
-      const pv = this.plugins[name];
-      if (pv !== undefined) {
-        if (pv.type == "const") return JSON.stringify(pv.value);
-        throw new NakoGenError(`『${name}』は関数であり参照できません。`);
-      }
-    }
-    if (res.isTop) {
-      return `__vars["${name}"]`;
-    } else {
-      return `__varslist[${i}]["${name}"]`;
-    }
-  }
-  c_def_func(node) {
-    const name = this.getFuncName( node.name.value );
-    const args = node.args;
-    const block = this.c_gen(node.block);
-    this.__vars[name] = "func";
-    let code = "(function(){\n";
-    code += "  try {\n    __vars = {}; __varslist.push(__vars);\n";
-    this.__vars = {};
-    this.__varslist.push(this.__vars);
-    const josilist = [];
-    for (let i = 0; i < args.length; i++) {
-      const arg = args[i];
-      const word = arg["word"].value;
-      const josi = [ arg["josi"] ];
-      josilist.push(josi);
-      console.log("arg=", arg, "word=", word, "josi=", josi);
-      this.__vars[word] = true;
-      code += `__vars["${word}"] = arguments[${i}];\n`;
-    }
-    code += block + "\n";
-    const popcode = "__varslist.pop(); __vars = __varslist[__varslist.length-1];";
-    code += `  } finally { ${popcode} }\n`;
-    code += "\n})\n";
-    const fn = eval(code);
-    this.nako_func[name] = {
-      "josi": josilist,
-      "fn": fn,
-      "type":"func"
-    };
-    this.used_func[name] = fn;
-    // console.log(fn.toString());
-    return `__vars["${name}"] = ${code};\n`;
-  }
-  c_json_obj(node) {
-    const list = node.value;
-    const codelist = list.map((e)=>{
-      const key = this.c_gen(e.key);
-      const val = this.c_gen(e.value)
-      return `'${key}':${val}`;
-    });
-    return "{" + codelist.join(",") + "}";
-  }
-  c_json_array(node) {
-    const list = node.value;
-    const codelist = list.map((e)=>{
-      return this.c_gen(e);
-    });
-    return "[" + codelist.join(",") + "]";
-  }
-  c_ref_array(node) {
-    const name = this.c_gen(node.name);
-    const list = node.index;
-    let code = name;
-    for (let i = 0; i < list.length; i++) {
-      const idx = this.c_gen(list[i]);
-      code += "[" + idx + "]";
-    }
-    return code;
-  }
-  c_let_array(node) {
-    const name = this.c_gen(node.name);
-    const list = node.index;
-    let code = name;
-    for (let i = 0; i < list.length; i++) {
-      const idx = this.c_gen(list[i]);
-      code += "[" + idx + "]";
-    }
-    const value = this.c_gen(node.value);
-    code += " = " + value + ";\n";
-    return code;
-  }
-  c_for(node) {
-    const kara = this.c_gen(node.from);
-    const made = this.c_gen(node.to);
-    const word = this.c_gen(node.word);
-    const block = this.c_gen(node.block);
-    const code =
-      `for(${word}=${kara}; ${word}<=${made}; ${word}++)` + "{\n" +
-      `  ${this.sore} = ${word};` + "\n" + 
-      "  " + block + "\n" +
-      "};\n";
-    return code;
-  }
-  c_repeat_times(node) {
-    const id = this.loop_id++;
-    const value = this.c_gen(node.value);
-    const block = this.c_gen(node.block);
-    const kaisu = this.varname('回数');
-    const code =
-      `for(let $nako_i${id} = 1; $nako_i${id} <= ${value}; $nako_i${id}++)`+"{\n"+
-      `  ${this.sore} = ${kaisu} = $nako_i${id};` + "\n" +
-      "  " + block + "\n}\n";
-    return code;
-  }
-  c_while(node) {
-    const cond = this.c_gen(node.cond);
-    const block = this.c_gen(node.block);
-    const code =
-      `while (${cond})` + "{\n" +
-      `  ${block}` + "\n" +
-      "}\n";
-    return code;
-  }
-  c_if(node) {
-    const expr = this.c_gen(node.expr);
-    const block = this.c_gen(node.block);
-    const false_block = this.c_gen(node.false_block);
-    const code = `if (${expr}) { ${block} } else { ${false_block} };\n`;
-    return code;
-  }
-  getFuncName(name) {
-    let name2 = name.replace(/[ぁ-ん]+$/, '');
-    if (name2 == '') name2 = name;
-    return name2;
-  }
-  // 関数の引数を調べる
-  c_func_get_args(func_name, func, node) {
-    const args = [];
-    for (let i = 0; i < func.josi.length; i++) {
-      const josilist = func.josi[i]; // 関数のi番目の助詞
-      let flag = false;
-      let sore = 1;
-      // 今回呼び出す関数の助詞を一つずつ調べる
-      for (let j = 0; j < node.args.length; j++) {
-        const arg = node.args[j];
-        const ajosi = arg.josi;
-        const k = josilist.indexOf(ajosi);
-        if (k < 0) continue;
-        args.push(this.c_gen(arg.value));
-        flag = true;
-      }
-      if (!flag) {
-        sore--;
-        if (sore < 0) {
-          const josi_s = josilist.join("|");
-          throw new NakoGenError(
-            `関数『${func_name}』の引数『${josi_s}』が見当たりません。`);
+
+    getVarsCode() {
+        let code = "";
+        // プログラム中で使った関数を列挙
+        for (const key in this.used_func) {
+            const f = this.used_func[key];
+            const name = `__varslist[0]["${key}"]`;
+            if (typeof(f) == "function") {
+                code += name + "=" + f.toString() + ";\n";
+            } else {
+                code += name + "=" + JSON.stringify(f) + ";\n";
+            }
         }
-        args.push(this.sore);
-      }
+        return code;
     }
-    return args;
-  }
-  c_func_get_args_calctype(func_name, func, node) {
-    const args = [];
-    for (let i = 0; i < node.args.length; i++) {
-      const arg = node.args[i];
-      // console.log('arg=', arg);
-      args.push(this.c_gen(arg));
+
+    getVarsList() {
+        return this.__varslist;
     }
-    return args;
-  }
-  /** 関数の呼び出し */
-  c_func(node, is_nako_type) {
-    const func_name = this.getFuncName(node.name.value);
-    let func_name_s;
-    const res = this.find_var(func_name);
-    if (res == null) {
-      throw new NakoGenError(`関数『${func_name}』が見当たりません。`);
+
+    clearLog() {
+        this.plugins["__print_log"].value = "";
     }
-    let func;
-    if (res.i == 0) { // plugin function
-      func = this.plugins[func_name];
-      func_name_s = `__varslist[0]["${func_name}"]`;
-    } else {
-      func = this.nako_func[func_name];
-      if (func === undefined) {
-        throw new NakoGenError(`『${func_name}』は関数ではありません。`);
-      }
-      func_name_s = `__varslist[${res.i}]["${func_name}"]`;
+
+    clearPlugin() {
+        this.plugins = {};
+        this.vars = {};
+        this.__varslist = [{}, this.__vars];
+        this.used_func = {};
     }
-    // 関数定義より助詞を一つずつ調べる
-    let args = [];
-    if (is_nako_type) {
-      args = this.c_func_get_args(func_name, func, node);
-    } else {
-      args = this.c_func_get_args_calctype(func_name, func, node);
+
+    /**
+     * プラグイン・オブジェクトを追加
+     */
+    addPlugin(po) {
+        // プラグインの値をオブジェクトにコピー
+        for (let key in po) {
+            const v = po[key];
+            this.plugins[key] = v;
+            this.__varslist[0][key] = (typeof(v.fn) == "function") ? v.fn : v.value;
+        }
     }
-    // function
-    if (typeof(this.used_func[func_name]) !== "function") {
-      this.used_func[func_name] = func.fn;
+
+    /** 単体で関数を追加する場合 */
+    addFunc(key, josi, fn) {
+        this.plugins[key] = {"josi": josi, "fn": fn};
     }
-    let args_code = args.join(",");
-    let code = `${func_name_s}(${args_code})`;
-    if (func.return_none) {
-      if (is_nako_type) { code = code + ";\n"; }
-    } else {
-      if (is_nako_type) {
-        code = this.sore + " = " + code + ";\n";
-      }
+
+    /** プラグイン関数を参照したい場合 */
+    getFunc(key) {
+        return this.plugins[key];
     }
-    return code;
-  }
-  c_op(node) {
-    let op = node.operator; // 演算子
-    const right = this.c_gen(node.right);
-    const left = this.c_gen(node.left);
-    if (op == "&") { op = '+ "" +'; }
-    return "(" + left + op + right + ")";
-  }
-  c_let(node) {
-    const value = this.c_gen(node.value);
-    const name = node.name.value;
-    const res = this.find_var(name);
-    // console.log("var=", name, "/", res);
-    // console.log(this.__varslist);
-    let is_top = true, code = "";
-    if (res == null) {
-      this.__vars[name] = true;
-    } else {
-      if (res.isTop) is_top = true;
+
+    c_gen(node) {
+        let code = "";
+        if (node == undefined) return "";
+        if (node instanceof Array) {
+            for (let i = 0; i < node.length; i++) {
+                const n = node[i];
+                code += this.c_gen(n);
+            }
+            return code;
+        }
+        if (typeof(node) != "object") return "" + node;
+        // switch
+        switch (node.type) {
+            case "nop":
+                break;
+            case "EOS":
+                code += "\n";
+                break;
+            case "break":
+                code += "break;";
+                break;
+            case "continue":
+                code += "continue;";
+                break;
+            case "end": // TODO: どう処理するか?
+                code += "quit();";
+                break;
+            case "number":
+                code += node.value;
+                break;
+            case "string":
+                code += this.c_string(node);
+                break;
+            case "let":
+                code += this.c_let(node) + "\n";
+                break;
+            case "variable":
+                code += this.c_get_var(node);
+                break;
+            case "calc":
+                code += this.c_op(node);
+                break;
+            case "func":
+                code += this.c_func(node, true);
+                break;
+            case "calc_func":
+                code += this.c_func(node, false);
+                break;
+            case "if":
+                code += this.c_if(node);
+                break;
+            case "for":
+                code += this.c_for(node);
+                break;
+            case "repeat_times":
+                code += this.c_repeat_times(node);
+                break;
+            case "while":
+                code += this.c_while(node);
+                break;
+            case "let_array":
+                code += this.c_let_array(node);
+                break;
+            case "ref_array":
+                code += this.c_ref_array(node);
+                break;
+            case "json_array":
+                code += this.c_json_array(node);
+                break;
+            case "json_obj":
+                code += this.c_json_obj(node);
+                break;
+            case "bool":
+                code += (node.value) ? "true" : "false";
+                break;
+            case "null":
+                code += "null";
+                break;
+            case "def_func":
+                code += this.c_def_func(node);
+                break;
+        }
+        return code;
     }
-    if (is_top) {
-      code = `__vars["${name}"]=${value};\n`;
-    } else {
-      code = `__varslist[${res.i}]["${name}"]=${value};\n`;
+
+    varname(name) {
+        return `__vars["${name}"]`;
     }
-    return code;
-  }
-  c_print(node) {
-    return `__print(${code});`;
-  }
-  c_string(node) {
-    let value = "" + node.value;
-    let mode = node.mode;
-    value = value.replace('"', '\\\"');
-    value = value.replace('\r', '\\r');
-    value = value.replace('\n', '\\n');
-    if (mode == "ex") {
-      let rf = (a, m) => {
-        return "\"+"+ this.varname(m) +"+\"";
-      };
-      value = value.replace(/\{(.+?)\}/g, rf);
-      value = value.replace(/｛(.+?)｝/g, rf);
+
+    find_var(name) {
+        // __vars ?
+        if (this.__vars[name] !== undefined) {
+            return {i: this.__varslist.length - 1, "name": name, isTop: true};
+        }
+        // __varslist ?
+        for (let i = this.__varslist.length - 2; i >= 0; i--) {
+            const vlist = this.__varslist[i];
+            if (vlist[name] !== undefined) {
+                return {"i": i, "name": name, isTop: false};
+            }
+        }
+        return null;
     }
-    return '"' + value + '"';
-  }
+
+    c_get_var(node) {
+        const name = node.value;
+        const res = this.find_var(name);
+        if (res == null) {
+            return `__vars["${name}"]/*?*/`;
+        }
+        const i = res.i;
+        if (i == 0) {
+            const pv = this.plugins[name];
+            if (pv !== undefined) {
+                if (pv.type == "const") return JSON.stringify(pv.value);
+                throw new NakoGenError(`『${name}』は関数であり参照できません。`);
+            }
+        }
+        if (res.isTop) {
+            return `__vars["${name}"]`;
+        } else {
+            return `__varslist[${i}]["${name}"]`;
+        }
+    }
+
+    c_def_func(node) {
+        const name = this.getFuncName(node.name.value);
+        const args = node.args;
+        const block = this.c_gen(node.block);
+        this.__vars[name] = "func";
+        let code = "(function(){\n";
+        code += "  try {\n    __vars = {}; __varslist.push(__vars);\n";
+        this.__vars = {};
+        this.__varslist.push(this.__vars);
+        const josilist = [];
+        for (let i = 0; i < args.length; i++) {
+            const arg = args[i];
+            const word = arg["word"].value;
+            const josi = [arg["josi"]];
+            josilist.push(josi);
+            console.log("arg=", arg, "word=", word, "josi=", josi);
+            this.__vars[word] = true;
+            code += `__vars["${word}"] = arguments[${i}];\n`;
+        }
+        code += block + "\n";
+        const popcode = "__varslist.pop(); __vars = __varslist[__varslist.length-1];";
+        code += `  } finally { ${popcode} }\n`;
+        code += "\n})\n";
+        const fn = eval(code);
+        this.nako_func[name] = {
+            "josi": josilist,
+            "fn": fn,
+            "type": "func"
+        };
+        this.used_func[name] = fn;
+        // console.log(fn.toString());
+        return `__vars["${name}"] = ${code};\n`;
+    }
+
+    c_json_obj(node) {
+        const list = node.value;
+        const codelist = list.map((e) => {
+            const key = this.c_gen(e.key);
+            const val = this.c_gen(e.value);
+            return `'${key}':${val}`;
+        });
+        return "{" + codelist.join(",") + "}";
+    }
+
+    c_json_array(node) {
+        const list = node.value;
+        const codelist = list.map((e) => {
+            return this.c_gen(e);
+        });
+        return "[" + codelist.join(",") + "]";
+    }
+
+    c_ref_array(node) {
+        const name = this.c_gen(node.name);
+        const list = node.index;
+        let code = name;
+        for (let i = 0; i < list.length; i++) {
+            const idx = this.c_gen(list[i]);
+            code += "[" + idx + "]";
+        }
+        return code;
+    }
+
+    c_let_array(node) {
+        const name = this.c_gen(node.name);
+        const list = node.index;
+        let code = name;
+        for (let i = 0; i < list.length; i++) {
+            const idx = this.c_gen(list[i]);
+            code += "[" + idx + "]";
+        }
+        const value = this.c_gen(node.value);
+        code += " = " + value + ";\n";
+        return code;
+    }
+
+    c_for(node) {
+        const kara = this.c_gen(node.from);
+        const made = this.c_gen(node.to);
+        const word = this.c_gen(node.word);
+        const block = this.c_gen(node.block);
+        const code =
+            `for(${word}=${kara}; ${word}<=${made}; ${word}++)` + "{\n" +
+            `  ${this.sore} = ${word};` + "\n" +
+            "  " + block + "\n" +
+            "};\n";
+        return code;
+    }
+
+    c_repeat_times(node) {
+        const id = this.loop_id++;
+        const value = this.c_gen(node.value);
+        const block = this.c_gen(node.block);
+        const kaisu = this.varname('回数');
+        const code =
+            `for(let $nako_i${id} = 1; $nako_i${id} <= ${value}; $nako_i${id}++)` + "{\n" +
+            `  ${this.sore} = ${kaisu} = $nako_i${id};` + "\n" +
+            "  " + block + "\n}\n";
+        return code;
+    }
+
+    c_while(node) {
+        const cond = this.c_gen(node.cond);
+        const block = this.c_gen(node.block);
+        const code =
+            `while (${cond})` + "{\n" +
+            `  ${block}` + "\n" +
+            "}\n";
+        return code;
+    }
+
+    c_if(node) {
+        const expr = this.c_gen(node.expr);
+        const block = this.c_gen(node.block);
+        const false_block = this.c_gen(node.false_block);
+        const code = `if (${expr}) { ${block} } else { ${false_block} };\n`;
+        return code;
+    }
+
+    getFuncName(name) {
+        let name2 = name.replace(/[ぁ-ん]+$/, '');
+        if (name2 == '') name2 = name;
+        return name2;
+    }
+
+    // 関数の引数を調べる
+    c_func_get_args(func_name, func, node) {
+        const args = [];
+        for (let i = 0; i < func.josi.length; i++) {
+            const josilist = func.josi[i]; // 関数のi番目の助詞
+            let flag = false;
+            let sore = 1;
+            // 今回呼び出す関数の助詞を一つずつ調べる
+            for (let j = 0; j < node.args.length; j++) {
+                const arg = node.args[j];
+                const ajosi = arg.josi;
+                const k = josilist.indexOf(ajosi);
+                if (k < 0) continue;
+                args.push(this.c_gen(arg.value));
+                flag = true;
+            }
+            if (!flag) {
+                sore--;
+                if (sore < 0) {
+                    const josi_s = josilist.join("|");
+                    throw new NakoGenError(
+                        `関数『${func_name}』の引数『${josi_s}』が見当たりません。`);
+                }
+                args.push(this.sore);
+            }
+        }
+        return args;
+    }
+
+    c_func_get_args_calctype(func_name, func, node) {
+        const args = [];
+        for (let i = 0; i < node.args.length; i++) {
+            const arg = node.args[i];
+            // console.log('arg=', arg);
+            args.push(this.c_gen(arg));
+        }
+        return args;
+    }
+
+    /** 関数の呼び出し */
+    c_func(node, is_nako_type) {
+        const func_name = this.getFuncName(node.name.value);
+        let func_name_s;
+        const res = this.find_var(func_name);
+        if (res == null) {
+            throw new NakoGenError(`関数『${func_name}』が見当たりません。`);
+        }
+        let func;
+        if (res.i == 0) { // plugin function
+            func = this.plugins[func_name];
+            func_name_s = `__varslist[0]["${func_name}"]`;
+        } else {
+            func = this.nako_func[func_name];
+            if (func === undefined) {
+                throw new NakoGenError(`『${func_name}』は関数ではありません。`);
+            }
+            func_name_s = `__varslist[${res.i}]["${func_name}"]`;
+        }
+        // 関数定義より助詞を一つずつ調べる
+        let args = [];
+        if (is_nako_type) {
+            args = this.c_func_get_args(func_name, func, node);
+        } else {
+            args = this.c_func_get_args_calctype(func_name, func, node);
+        }
+        // function
+        if (typeof(this.used_func[func_name]) !== "function") {
+            this.used_func[func_name] = func.fn;
+        }
+        let args_code = args.join(",");
+        let code = `${func_name_s}(${args_code})`;
+        if (func.return_none) {
+            if (is_nako_type) {
+                code = code + ";\n";
+            }
+        } else {
+            if (is_nako_type) {
+                code = this.sore + " = " + code + ";\n";
+            }
+        }
+        return code;
+    }
+
+    c_op(node) {
+        let op = node.operator; // 演算子
+        const right = this.c_gen(node.right);
+        const left = this.c_gen(node.left);
+        if (op == "&") {
+            op = '+ "" +';
+        }
+        return "(" + left + op + right + ")";
+    }
+
+    c_let(node) {
+        const value = this.c_gen(node.value);
+        const name = node.name.value;
+        const res = this.find_var(name);
+        // console.log("var=", name, "/", res);
+        // console.log(this.__varslist);
+        let is_top = true, code = "";
+        if (res == null) {
+            this.__vars[name] = true;
+        } else {
+            if (res.isTop) is_top = true;
+        }
+        if (is_top) {
+            code = `__vars["${name}"]=${value};\n`;
+        } else {
+            code = `__varslist[${res.i}]["${name}"]=${value};\n`;
+        }
+        return code;
+    }
+
+    c_print(node) {
+        return `__print(${code});`;
+    }
+
+    c_string(node) {
+        let value = "" + node.value;
+        let mode = node.mode;
+        value = value.replace('"', '\\\"');
+        value = value.replace('\r', '\\r');
+        value = value.replace('\n', '\\n');
+        if (mode == "ex") {
+            let rf = (a, m) => {
+                return "\"+" + this.varname(m) + "+\"";
+            };
+            value = value.replace(/\{(.+?)\}/g, rf);
+            value = value.replace(/｛(.+?)｝/g, rf);
+        }
+        return '"' + value + '"';
+    }
 }
 
 module.exports = NakoGen;
-


### PR DESCRIPTION
`src/lang/src/nako_gen.js`の`c_string`関数の文字列の置換において、最初にヒットした文字列しか置換されなくなっていたバグを修正しました。

参考 :  http://marycore.jp/prog/js/replace-all/