### PR TITLE
深い再帰にならないよう修正

### DIFF
--- a/src/nako_lexer.js
+++ b/src/nako_lexer.js
@@ -119,7 +119,7 @@ class NakoLexer {
     this.funclist = list
   }
 
-  setInput (code, line, isFirst) {
+  setInput (code, isFirst, line) {
     // 最初に全部を区切ってしまう
     this.tokenize(code, line)
     // 関数の定義があれば funclist を更新


### PR DESCRIPTION
#222 
前置処理と単語分割処理において、再帰が深くなる可能性があり、かつ、オーバーヘッドが大きくなる (codeが含まれていないことが確実な単語列に対してcodeが含まれているか確認してしまう) 構造があったため、再帰呼び出しが起こらないように修正しました。