### PR TITLE
開発環境のセットアップ手順ドキュメントへnadesiko3リポジトリをローカルにダウンロードが必要の旨の補足を追加( Issue #181 )

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -1,4 +1,4 @@
-# なでしこ3 - 開発環境のセットアップ方法
+﻿# なでしこ3 - 開発環境のセットアップ方法
 
 [![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](http://standardjs.com)
 
@@ -8,6 +8,11 @@ Node.jsをインストールしておく。
 
 ```
 $ npm install -g npm-check-updates electron asar
+```
+
+nadesiko3のリポジトリをローカルにダウンロードし展開（もしくはクローン）して、その中（トップディレクトリ）で以下のコマンドを実行する。
+
+```
 $ npm install --no-optional
 ```
 


### PR DESCRIPTION
開発環境セットアップ手順の「npm install --no-optional」の部分に、
nadesiko3のリポジトリをローカルにダウンロードして、その中で実行する必要がある旨の補足を追記してみました。