### PR TITLE
文字抜出について

### DIFF
--- a/src/plugin_system.js
+++ b/src/plugin_system.js
@@ -732,6 +732,7 @@ const PluginSystem = {
     type: 'func',
     josi: [['で', 'の'], ['から'], ['を']],
     fn: function (s, a, cnt) {
+      cnt = cnt ? cnt : undefined
       return (String(s).substr(a - 1, cnt))
     }
   },
@@ -739,6 +740,7 @@ const PluginSystem = {
     type: 'func',
     josi: [['で', 'の'], ['から'], ['を', '']],
     fn: function (s, a, cnt) {
+      cnt = cnt ? cnt : undefined
       return (String(s).substr(a - 1, cnt))
     }
   },


### PR DESCRIPTION
「くぁｗせｄｒｆｔｇｙふじこｌｐ」で４から文字抜出
としたとき何も表示されないので表示できるようにしました。