### PR TITLE
CSV取得命令をRFC4180に対応させる #314

### DIFF
--- a/src/plugin_system.js
+++ b/src/plugin_system.js
@@ -1523,7 +1523,17 @@ const PluginSystem = {
       for (let i = 0; i < split_quote.length; i++) {
         const s_q = split_quote[i]
 
-        if (i % 2 === 0) { //偶数番目の要素 (さらに区切れる可能性がある) のとき
+        if (s_q === '') { // エスケープされたダブルクオーテーションのとき
+          // ダブルクオーテーション
+          const quote = '"'
+
+          // 行の末尾の要素にダブルクオーテーションを追加
+          if (data_row.length === 0) data_row.push(quote)
+          else data_row[data_row.length - 1] += quote
+
+          // ダブルクオーテーションフラグを立てる
+          is_quote = true
+        } else if (i % 2 === 0) { //偶数番目の要素 (さらに区切れる可能性がある) のとき
           let s
 
           if (is_quote) { // ダブルクオーテーションが立っているとき、行の末尾の要素を取り出す (今見ている要素と連結させるため)
@@ -1549,17 +1559,10 @@ const PluginSystem = {
               }
             }
           }
-        } else if (s_q === '') { // 奇数番目の要素で空文字列 (エスケープされたダブルクオーテーション) のとき
-          // ダブルクオーテーション
-          const quote = '"'
-
-          // 行の末尾の要素にダブルクオーテーションを追加
-          if (data_row.length === 0) data_row.push(quote)
-          else data_row[data_row.length - 1] += quote
-
-          // ダブルクオーテーションフラグを立てる
-          is_quote = true
-        } else data_row.push(s_q) // 奇数番目の要素 (これ以上区切れない) で、空文字列でないとき、文字列を行に追加
+        } else if (is_quote) { // 奇数番目の要素 (これ以上区切れない) で、ダブルクオーテーションが立っているとき
+          data_row[data_row.length - 1] += s_q
+          is_quote = false
+        } else data_row.push(s_q) // 奇数番目の要素 (これ以上区切れない) で、ダブルクオーテーションが立っていないとき
       }
 
       return data

--- a/src/plugin_system.js
+++ b/src/plugin_system.js
@@ -1534,15 +1534,16 @@ const PluginSystem = {
           // ダブルクオーテーションフラグを立てる
           is_quote = true
         } else if (i % 2 === 0) { //偶数番目の要素 (さらに区切れる可能性がある) のとき
-          let s
+          let s = s_q
 
-          if (is_quote) { // ダブルクオーテーションが立っているとき、行の末尾の要素を取り出す (今見ている要素と連結させるため)
-            s = data_row.pop()
+          // ダブルクオーテーションが立っているとき、行の末尾の要素を取り出す (今見ている要素と連結させるため)
+          if (is_quote) {
+            s = data_row.pop() + s
             is_quote = false
-          } else s = ''
+          }
 
           // 改行で区切った文字列のリスト
-          const split_linesep = (s + s_q).split('\n')
+          const split_linesep = s.split('\n')
 
           for (let j = 0; j < split_linesep.length; j++) {
             // 区切り文字で区切った文字列を行の末尾に追加する

--- a/test/plugin_system_test.js
+++ b/test/plugin_system_test.js
@@ -258,10 +258,12 @@ describe('plugin_system_test', () => {
   it('CSV取得', () => {
     cmp('a=「1,2,3\n4,5,6」のCSV取得。a[1][2]を表示', '6')
     cmp('a=「"a",b,c\n""a,b,c\na,""b,c\na,b,c""\n"a,\nb",c,d\na,"b,\nc",d\na,b,"c,\nd"」のCSV取得。a[5][1]を表示', 'b,\nc')
+    cmp('a=「1,"a""a",2」のCSV取得。a[0][1]を表示', 'a"a')
   })
   it('TSV取得', () => {
     cmp('a=「1\t2\t3\n4\t5\t6」のTSV取得。a[1][2]を表示', '6')
     cmp('a=「"a"\tb\tc\n""a\tb\tc\na\t""b\tc\na\tb\tc""\n"a\t\nb"\tc\td\na\t"b\t\nc"\td\na\tb\t"c\t\nd"」のCSV取得。a[5][1]を表示', 'b\t\nc')
+    cmp('a=「1\t"a""a"\t2」のTSV取得。a[0][1]を表示', 'a"a')
   })
   it('表CSV変換', () => {
     cmp('[[1,2,"3 \n,"],[4,5,6]]を表CSV変換して表示', '"1","2","3 \n,"\n"4","5","6"')


### PR DESCRIPTION
以下のようなCSVをうまく二次元配列に変換できるように修正しました。

```csv
1,"a""a",2
```