### PR TITLE
ファイル名を拡張子付きに修正

### DIFF
--- a/editor/command_list.jsx
+++ b/editor/command_list.jsx
@@ -7,9 +7,9 @@ export default class CommandList extends React.Component {
   constructor (props) {
     super(props)
     this.files = [
-      'plugin_browser',
-      'plugin_turtle',
-      'plugin_system'
+      'plugin_browser.js',
+      'plugin_turtle.js',
+      'plugin_system.js'
     ]
     this.listItems = []
   }


### PR DESCRIPTION
`command.json`を読み込めないエラーが発生していたため修正を行いました。