### PR TITLE
Babelのpresetパッケージを削除し、代わりにbabel-preset-envを導入

### DIFF
--- a/src/lang/.babelrc
+++ b/src/lang/.babelrc
@@ -1,3 +1,15 @@
 {
-  "presets":["es2015","es2016","es2017"]
+  "presets": [
+    [
+      "env",
+      {
+        "targets": {
+          "browsers": [
+            "last 2 versions",
+            "safari >= 7"
+          ]
+        }
+      }
+    ]
+  ]
 }

--- a/src/lang/package.json
+++ b/src/lang/package.json
@@ -25,9 +25,7 @@
   "devDependencies": {
     "babel-cli": "^6.22.2",
     "babel-loader": "^6.3.2",
-    "babel-preset-es2015": "^6.22.0",
-    "babel-preset-es2016": "^6.22.0",
-    "babel-preset-es2017": "^6.22.0",
+    "babel-preset-env": "^1.2.0",
     "mocha": "^3.2.0",
     "pegjs": "^0.10.0",
     "pump": "^1.0.2",


### PR DESCRIPTION
※詳しくは [babel-preset-envを簡単にさわってみた。 - Qiita](http://qiita.com/ryuone/items/13f5d450c3865709ba10) を参照