### PR TITLE
コマンド1つでElectronを配布可能な状態にできるよう実装

### DIFF
--- a/doc/SETUP.md
+++ b/doc/SETUP.md
@@ -160,8 +160,6 @@ $ npm run electron
 $ npm run build:electron
 ```
 
-ビルドしたenako3.asarを配布可能な形式にする方法については[Electronでアプリケーションを作ってみよう - Qiita](http://qiita.com/Quramy/items/a4be32769366cfe55778#配布してみる)を参照。
-
 ## Gitからリポジトリを取得して利用する場合
 
 最低限のライブラリで良い場合には、``npm install --production``を実行するだけ。

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "start": "node src/nako3server.js",
     "nako3edit": "node src/cnako3.js tools/nako3edit/index.nako3",
     "nako3edit:run": "node tools/nako3edit/run.js",
-    "electron": "electron src/enako3.js",
+    "electron": "electron .",
     "build": "webpack --mode production",
     "build:command": "node src/cnako3.js batch/build_command.nako3",
-    "build:electron": "asar pack src/enako3.js release/enako3.asar",
+    "build:electron": "electron-packager . --out release/enako3 --asar --all --overwrite",
     "build:win32": "node src/cnako3.js installer/make-win32.nako3",
     "build:readme": "node src/cnako3.js batch/build_readme.nako3",
     "watch": "webpack --watch --mode development"
@@ -119,8 +119,8 @@
     "ssri": "^6.0.1",
     "style-loader": "^1.0.0",
     "whatwg-fetch": "^2.0.4",
-    "asar": "^2.1.0",
     "electron": "^8.0.2",
+    "electron-packager": "^14.2.1",
     "npm-check-updates": "^4.0.3"
   },
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,9 @@
-// Node.jsでモジュールモードでなでしこを利用する場合
 module.exports = {
+  // Node.jsでモジュールモードでなでしこを利用する場合
   'compiler': require('./nako3.js'),
-  'PluginNode': require('./plugin_node.js')
+  'PluginNode': require('./plugin_node.js'),
+
+  // Electron
+  'app': require('./enako3').app
 }
 


### PR DESCRIPTION
`electron-packager` を使うことで、コマンド1つでElectronを配布可能な状態にできるよう実装しました。