### PR TITLE
デバッグ変数を一括で切り替える変数追加, closes #436

### DIFF
--- a/src/nako3.js
+++ b/src/nako3.js
@@ -15,11 +15,12 @@ const lexer = new Lexer()
 
 class NakoCompiler {
   constructor () {
-    this.debug = false
+    this.debugAll = false
+    this.debug = false || this.debugAll
     this.silent = true
-    this.debugParser = false
-    this.debugJSCode = true
-    this.debugLexer = false
+    this.debugParser = false || this.debugAll
+    this.debugJSCode = true || this.debugAll
+    this.debugLexer = false || this.debugAll
     this.filename = 'inline'
     // 環境のリセット
     this.__varslist = [{}, {}, {}] // このオブジェクトは変更しないこと (this.gen.__varslist と共有する)

--- a/src/nako_parser_base.js
+++ b/src/nako_parser_base.js
@@ -6,8 +6,9 @@ const NakoSyntaxError = require('./nako_syntax_error')
 
 class NakoParserBase {
   constructor () {
-    this.debug = false
-    this.debugStack = false
+    this.debugAll = false
+    this.debug = false || this.debugAll
+    this.debugStack = false || this.debugAll
     this.stackList = [] // 関数定義の際にスタックが混乱しないように整理する
     this.filename = ''
     this.init()


### PR DESCRIPTION
ref. #436 

`NakoCompiler`, `NakoParserBase` にデバッグ変数を一括で切り替える変数 `debugAll` を追加しました。
これにより、全てのデバッグ機能をオンにした状態で開発したい時は `NakoCompiler`, `NakoParserBase` の `debugAll` を `true` にするだけでよくなります。