### PR TITLE
関数定義のコード生成部を修正, close #398

### DIFF
--- a/src/nako_gen.js
+++ b/src/nako_gen.js
@@ -556,7 +556,8 @@ class NakoGen {
     if (name)
       {this.nako_func[name]['fn'] = code}
 
-    this.__vars = this.__varslist.pop()
+    this.__varslist.pop()
+    this.__vars = this.__varslist[this.__varslist.length-1]
     if (name)
       {this.__varslist[1][name] = code}
 


### PR DESCRIPTION
ref. #398
 
関数定義のコードを生成後、 `__vars` の内容を元に戻す処理がうまくいっていない ( `__varslist[2]` ではなく `__varslist[3]` を代入している) のが https://nadesiko.g.hatena.ne.jp/snowdrops89/20190906/1567781611 の原因なようなので修正しました。