### PR TITLE
テストの初期化処理を追加 #391

### DIFF
--- a/src/wnako3.js
+++ b/src/wnako3.js
@@ -54,6 +54,11 @@ class WebNakoCompiler extends NakoCompiler {
 
     if (isTest && code !== '') {
       code = '// mocha初期化\n' +
+        'const stats = document.getElementById(\'mocha-stats\');\n' +
+        'if(stats !== null) {\n' +
+        ' document.getElementById(\'mocha\').removeChild(stats);\n' +
+        '}\n' +
+        'mocha.suite.suites = [];\n' +
         'mocha.setup("bdd");\n' +
         'mocha.checkLeaks();\n' +
         '\n' +


### PR DESCRIPTION
ref. #391 

なでしこエディタで何度もテストを実行すると、

* エラーが発生する
* 右上の表示の数字が重なって表示される

といった問題が発生していたため、テストを実行する前に初期化 (mochaのリセット, 右上の表示の削除) を行うようにしました。