### PR TITLE
babel-core, polyfill周りのアップデート, polyfillの記述方法変更, closes #445

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "babel": {
     "presets": [
       [
-        "env",
+        "@babel/preset-env",
         {
           "targets": {
             "browsers": [
@@ -58,12 +58,14 @@
               "last 2 versions",
               "Firefox ESR",
               "not dead"
-            ],
-            "useBuiltIns": true
-          }
+            ]
+          },
+          "useBuiltIns": "usage",
+          "corejs": 3,
+          "debug": true
         }
       ],
-      "react"
+      "@babel/preset-react"
     ]
   },
   "eslintConfig": {
@@ -90,11 +92,10 @@
   "homepage": "https://github.com/kujirahand/nadesiko3#readme",
   "devDependencies": {
     "@babel/cli": "^7.8.3",
-    "babel-core": "^6.26.3",
-    "babel-loader": "^7.1.5",
-    "babel-polyfill": "^6.26.0",
-    "babel-preset-env": "^1.7.0",
-    "babel-preset-react": "^6.23.0",
+    "@babel/core": "^7.0.0",
+    "babel-loader": "^8.0.0",
+    "@babel/preset-env": "^7.0.0",
+    "@babel/preset-react": "^7.0.0",
     "date-utils": "^1.2.21",
     "es6-promise": "^4.2.6",
     "eslint": "^4.19.1",
@@ -118,6 +119,7 @@
     "body-parser": "^1.19.0",
     "commander": "^2.20.0",
     "copy-paste-win32fix": "^1.4.0",
+    "core-js": "^3.6.4",
     "css-loader": "^3.2.0",
     "csv-lite-js": "^0.0.7",
     "express": "^4.16.4",
@@ -132,6 +134,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "readline-sync": "^1.4.9",
+    "regenerator-runtime": "^0.13.3",
     "sendkeys-js": "0.0.4",
     "ssri": "^6.0.1",
     "style-loader": "^1.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,10 +8,9 @@ process.noDeprecation = true
 
 module.exports = {
   entry: {
-    // IE11対策としてbabel-polyfillを追加。時期が来たら削除する。
-    wnako3: ['babel-polyfill', path.join(srcPath, 'wnako3.js')], // plugin_system+plugin_browser含む
+    wnako3: [path.join(srcPath, 'wnako3.js')], // plugin_system+plugin_browser含む
     plugin_turtle: [path.join(srcPath, 'plugin_turtle.js')],
-    editor: ['babel-polyfill', path.join(editorPath, 'edit_main.jsx')]
+    editor: [path.join(editorPath, 'edit_main.jsx')]
   },
 
   output: {
@@ -32,7 +31,7 @@ module.exports = {
         exclude: /node_modules/,
         include: [editorPath, srcPath],
         query: {
-          presets: ['env', 'react']
+          presets: ['@babel/preset-env', '@babel/preset-react']
         }
       },
       // .js file
@@ -42,7 +41,7 @@ module.exports = {
         exclude: /node_modules/,
         include: [srcPath],
         query: {
-          presets: ['env']
+          presets: ['@babel/preset-env']
         }
       },
       {


### PR DESCRIPTION
ref. #445 

ライブラリインストール時の以下の警告を解消するため、ライブラリをアップデートしました。

```
$ npm install
npm WARN deprecated core-js@2.6.11: core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.
...
npm WARN @babel/cli@7.8.4 requires a peer of @babel/core@^7.0.0-0 but none is installed. You must install peer dependencies yourself.
...
```

また、それに伴ってpolyfill周りの記述方法を変更しました。
なお、 `"useBuiltIns": "usage"` を指定することで、必要なpolyfillのみをimportするようにしています (参考: [Babel 7 の主な変更点まとめ - Qiita](https://qiita.com/soarflat/items/21b8955f992bf7d38581#babelpreset-env-%E3%81%AE-usebuiltins-%E3%82%92%E5%88%A9%E7%94%A8%E3%81%97%E3%81%A6core-js3-%E3%81%8B%E3%82%89%E5%BF%85%E8%A6%81%E3%81%AA-polyfill-%E3%81%AE%E3%81%BF%E3%82%92-import-%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%AA%E3%81%A3%E3%81%9Fbabel-740-%E3%81%8B%E3%82%89))。