### PR TITLE
なでしこ3をローカルにしかインストールしていなくてもcnako3上で実行するscriptが動くよう修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,14 +12,14 @@
     "test": "mocha",
     "start": "node src/nako3server.js",
     "server": "lite-server --config=demo/bs-config.json",
-    "nako3edit": "cnako3 tools/nako3edit/index.nako3",
+    "nako3edit": "node src/cnako3.js tools/nako3edit/index.nako3",
     "nako3edit:run": "node tools/nako3edit/run.js",
     "electron": "electron src/enako3.js",
     "build": "webpack --mode production",
-    "build:command": "cnako3 batch/build_command.nako3",
+    "build:command": "node src/cnako3.js batch/build_command.nako3",
     "build:electron": "asar pack src/enako3.js release/enako3.asar",
-    "build:win32": "cnako3 installer/make-win32.nako3",
-    "build:readme": "cnako3 batch/build_readme.nako3",
+    "build:win32": "node src/cnako3.js installer/make-win32.nako3",
+    "build:readme": "node src/cnako3.js batch/build_readme.nako3",
     "watch": "webpack --watch --mode development"
   },
   "repository": {


### PR DESCRIPTION
`npm run build:readme` のようなpackage.jsonに定義されたcnako3上で実行するscriptをなでしこ3がローカルにしかインストールされていない状態でも動作するように修正します。

なお、なでしこ3をローカルにしかインストールしていない場合、現状ではこれらのコマンドを実行すると、以下のようなエラーが発生します。

```
 $ npm run build:readme

> nadesiko3@3.0.69 build:readme /Users/hoge/Documents/nadesiko3
> cnako3 batch/build_readme.nako3

sh: cnako3: command not found
npm ERR! code ELIFECYCLE
npm ERR! syscall spawn
npm ERR! file sh
npm ERR! errno ENOENT
npm ERR! nadesiko3@3.0.69 build:readme: `cnako3 batch/build_readme.nako3`
npm ERR! spawn ENOENT
npm ERR! 
npm ERR! Failed at the nadesiko3@3.0.69 build:readme script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/hoge/.npm/_logs/2020-02-28T22_47_20_345Z-debug.log
```