### PR TITLE
cnako3のマニュアル表示を修正, closes #403

### DIFF
--- a/batch/cmd_txt2json.nako3
+++ b/batch/cmd_txt2json.nako3
@@ -50,9 +50,10 @@ P_cnako3={}
 　　　　P[プラグイン名][表題]にVを配列追加。
        V_cnako3={}
        V_cnako3[「タイプ」]=タイプ
+       V_cnako3[「名前」]=名前
+       V_cnako3[「ヨミ」]=ヨミ_cnako3
        V_cnako3[「引数」]=引数
        V_cnako3[「説明」]=説明
-       V_cnako3[「ヨミ」]=ヨミ_cnako3
 　　　　P_cnako3[名前]=V_cnako3
 　　ここまで。
 ここまで。


### PR DESCRIPTION
ref. #403 

cnako3のマニュアル表示を以下のようにわかりやすくします。

```
$ node src/cnako3.js -m 表示
タイプ: 関数
名前: 表示
ヨミ: ひょうじ
引数: Sを/Sと
説明: Sを表示
```