### PR TITLE
文法定義から『＃』を除去 (前処理で半角に変換されているため)

### DIFF
--- a/src/nako_parser.pegjs
+++ b/src/nako_parser.pegjs
@@ -213,7 +213,7 @@ whitespace = [ \t\r、　,・]
 SPCLF = [\t\r\n 　]*
 SPC = [\t\r 　]*
 range_comment = "/*" s:$(!"*/" .)* "*/" { return s; }
-line_comment = ("//" / "#" / "＃" / "※") s:$[^\n]* LF { return s; }
+line_comment = ("//" / "#" / "※") s:$[^\n]* LF { return s; }
 comment
   = n:(range_comment / line_comment) {
     return {type:"comment",value:n,loc:location()};


### PR DESCRIPTION
#94