### PR TITLE
ビルド時にDeprecationWarningが出ないよう修正

### DIFF
--- a/src/lang/webpack.config.js
+++ b/src/lang/webpack.config.js
@@ -1,5 +1,4 @@
 module.exports = {
-
     entry: {
         wnako3: './src/wnako3.js', // plugin_system + plugin_browser を含む
         plugin_turtle: './src/plugin_turtle.js',
@@ -22,11 +21,9 @@ module.exports = {
                 ],
                 loader: "babel-loader",
                 query: {
-                  presets: ['env']
+                    presets: ['env']
                 }
             }
         ]
     }
 };
-
-

--- a/src/lang/webpack.config.js
+++ b/src/lang/webpack.config.js
@@ -1,3 +1,5 @@
+process.noDeprecation = true;
+
 module.exports = {
     entry: {
         wnako3: './src/wnako3.js', // plugin_system + plugin_browser を含む


### PR DESCRIPTION
ビルド時に以下のような警告が出ないよう修正を行いました。

```
(node:16482) DeprecationWarning: loaderUtils.parseQuery() received a non-string value which can be problematic, see https://github.com/webpack/loader-utils/issues/56
parseQuery() will be replaced with getOptions() in the next major version of loader-utils.
```