### PR TITLE
READMEに対応機器, 対応ブラウザを明示的に埋め込めるよう実装, 対応ブラウザにNode追加, closes #447

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@
 			* 72
 			* 71
 			* 68
-		* IE
+		* Internet Explorer
 			* 11
 		* Opera
 			* 66

--- a/README.template.md
+++ b/README.template.md
@@ -12,64 +12,7 @@
 
 ## 対応機器/Webブラウザ
 
-* Webブラウザ
-	* モバイル
-		* Chrome for Android
-			* 79
-		* Firefox for Android
-			* 68
-		* QQ Browser
-			* 1.2
-		* UC Browser for Android
-			* 12.12
-		* Android Browser
-			* 76
-		* Baidu Browser
-			* 7.12
-		* iOS Safari
-			* 13.3
-			* 13.2
-			* 13.0-13.1
-			* 12.2-12.4
-			* 12.0-12.1
-			* 11.3-11.4
-			* 10.3
-		* KaiOS Browser
-			* 2.5
-		* Opera Mini
-			* all
-		* Opera Mobile
-			* 46
-		* Samsung Internet
-			* 10.1
-			* 9.2
-	* PC
-		* Chrome
-			* 80
-			* 79
-			* 78
-			* 49
-		* Edge
-			* 80
-			* 79
-			* 18
-		* Firefox
-			* 72
-			* 71
-			* 68
-		* IE
-			* 11
-		* Opera
-			* 66
-			* 65
-		* Safari
-			* 13
-			* 12.1
-* PC (Windows/macOS/Linux)
-	* Node
-		* 13.8.0
-		* 12.16.0
-		* 10.19.0
+{embed browser}
 
 ## Webブラウザで利用する場合
 

--- a/doc/SETUP.md
+++ b/doc/SETUP.md
@@ -137,7 +137,7 @@ $ npm run build:command
 ```
 ### READMEの生成
 
-「対応機器, 対応ブラウザを展開したい場所に `{embed browser}` する」という規則に従って[README.template.md](../README.template.md)を記述し、以下のコマンドを実行します。
+「対応機器, 対応ブラウザを展開したい場所に `{embed browser}` と記述する」という規則に従って[README.template.md](../README.template.md)を記述し、以下のコマンドを実行します。
 
 ```
 $ npm run build:readme

--- a/doc/SETUP.md
+++ b/doc/SETUP.md
@@ -135,6 +135,13 @@ $ npm start
 ```
 $ npm run build:command
 ```
+### READMEの生成
+
+「対応機器, 対応ブラウザを展開したい場所に `{embed browser}` する」という規則に従って[README.template.md](../README.template.md)を記述し、以下のコマンドを実行します。
+
+```
+$ npm run build:readme
+```
 
 ### Node.jsのパッケージの更新方法
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build:command": "cnako3 batch/build_command.nako3",
     "build:electron": "asar pack src/enako3.js release/enako3.asar",
     "build:win32": "cnako3 installer/make-win32.nako3",
+    "build:readme": "node tools/readme_generator/generator.js",
     "watch": "webpack --watch --mode development"
   },
   "repository": {
@@ -51,15 +52,6 @@
       [
         "@babel/preset-env",
         {
-          "targets": {
-            "browsers": [
-              "> 0.5%",
-              "> 0.5% in JP",
-              "last 2 versions",
-              "Firefox ESR",
-              "not dead"
-            ]
-          },
           "useBuiltIns": "usage",
           "corejs": 3,
           "debug": true
@@ -68,6 +60,14 @@
       "@babel/preset-react"
     ]
   },
+  "browserslist": [
+    "> 0.5%",
+    "> 0.5% in JP",
+    "last 2 versions",
+    "Firefox ESR",
+    "maintained node versions",
+    "not dead"
+  ],
   "eslintConfig": {
     "extends": [
       "standard",
@@ -113,7 +113,8 @@
     "source-map": "^0.7.3",
     "uuid": "^3.3.2",
     "webpack": "^4.31.0",
-    "webpack-cli": "^3.3.2"
+    "webpack-cli": "^3.3.2",
+    "caniuse-db": "^1.0.30001027"
   },
   "dependencies": {
     "body-parser": "^1.19.0",

--- a/tools/README.md
+++ b/tools/README.md
@@ -6,5 +6,6 @@
 
 なでしこ3(Node版)のエディタ
 
-
-
+## readme_generator
+[README.template.md](../README.template.md)を元に対応機器, 対応ブラウザを展開した[README.md]](../README.md)を生成します。
+なお、[README.template.md](../README.template.md)を記述する際は対応機器, 対応ブラウザを展開したい場所に `{embed browser}` と記述する必要があります。

--- a/tools/README.md
+++ b/tools/README.md
@@ -7,5 +7,5 @@
 なでしこ3(Node版)のエディタ
 
 ## readme_generator
-[README.template.md](../README.template.md)を元に対応機器, 対応ブラウザを展開した[README.md]](../README.md)を生成します。
+[README.template.md](../README.template.md)を元に対応機器, 対応ブラウザを展開した[README.md](../README.md)を生成します。
 なお、[README.template.md](../README.template.md)を記述する際は対応機器, 対応ブラウザを展開したい場所に `{embed browser}` と記述する必要があります。

--- a/tools/readme_generator/generator.js
+++ b/tools/readme_generator/generator.js
@@ -1,0 +1,83 @@
+const fs = require('fs')
+const browserslist = require('browserslist')
+const agents = require('caniuse-db/data.json').agents
+
+const browsers = {}
+
+for (const browserStr of browserslist()) {
+  const browser = browserStr.split(' ')
+  let type = 'その他'
+  let device = ''
+
+  if (browser[0] in agents) {
+    const browserData = agents[browser[0]]
+
+    browser[0] = browserData.browser
+
+    switch (browserData.type) {
+      case 'mobile':
+        type = 'Webブラウザ'
+        device = 'モバイル'
+        break
+      case 'desktop':
+        type = 'Webブラウザ'
+        device = 'PC'
+        break
+      default:
+        type = browserData.type
+        break
+    }
+  } else if (browser[0] === 'node') {
+    type = 'PC (Windows/macOS/Linux)'
+    browser[0] = 'Node'
+  }
+
+  if (!(type in browsers)) {
+    browsers[type] = {}
+  }
+
+  if (!(device in browsers[type])) {
+    browsers[type][device] = {}
+  }
+
+  if (!(browser[0] in browsers[type][device])) {
+    browsers[type][device][browser[0]] = []
+  }
+
+  browsers[type][device][browser[0]].push(browser[1])
+}
+
+const browserMd = []
+
+for (const type in browsers) {
+  browserMd.push('* ' + type)
+
+  for (const device in browsers[type]) {
+    let indent = ''
+
+    if (device !== '') {
+      browserMd.push('\t* ' + device)
+      indent = '\t'
+    }
+
+    for (const browser in browsers[type][device]) {
+      browserMd.push(indent + '\t* ' + browser)
+
+      for (const version of browsers[type][device][browser]) {
+        browserMd.push(indent + '\t\t* ' + version)
+      }
+    }
+  }
+}
+
+let md = []
+
+for (const row of fs.readFileSync('README.template.md').toString().split('\n')) {
+  if (row === '{embed browser}') {
+    md = md.concat(browserMd)
+  } else {
+    md.push(row)
+  }
+}
+
+fs.writeFileSync('README.md', md.join('\n'))

--- a/tools/readme_generator/generator.js
+++ b/tools/readme_generator/generator.js
@@ -12,7 +12,11 @@ for (const browserStr of browserslist()) {
   if (browser[0] in agents) {
     const browserData = agents[browser[0]]
 
-    browser[0] = browserData.browser
+    if (browserData.browser === 'IE') {
+      browser[0] = 'Internet Explorer'
+    } else {
+      browser[0] = browserData.browser
+    }
 
     switch (browserData.type) {
       case 'mobile':


### PR DESCRIPTION
ref. #447

テンプレートファイルを元に対応機器, 対応ブラウザを展開したREADMEを生成できるよう実装しました。
また、対応ブラウザに `maintained node versions` (サポートされているNode) を追加しました。