### PR TITLE
Webエディタでキャンバスに描画できるようにする

### DIFF
--- a/editor/editor_button_component.jsx
+++ b/editor/editor_button_component.jsx
@@ -52,6 +52,5 @@ EditorButtonComponent.propTypes = {
   onInformationChanged: PropTypes.func.isRequired,
   onReset: PropTypes.func.isRequired,
   onErrorChanged: PropTypes.func.isRequired,
-  nako3: PropTypes.object.isRequired,
-  canvasId: PropTypes.string.isRequired
+  nako3: PropTypes.object.isRequired
 }

--- a/editor/editor_button_component.jsx
+++ b/editor/editor_button_component.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import moment from 'moment-timezone'
 
 export default function EditorButtonComponent (props) {
+  const preCode = `カメ描画先は『#${props.canvasId}』。\n『#${props.canvasId}』へ描画開始。\n`
   return (
     <div className="buttons">
       <button onClick={() => {
@@ -11,7 +12,7 @@ export default function EditorButtonComponent (props) {
           // なでしこの関数をカスタマイズ --- TODO: なでしこの追加命令は edit_main.jsxで書いているので別途関数を作ってそこでまとめるように
           props.nako3.setFunc('表示', [['と', 'を', 'の']], props.onInformationChanged)
           window.localStorage['nako3/editor/code'] = props.code
-          props.nako3.run(props.code)
+          props.nako3.run(preCode + props.code)
         } catch (e) {
           props.onErrorChanged(e)
         }
@@ -21,7 +22,7 @@ export default function EditorButtonComponent (props) {
       <button onClick={() => {
         try {
           window.localStorage['nako3/editor/code'] = props.code
-          props.nako3.test(props.code)
+          props.nako3.test(preCode + props.code)
         } catch (e) {
           props.onErrorChanged(e)
         }
@@ -32,7 +33,7 @@ export default function EditorButtonComponent (props) {
       <button onClick={() => {
         try {
           const link = document.createElement('a')
-          link.href = window.URL.createObjectURL(new Blob([props.nako3.compile(props.code)]))
+          link.href = window.URL.createObjectURL(new Blob([props.nako3.compile(preCode + props.code)]))
           link.download = 'nako3_' + moment().format('YYYYMMDDHHmmss') + '.js'
           link.click()
         } catch (e) {
@@ -50,5 +51,6 @@ EditorButtonComponent.propTypes = {
   onInformationChanged: PropTypes.func.isRequired,
   onReset: PropTypes.func.isRequired,
   onErrorChanged: PropTypes.func.isRequired,
-  nako3: PropTypes.object.isRequired
+  nako3: PropTypes.object.isRequired,
+  canvasId: PropTypes.string.isRequired
 }

--- a/editor/editor_button_component.jsx
+++ b/editor/editor_button_component.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import moment from 'moment-timezone'
 
 export default function EditorButtonComponent (props) {
-  const preCode = `カメ描画先は『#${props.canvasId}』。\n『#${props.canvasId}』へ描画開始。\n`
+  const preCode = props.preCode + '\n'
   return (
     <div className="buttons">
       <button onClick={() => {
@@ -47,6 +47,7 @@ export default function EditorButtonComponent (props) {
 }
 
 EditorButtonComponent.propTypes = {
+  preCode: PropTypes.string.isRequired,
   code: PropTypes.string.isRequired,
   onInformationChanged: PropTypes.func.isRequired,
   onReset: PropTypes.func.isRequired,

--- a/editor/editor_component.jsx
+++ b/editor/editor_component.jsx
@@ -16,11 +16,13 @@ export default class EditorComponent extends React.Component {
 
   render () {
     const canvasId = 'nako3_canvas_1'
+    const preCode = `# 自動的に実行されるコード (編集不可)\nカメ描画先は『#${canvasId}』。\n『#${canvasId}』へ描画開始。`
     return (
       <div>
-        <EditorFormComponent title={this.props.title} code={this.state.code}
+        <EditorFormComponent title={this.props.title} code={preCode} row="3" readOnly={true} />
+        <EditorFormComponent title={this.props.title} code={this.state.code} row="10" readOnly={false}
                              ref={(e) => this.form = e} onChange={(e) => this.setState({code: e.target.value})} />
-        <EditorButtonComponent nako3={this.props.nako3} code={this.state.code} canvasId={canvasId}
+        <EditorButtonComponent nako3={this.props.nako3} preCode={preCode} code={this.state.code} canvasId={canvasId}
                                onInformationChanged={(s) => {
                                  this.info.push(s)
                                  this.setState({err: null})

--- a/editor/editor_component.jsx
+++ b/editor/editor_component.jsx
@@ -30,8 +30,7 @@ export default class EditorComponent extends React.Component {
                                  this.setState({err: null})
                                }}
                                onErrorChanged={(e) => this.setState({err: e})} />
-        <EditorInformationComponent info={this.info.join('\n')} err={this.state.err} />
-        <canvas id={canvasId} width="310" height="150"/>
+        <EditorInformationComponent info={this.info.join('\n')} err={this.state.err} canvasId={canvasId} />
         <EditorTestInformationComponent/>
         <CommandListComponent onClick={(e) => {
           this.setState({code: this.state.code.substr(0, this.form.pos()) + e.target.getAttribute('data-paste') + this.state.code.substr(this.form.pos())})

--- a/editor/editor_component.jsx
+++ b/editor/editor_component.jsx
@@ -22,7 +22,7 @@ export default class EditorComponent extends React.Component {
         <EditorFormComponent title={this.props.title} code={preCode} row="3" readOnly={true} />
         <EditorFormComponent title={this.props.title} code={this.state.code} row="10" readOnly={false}
                              ref={(e) => this.form = e} onChange={(e) => this.setState({code: e.target.value})} />
-        <EditorButtonComponent nako3={this.props.nako3} preCode={preCode} code={this.state.code} canvasId={canvasId}
+        <EditorButtonComponent nako3={this.props.nako3} preCode={preCode} code={this.state.code}
                                onInformationChanged={(s) => {
                                  this.info.push(s)
                                  this.setState({err: null})

--- a/editor/editor_component.jsx
+++ b/editor/editor_component.jsx
@@ -16,11 +16,11 @@ export default class EditorComponent extends React.Component {
 
   render () {
     const canvasId = 'nako3_canvas_1'
-    const preCode = `# 自動的に実行されるコード (編集不可)\nカメ描画先は『#${canvasId}』。\n『#${canvasId}』へ描画開始。`
+    const preCodeList = ['# 自動的に実行されるコード (編集不可)', `カメ描画先は『#${canvasId}』。`, `『#${canvasId}』へ描画開始。`]
+    const preCode = preCodeList.join('\n')
     return (
       <div>
-        <EditorFormComponent title={this.props.title} code={preCode}
-                             row={preCode.split('\n').length} readOnly={true} />
+        <EditorFormComponent title={this.props.title} code={preCode} row={preCodeList.length} readOnly={true} />
         <EditorFormComponent title={this.props.title} code={this.state.code} row="10" readOnly={false}
                              ref={(e) => this.form = e} onChange={(e) => this.setState({code: e.target.value})} />
         <EditorButtonComponent nako3={this.props.nako3} preCode={preCode} code={this.state.code}

--- a/editor/editor_component.jsx
+++ b/editor/editor_component.jsx
@@ -19,7 +19,8 @@ export default class EditorComponent extends React.Component {
     const preCode = `# 自動的に実行されるコード (編集不可)\nカメ描画先は『#${canvasId}』。\n『#${canvasId}』へ描画開始。`
     return (
       <div>
-        <EditorFormComponent title={this.props.title} code={preCode} row="3" readOnly={true} />
+        <EditorFormComponent title={this.props.title} code={preCode}
+                             row={preCode.split('\n').length} readOnly={true} />
         <EditorFormComponent title={this.props.title} code={this.state.code} row="10" readOnly={false}
                              ref={(e) => this.form = e} onChange={(e) => this.setState({code: e.target.value})} />
         <EditorButtonComponent nako3={this.props.nako3} preCode={preCode} code={this.state.code}

--- a/editor/editor_component.jsx
+++ b/editor/editor_component.jsx
@@ -15,11 +15,12 @@ export default class EditorComponent extends React.Component {
   }
 
   render () {
+    const canvasId = 'nako3_canvas_1'
     return (
       <div>
         <EditorFormComponent title={this.props.title} code={this.state.code}
                              ref={(e) => this.form = e} onChange={(e) => this.setState({code: e.target.value})} />
-        <EditorButtonComponent nako3={this.props.nako3} code={this.state.code}
+        <EditorButtonComponent nako3={this.props.nako3} code={this.state.code} canvasId={canvasId}
                                onInformationChanged={(s) => {
                                  this.info.push(s)
                                  this.setState({err: null})
@@ -30,6 +31,7 @@ export default class EditorComponent extends React.Component {
                                }}
                                onErrorChanged={(e) => this.setState({err: e})} />
         <EditorInformationComponent info={this.info.join('\n')} err={this.state.err} />
+        <canvas id={canvasId} width="310" height="150"/>
         <EditorTestInformationComponent/>
         <CommandListComponent onClick={(e) => {
           this.setState({code: this.state.code.substr(0, this.form.pos()) + e.target.getAttribute('data-paste') + this.state.code.substr(this.form.pos())})

--- a/editor/editor_form_component.jsx
+++ b/editor/editor_form_component.jsx
@@ -12,15 +12,18 @@ export default class EditorFormComponent extends React.Component {
   }
 
   render () {
-    return <textarea className="src" rows="10" ref={(e) => this.textarea = e}
-                     onChange={this.props.onChange} title={this.props.title} value={this.props.code} />
+    return <textarea className="src" rows={this.props.row} ref={(e) => this.textarea = e}
+                     onChange={this.props.onChange} title={this.props.title} value={this.props.code}
+                     readOnly={this.props.readOnly}/>
   }
 }
 
 EditorFormComponent.propTypes = {
   title: PropTypes.string.isRequired,
   code: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired
+  row: PropTypes.number.isRequired,
+  readOnly: PropTypes.bool.isRequired,
+  onChange: PropTypes.func
 }
 
 EditorFormComponent.defaultProps = {

--- a/editor/editor_information_component.jsx
+++ b/editor/editor_information_component.jsx
@@ -26,6 +26,7 @@ export default function EditorInformationComponent (props) {
         <p className="edit_head">実行結果:</p>
         <p className="info">{nl2br(props.info)}</p>
         <div id="nako3_div_1"></div>
+        <canvas id={props.canvasId} width="310" height="150"/>
       </div>
     </div>
   )
@@ -33,5 +34,6 @@ export default function EditorInformationComponent (props) {
 
 EditorInformationComponent.propTypes = {
   info: PropTypes.string,
-  err: PropTypes.object
+  err: PropTypes.object,
+  canvasId: PropTypes.string.isRequired
 }


### PR DESCRIPTION
[なでしこ3簡易エディタ - なでしこ3](https://nadesi.com/doc3/index.php?%E3%81%AA%E3%81%A7%E3%81%97%E3%81%933%E7%B0%A1%E6%98%93%E3%82%A8%E3%83%87%E3%82%A3%E3%82%BF#h46566929)ではHTML上でキャンバスが定義されており、そこに描画できるようにするコードが自動的に実行されます。
これと同等の機能をなでしこ3のWebエディタ上にも実装します。