### PR TITLE
対応ブラウザの範囲を拡大

### DIFF
--- a/src/lang/.babelrc
+++ b/src/lang/.babelrc
@@ -5,7 +5,9 @@
       {
         "targets": {
           "browsers": [
-            "not ie <= 10"
+            "last 1 version",
+            "last 2 Safari versions",
+            "last 2 iOS versions"
           ]
         }
       }


### PR DESCRIPTION
#19 
対応ブラウザを『以下の _いずれか_ に当てはまるもの』に拡大しました。
* [browserslist](https://github.com/ai/browserslist#browsers) に記載されているブラウザの最新バージョン
* Safari (iOS版含む) の最新2バージョン