### PR TITLE
'eq'と重複しているパターンを削除

### DIFF
--- a/src/nako_lexer.js
+++ b/src/nako_lexer.js
@@ -71,7 +71,6 @@ const rules = [
   { name: 'lt', pattern: /^</ },
   { name: 'and', pattern: /^(かつ|&&)/ },
   { name: 'or', pattern: /^(または|\|\|)/ },
-  { name: '=', pattern: /^=/ },
   { name: '@', pattern: /^@/ },
   { name: '+', pattern: /^\+/ },
   { name: '-', pattern: /^-/ },


### PR DESCRIPTION
'eq' と '=' で pattern が重複していて、'=' の方にマッチすることはなさそうだったので、削っても良さそうに見えました。