### PR TITLE
eslintをアップデート

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "babel-preset-react": "^6.23.0",
     "date-utils": "^1.2.21",
     "es6-promise": "^4.2.6",
-    "eslint": "^4.19.1",
+    "eslint": "^6.8.0",
     "eslint-config-standard": "^11.0.0",
     "eslint-plugin-import": "^2.17.2",
     "eslint-plugin-node": "^6.0.1",


### PR DESCRIPTION
`eslint@4.19.1` が間接的に依存している `circular-json` は非推奨となっているため、eslintをアップデートします。

```
$ npm install
...
npm WARN deprecated circular-json@0.3.3: CircularJSON is in maintenance only, flatted is its successor.
...

#circular-jsonに依存しているライブラリ
$ npm ls circular-json
nadesiko3@3.0.68 /Users/elegant_belltree/Documents/nadesiko3
└─┬ eslint@4.19.1
  └─┬ file-entry-cache@2.0.0
    └─┬ flat-cache@1.3.4
      └── circular-json@0.3.3 
```