### PR TITLE
git submoduleとしてのnadesiko3-hogeを削除

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "test/nadesiko3-hoge"]
-	path = test/nadesiko3-hoge
-	url = git@github.com:kujirahand/nadesiko3-hoge.git

--- a/doc/SETUP.md
+++ b/doc/SETUP.md
@@ -35,7 +35,7 @@ Homebrew( https://brew.sh/index_ja ) (そしてXcode)をインストールして
 
 
 ```
-$ git clone --recursive https://github.com/kujirahand/nadesiko3
+$ git clone https://github.com/kujirahand/nadesiko3
 $ cd nadesiko3
 $ npm install --no-optional
 ```


### PR DESCRIPTION
https://github.com/kujirahand/nadesiko3/commit/92a4163a15f00863d0f085662d086f6759358757 でライブラリとして `nadesiko3-hoge` を導入しているため、git submoduleとしてGitリポジトリから取得していた `nadesiko3-hoge` を削除します。