### PR TITLE
wnako3ではcaniuse-dbの一部だけをビルド対象に含めるよう修正 #471

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ batch/*.txt
 .DS_Store
 Thumbs.db
 Desktop.ini
+
+src/agents.json

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "nako3edit": "node src/cnako3.js tools/nako3edit/index.nako3",
     "nako3edit:run": "node tools/nako3edit/run.js",
     "electron": "electron .",
-    "build": "webpack --mode production",
+    "build": "node src/generate_agents.js && webpack --mode production",
     "build:command": "node src/cnako3.js batch/build_command.nako3",
     "build:electron": "electron-packager . --out release/enako3 --asar --all --overwrite",
     "build:win32": "node src/cnako3.js installer/make-win32.nako3",

--- a/src/generate_agents.js
+++ b/src/generate_agents.js
@@ -1,0 +1,5 @@
+const fs = require('fs')
+const path = require('path')
+const data = require('caniuse-db/data.json')
+
+fs.writeFileSync(path.join(__dirname, 'agents.json'), JSON.stringify(data.agents))

--- a/src/plugin_browser.js
+++ b/src/plugin_browser.js
@@ -44,6 +44,7 @@ const PluginBrowser = {
   'オリーブ色': {type: 'const', value: 'olive'}, // @おりーぶいろ
   'ベージュ色': {type: 'const', value: 'beige'}, // @べーじゅいろ
   'アリスブルー色': {type: 'const', value: 'aliceblue'}, // @ありすぶるーいろ
+  'ブラウザ名変換表': {type: 'const', value: require('./agents.json')}, // @ぶらうざめいへんかんひょう
   'RGB': { // @赤緑青を256段階でそれぞれ指定して、#RRGGBB形式の値を返す // @RGB
     type: 'func',
     josi: [['と'], ['と'], ['で', 'の']],

--- a/src/plugin_node.js
+++ b/src/plugin_node.js
@@ -46,6 +46,7 @@ const PluginNode = {
       sys.__v0['AJAX:ONERROR'] = null
     }
   },
+  'ブラウザ名変換表': {type: 'const', value: require('caniuse-db/data.json').agents}, // @ぶらうざめいへんかんひょう
   // @ファイル入出力
   '開': { // @ファイルSを開く // @ひらく
     type: 'func',

--- a/src/plugin_system.js
+++ b/src/plugin_system.js
@@ -70,7 +70,6 @@ const PluginSystem = {
   'CR': {type: 'const', value: '\r'}, // @CR
   'LF': {type: 'const', value: '\n'}, // @LF
   '元号データ': {type: 'const', value: require('./era.json')}, // @げんごうでーた
-  'ブラウザ名変換表': {type: 'const', value: require('caniuse-db/data.json').agents}, // @ぶらうざめいへんかんひょう
   '空配列': { // @空の配列を返す // @からはいれつ
     type: 'func',
     josi: [],


### PR DESCRIPTION
ref. #471

caniuse-dbのうち、実際に使っているのは一部のデータ (`caniuse-db/data.json` の `agents`) だけです。
そのため、wnako3では使うデータだけをビルド対象に含めるようにし、配布サイズを削減します。