### PR TITLE
〜と〜になるコマンド追加, closes #397

### DIFF
--- a/src/plugin_test.js
+++ b/src/plugin_test.js
@@ -15,7 +15,7 @@ const PluginTest = {
   // @テスト
   'なる': { // @ mochaによるテストで、ASSERTでAとBが正しいことを報告する // @なる
     type: 'func',
-    josi: [['が'], ['に']],
+    josi: [['と'], ['に']],
     fn: function (a, b, sys) {
       const assert = require('assert')
       assert.strictEqual(a, b)

--- a/src/plugin_test.js
+++ b/src/plugin_test.js
@@ -11,6 +11,15 @@ const PluginTest = {
       const assert = require('assert')
       assert.strictEqual(a, b)
     }
+  },
+  // @テスト
+  'なる': { // @ mochaによるテストで、ASSERTでAとBが正しいことを報告する // @なる
+    type: 'func',
+    josi: [['が'], ['に']],
+    fn: function (a, b, sys) {
+      const assert = require('assert')
+      assert.strictEqual(a, b)
+    }
   }
 }
 


### PR DESCRIPTION
ref. #397 

`〜と〜がASSERT等しい` と等価の命令 `〜と〜になる` を追加します。

```
●一つ足す(数に)
　数+1を戻す
ここまで

●テスト:テスト1
　(2に一つ足す)と3になる #「(2に一つ足す)と3がASSERT等しい」と等価
ここまで
```