### PR TITLE
引数が1つでない関数への代入的呼び出し時に例外を返すよう実装 #443

### DIFF
--- a/src/nako_parser3.js
+++ b/src/nako_parser3.js
@@ -719,7 +719,7 @@ class NakoParser extends NakoParserBase {
     if (nullCount >= 2 && (0 < valueCount || t.josi === '' || keizokuJosi.indexOf(t.josi) >= 0))
       {throw new NakoSyntaxError(`関数『${t.value}』の引数が不足しています。`, t.line, this.filename)}
 
-    const funcNode = {type: 'func', name: t.value, args: args, josi: t.josi, line: t.line}
+    const funcNode = {type: 'func', name: t.value, args: args, josi: t.josi, line: t.line, meta: t.meta}
     // 言い切りならそこで一度切る
     if (t.josi === '')
       {return funcNode}

--- a/src/nako_parser3.js
+++ b/src/nako_parser3.js
@@ -610,11 +610,11 @@ class NakoParser extends NakoParserBase {
           case 'func': // 関数の代入的呼び出し
             switch (word.meta.josi.length) {
               case 0:
-                throw new NakoSyntaxError(`引数がない関数『${word.name}』を代入的呼び出ししようとしています。`, dainyu.line, this.filename)
+                throw new NakoSyntaxError(`引数がない関数『${word.name}』を代入的呼び出しすることはできません。`, dainyu.line, this.filename)
               case 1:
                 return {type: 'func', name: word.name, args: [value], setter: true, line: dainyu.line, josi: ''}
               default:
-                throw new NakoSyntaxError(`関数『${word.name}』の引数が不足しています。`, dainyu.line, this.filename)
+                throw new NakoSyntaxError(`引数が2つ以上ある関数『${word.name}』を代入的呼び出しすることはできません。`, dainyu.line, this.filename)
             }
           case 'ref_array': // 配列への代入
             return {type: 'let_array', name: word.name, index: word.index, value: value, line: dainyu.line, josi: ''}
@@ -743,7 +743,7 @@ class NakoParser extends NakoParserBase {
         if (this.accept(['func', 'eq', this.yCalc])) {
           switch (this.y[0].meta.josi.length) {
             case 0:
-              throw new NakoSyntaxError(`引数がない関数『${this.y[0].value}』を代入的呼び出ししようとしています。`, this.y[0].line, this.filename)
+              throw new NakoSyntaxError(`引数がない関数『${this.y[0].value}』を代入的呼び出しすることはできません。`, this.y[0].line, this.filename)
             case 1:
               return {
                 type: 'func',
@@ -753,7 +753,7 @@ class NakoParser extends NakoParserBase {
                 line: this.y[0].line
               }
             default:
-              throw new NakoSyntaxError(`関数『${this.y[0].value}』の引数が不足しています。`, this.y[0].line, this.filename)
+              throw new NakoSyntaxError(`引数が2つ以上ある関数『${this.y[0].value}』を代入的呼び出しすることはできません。`, this.y[0].line, this.filename)
           }
         } else
           {throw new NakoSyntaxError(

--- a/src/nako_parser3.js
+++ b/src/nako_parser3.js
@@ -719,7 +719,7 @@ class NakoParser extends NakoParserBase {
     if (nullCount >= 2 && (0 < valueCount || t.josi === '' || keizokuJosi.indexOf(t.josi) >= 0))
       {throw new NakoSyntaxError(`関数『${t.value}』の引数が不足しています。`, t.line, this.filename)}
 
-    const funcNode = {type: 'func', name: t.value, args: args, josi: t.josi, line: t.line, meta: f}
+    const funcNode = {type: 'func', name: t.value, args: args, josi: t.josi, line: t.line}
     // 言い切りならそこで一度切る
     if (t.josi === '')
       {return funcNode}
@@ -730,6 +730,7 @@ class NakoParser extends NakoParserBase {
       return funcNode
     }
     // 続き
+    funcNode.meta = f
     this.pushStack(funcNode)
     return null
   }

--- a/src/nako_parser3.js
+++ b/src/nako_parser3.js
@@ -719,7 +719,7 @@ class NakoParser extends NakoParserBase {
     if (nullCount >= 2 && (0 < valueCount || t.josi === '' || keizokuJosi.indexOf(t.josi) >= 0))
       {throw new NakoSyntaxError(`関数『${t.value}』の引数が不足しています。`, t.line, this.filename)}
 
-    const funcNode = {type: 'func', name: t.value, args: args, josi: t.josi, line: t.line, meta: t.meta}
+    const funcNode = {type: 'func', name: t.value, args: args, josi: t.josi, line: t.line, meta: f}
     // 言い切りならそこで一度切る
     if (t.josi === '')
       {return funcNode}

--- a/test/func_call.js
+++ b/test/func_call.js
@@ -73,7 +73,7 @@ describe('関数呼び出しテスト', () => {
       err => {
         assert(err instanceof NakoSyntaxError)
 
-        // エラーメッセージ の内容が正しいか
+        // エラーメッセージの内容が正しいか
         assert(err.message.indexOf(`引数がない関数『${funcName}』を代入的呼び出ししようとしています。`) > -1)
         return true
       }
@@ -86,7 +86,7 @@ describe('関数呼び出しテスト', () => {
       err => {
         assert(err instanceof NakoSyntaxError)
 
-        // エラーメッセージ の内容が正しいか
+        // エラーメッセージの内容が正しいか
         assert(err.message.indexOf(`関数『${funcName}』の引数が不足しています。`) > -1)
 
         return true

--- a/test/func_call.js
+++ b/test/func_call.js
@@ -74,7 +74,7 @@ describe('関数呼び出しテスト', () => {
         assert(err instanceof NakoSyntaxError)
 
         // エラーメッセージの内容が正しいか
-        assert(err.message.indexOf(`引数がない関数『${funcName}』を代入的呼び出ししようとしています。`) > -1)
+        assert(err.message.indexOf(`引数がない関数『${funcName}』を代入的呼び出しすることはできません。`) > -1)
         return true
       }
     )
@@ -87,7 +87,7 @@ describe('関数呼び出しテスト', () => {
         assert(err instanceof NakoSyntaxError)
 
         // エラーメッセージの内容が正しいか
-        assert(err.message.indexOf(`関数『${funcName}』の引数が不足しています。`) > -1)
+        assert(err.message.indexOf(`引数が2つ以上ある関数『${funcName}』を代入的呼び出しすることはできません。`) > -1)
 
         return true
       }
@@ -101,7 +101,7 @@ describe('関数呼び出しテスト', () => {
         assert(err instanceof NakoSyntaxError)
 
         // エラーメッセージの内容が正しいか
-        assert(err.message.indexOf(`引数がない関数『${funcName}』を代入的呼び出ししようとしています。`) > -1)
+        assert(err.message.indexOf(`引数がない関数『${funcName}』を代入的呼び出しすることはできません。`) > -1)
         return true
       }
     )
@@ -114,7 +114,7 @@ describe('関数呼び出しテスト', () => {
         assert(err instanceof NakoSyntaxError)
 
         // エラーメッセージの内容が正しいか
-        assert(err.message.indexOf(`関数『${funcName}』の引数が不足しています。`) > -1)
+        assert(err.message.indexOf(`引数が2つ以上ある関数『${funcName}』を代入的呼び出しすることはできません。`) > -1)
 
         return true
       }
@@ -128,7 +128,7 @@ describe('関数呼び出しテスト', () => {
         assert(err instanceof NakoSyntaxError)
 
         // エラーメッセージの内容が正しいか
-        assert(err.message.indexOf(`引数がない関数『${funcName}』を代入的呼び出ししようとしています。`) > -1)
+        assert(err.message.indexOf(`引数がない関数『${funcName}』を代入的呼び出しすることはできません。`) > -1)
         return true
       }
     )
@@ -141,7 +141,7 @@ describe('関数呼び出しテスト', () => {
         assert(err instanceof NakoSyntaxError)
 
         // エラーメッセージの内容が正しいか
-        assert(err.message.indexOf(`関数『${funcName}』の引数が不足しています。`) > -1)
+        assert(err.message.indexOf(`引数が2つ以上ある関数『${funcName}』を代入的呼び出しすることはできません。`) > -1)
 
         return true
       }

--- a/test/func_call.js
+++ b/test/func_call.js
@@ -69,7 +69,7 @@ describe('関数呼び出しテスト', () => {
   it('関数の代入的呼び出しその3', () => {
     const funcName = 'テスト'
     assert.throws(
-      () => cmd(`●${funcName};それは5;ここまで;テスト=8`),
+      () => cmd(`●${funcName};それは5;ここまで;${funcName}=8`),
       err => {
         assert(err instanceof NakoSyntaxError)
 
@@ -82,7 +82,61 @@ describe('関数呼び出しテスト', () => {
   it('関数の代入的呼び出しその4', () => {
     const funcName = 'テスト'
     assert.throws(
-      () => cmd(`●${funcName}(aとbを);それはa+b;ここまで;テスト=8`),
+      () => cmd(`●${funcName}(aとbを);それはa+b;ここまで;${funcName}=8`),
+      err => {
+        assert(err instanceof NakoSyntaxError)
+
+        // エラーメッセージの内容が正しいか
+        assert(err.message.indexOf(`関数『${funcName}』の引数が不足しています。`) > -1)
+
+        return true
+      }
+    )
+  })
+  it('関数の代入的呼び出しその5', () => {
+    const funcName = 'テスト'
+    assert.throws(
+      () => cmd(`●${funcName};それは5;ここまで;${funcName}に8を代入`),
+      err => {
+        assert(err instanceof NakoSyntaxError)
+
+        // エラーメッセージの内容が正しいか
+        assert(err.message.indexOf(`引数がない関数『${funcName}』を代入的呼び出ししようとしています。`) > -1)
+        return true
+      }
+    )
+  })
+  it('関数の代入的呼び出しその6', () => {
+    const funcName = 'テスト'
+    assert.throws(
+      () => cmd(`●${funcName}(aとbを);それはa+b;ここまで;${funcName}に8を代入`),
+      err => {
+        assert(err instanceof NakoSyntaxError)
+
+        // エラーメッセージの内容が正しいか
+        assert(err.message.indexOf(`関数『${funcName}』の引数が不足しています。`) > -1)
+
+        return true
+      }
+    )
+  })
+  it('関数の代入的呼び出しその7', () => {
+    const funcName = 'テスト'
+    assert.throws(
+      () => cmd(`●${funcName};それは5;ここまで;${funcName}は8`),
+      err => {
+        assert(err instanceof NakoSyntaxError)
+
+        // エラーメッセージの内容が正しいか
+        assert(err.message.indexOf(`引数がない関数『${funcName}』を代入的呼び出ししようとしています。`) > -1)
+        return true
+      }
+    )
+  })
+  it('関数の代入的呼び出しその8', () => {
+    const funcName = 'テスト'
+    assert.throws(
+      () => cmd(`●${funcName}(aとbを);それはa+b;ここまで;${funcName}は8`),
       err => {
         assert(err instanceof NakoSyntaxError)
 

--- a/test/func_call.js
+++ b/test/func_call.js
@@ -1,5 +1,6 @@
 const assert = require('assert')
 const NakoCompiler = require('../src/nako3')
+const NakoSyntaxError = require('../src/nako_parser_base').NakoSyntaxError
 
 describe('関数呼び出しテスト', () => {
   const nako = new NakoCompiler()
@@ -65,6 +66,33 @@ describe('関数呼び出しテスト', () => {
     cmp('INT=3.5;それを表示;', '3')
     cmp('INTは3.5;それを表示;', '3')
   })
+  it('関数の代入的呼び出しその3', () => {
+    const funcName = 'テスト'
+    assert.throws(
+      () => cmd(`●${funcName};それは5;ここまで;テスト=8`),
+      err => {
+        assert(err instanceof NakoSyntaxError)
+
+        // エラーメッセージ の内容が正しいか
+        assert(err.message.indexOf(`引数がない関数『${funcName}』を代入的呼び出ししようとしています。`) > -1)
+        return true
+      }
+    )
+  })
+  it('関数の代入的呼び出しその4', () => {
+    const funcName = 'テスト'
+    assert.throws(
+      () => cmd(`●${funcName}(aとbを);それはa+b;ここまで;テスト=8`),
+      err => {
+        assert(err instanceof NakoSyntaxError)
+
+        // エラーメッセージ の内容が正しいか
+        assert(err.message.indexOf(`関数『${funcName}』の引数が不足しています。`) > -1)
+
+        return true
+      }
+    )
+  })
   it('関数の引数に関数呼び出しがある場合', () => {
     cmp('A=「ab」;「abcd」の1から(Aの文字数)だけ文字削除。それを表示。', 'cd')
   })
@@ -72,7 +100,7 @@ describe('関数呼び出しテスト', () => {
     cmp('●MYSORT(a,b)とは\n' +
         '(INT(a) - INT(b))で戻る。\n' +
         'ここまで。\n' +
-        'ARY=[8,3,4];' + 
+        'ARY=[8,3,4];' +
         '「MYSORT」でARYを配列カスタムソートしてJSONエンコードして表示', '[3,4,8]')
   })
   it('引数の順番を入れ替えて呼び出す(#342)その1', () => {


### PR DESCRIPTION
ref. #443 

引数が1つでない関数への代入的呼び出しが行われた場合、コンパイル時に例外を返すよう実装しました。

例えば #443 で挙げられていたコードの場合、

```
●テスト
それは５
ここまで
テスト＝８
テストを表示
```

以下のように例外が投げられます。

```
文法エラー](4行目): 関数『テスト』の代入的呼び出しにエラーがあります。
[文法エラー](4行目): 引数がない関数『テスト』を代入的呼び出ししようとしています。
[バージョン] 3.0.69
[バージョン] 3.0.69
```