### PR TITLE
マークアップ言語関連の命令を別のプラグインとして分離 #489

### DIFF
--- a/demo/basic.html
+++ b/demo/basic.html
@@ -61,5 +61,6 @@
 <!-- editor -->
 <!--React.jsのスクリプトはHTMLの末尾で読み込む-->
 <script src="../release/editor.js"></script>
+<script src="../release/plugin_markup.js"></script>
 </body>
 </html>

--- a/demo/flow.html
+++ b/demo/flow.html
@@ -87,5 +87,6 @@
 <!-- editor -->
 <!--React.jsのスクリプトはHTMLの末尾で読み込む-->
 <script src="../release/editor.js"></script>
+<script src="../release/plugin_markup.js"></script>
 </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -51,5 +51,6 @@
 <!-- editor -->
 <!--React.jsのスクリプトはHTMLの末尾で読み込む-->
 <script src="../release/editor.js"></script>
+<script src="../release/plugin_markup.js"></script>
 </body>
 </html>

--- a/demo/runscript.html
+++ b/demo/runscript.html
@@ -5,6 +5,7 @@
   <title>なでしこ3 - script要素を実行するデモ</title>
   <!-- なでしこを使う準備 -->
   <script src="../release/wnako3.js?run"></script>
+  <script src="../release/plugin_markup.js"></script>
   <script type="なでしこ">
     # # # # # # # # # # # # # # # # #
     # なでしこのプログラムをここに書く

--- a/demo/runscript2.html
+++ b/demo/runscript2.html
@@ -5,6 +5,7 @@
   <title>なでしこ3 - script要素を実行するデモ</title>
   <!-- なでしこを使う準備 -->
   <script src="../release/wnako3.js?run"></script>
+  <script src="../release/plugin_markup.js"></script>
   <script type="なでしこ">
     # # # # # # # # # # # # # # # # #
     # なでしこのプログラムをここに書く

--- a/demo/turtle.html
+++ b/demo/turtle.html
@@ -6,6 +6,7 @@
   <title>なでしこ3/タートルグラフィックス</title>
   <!-- なでしこを使う準備 -->
   <script src="../release/wnako3.js"></script>
+  <script src="../release/plugin_markup.js"></script>
   <script src="../release/plugin_turtle.js"></script>
   <script src="common.js"></script>
   <script src="turtle_test.js"></script>

--- a/demo/turtle2.html
+++ b/demo/turtle2.html
@@ -6,6 +6,7 @@
   <title>なでしこ3/タートルグラフィックス</title>
   <!-- なでしこを使う準備 -->
   <script src="../release/wnako3.js"></script>
+  <script src="../release/plugin_markup.js"></script>
   <script src="../release/plugin_turtle.js"></script>
   <!-- なでしこを呼び出して使う -->
   <script src="common.js"></script>
@@ -102,7 +103,7 @@
 　　(サイズ/3)と(深度-1)でフラクタル。
 　　60だけカメ左回転。
 　　(サイズ/3)と(深度-1)でフラクタル。
-ここまで。                                             
+ここまで。
 カメ作成。
 1にカメ速度設定。# 最速に
 [10,200]にカメ起点移動。

--- a/demo/turtle3.html
+++ b/demo/turtle3.html
@@ -6,6 +6,7 @@
   <title>なでしこ3/タートルグラフィックス</title>
   <!-- なでしこを使う準備 -->
   <script src="../release/wnako3.js"></script>
+  <script src="../release/plugin_markup.js"></script>
   <script src="../release/plugin_turtle.js"></script>
   <!-- なでしこを呼び出して使う -->
   <script src="common.js"></script>

--- a/src/plugin_markup.js
+++ b/src/plugin_markup.js
@@ -1,0 +1,24 @@
+const PluginMarkup = {
+  'マークダウンHTML変換': { // @マークダウン形式で記述された文字列SをHTML形式に変換する // @まーくだうんえいちてぃーえむえるへんかん
+    type: 'func',
+    josi: [['を']],
+    fn: function (s) {
+      const markdown = require('markdown')
+      return markdown.parse(s)
+    }
+  },
+  'HTML整形': { // @HTML形式で記述された文字列Sを整形する // @えいちてぃーえむえるせいけい
+    type: 'func',
+    josi: [['を']],
+    fn: function (s) {
+      const html = require('html')
+      return html.prettyPrint(s, {indent_size: 2})
+    }
+  }
+}
+
+module.exports = PluginMarkup
+
+// scriptタグで取り込んだ時、自動で登録する
+if (typeof (navigator) === 'object')
+  {navigator.nako3.addPluginObject('PluginMarkup', PluginMarkup)}

--- a/src/plugin_markup.js
+++ b/src/plugin_markup.js
@@ -1,3 +1,7 @@
+/**
+ * file: plugin_markup.js
+ * マークアップ言語関連のプラグイン
+ */
 const PluginMarkup = {
   'マークダウンHTML変換': { // @マークダウン形式で記述された文字列SをHTML形式に変換する // @まーくだうんえいちてぃーえむえるへんかん
     type: 'func',

--- a/src/plugin_system.js
+++ b/src/plugin_system.js
@@ -2131,22 +2131,6 @@ const PluginSystem = {
       const browserslist = require('browserslist')
       return browserslist()
     }
-  },
-  'マークダウンHTML変換': { // @マークダウン形式で記述された文字列SをHTML形式に変換する // @まーくだうんえいちてぃーえむえるへんかん
-    type: 'func',
-    josi: [['を']],
-    fn: function (s) {
-      const markdown = require('markdown')
-      return markdown.parse(s)
-    }
-  },
-  'HTML整形': { // @HTML形式で記述された文字列Sを整形する // @えいちてぃーえむえるせいけい
-    type: 'func',
-    josi: [['を']],
-    fn: function (s) {
-      const html = require('html')
-      return html.prettyPrint(s, {indent_size: 2})
-    }
   }
 }
 

--- a/test/plugin_markup_test.js
+++ b/test/plugin_markup_test.js
@@ -1,0 +1,45 @@
+const assert = require('assert')
+const NakoCompiler = require('../src/nako3')
+const CNako3 = require('../src/cnako3')
+const PluginMarkup = require('../src/plugin_markup')
+
+describe('plugin_markup_test', () => {
+  const wnako = new NakoCompiler()
+  wnako.addPluginFile('PluginMarkup', 'plugin_markup.js', PluginMarkup)
+
+  const cnako = new CNako3()
+  cnako.silent = true
+
+  const cmp = (code, res) => {
+    for (let nako of [cnako, wnako]) {
+      let c = code
+
+      if (nako === cnako) {
+        c = '!「src/plugin_markup.js」を取り込む。\n' + c
+      }
+
+      if (nako.debug) {
+        console.log('code=' + c)
+      }
+
+      assert.equal(nako.runReset(c).log, res)
+    }
+  }
+
+  // --- test ---
+  it('マークダウンHTML変換', () => {
+    cmp('「#test\n* 1234\n\t* ABCD」をマークダウンHTML変換して表示', '<h1>test</h1>\n\n<ul><li>1234<ul><li>ABCD</li></ul></li></ul>')
+  })
+  it('HTML整形', () => {
+    cmp('「<h1>test</h1>\n\n<ul><li>1234<ul><li>ABCD</li></ul></li></ul>」をHTML整形して表示',
+      '<h1>test</h1>\n' +
+      '\n' +
+      '<ul>\n' +
+      '  <li>1234\n' +
+      '    <ul>\n' +
+      '      <li>ABCD</li>\n' +
+      '    </ul>\n' +
+      '  </li>\n' +
+      '</ul>')
+  })
+})

--- a/test/plugin_system_test.js
+++ b/test/plugin_system_test.js
@@ -461,19 +461,4 @@ describe('plugin_system_test', () => {
     cmp('「2019/04/30」を和暦変換。それを表示', '平成31/04/30')
     cmp('「2019/05/01」を和暦変換。それを表示', '令和元/05/01')
   })
-  it('マークダウンHTML変換', () => {
-    cmp('「#test\n* 1234\n\t* ABCD」をマークダウンHTML変換して表示', '<h1>test</h1>\n\n<ul><li>1234<ul><li>ABCD</li></ul></li></ul>')
-  })
-  it('HTML整形', () => {
-    cmp('「<h1>test</h1>\n\n<ul><li>1234<ul><li>ABCD</li></ul></li></ul>」をHTML整形して表示',
-      '<h1>test</h1>\n' +
-      '\n' +
-      '<ul>\n' +
-      '  <li>1234\n' +
-      '    <ul>\n' +
-      '      <li>ABCD</li>\n' +
-      '    </ul>\n' +
-      '  </li>\n' +
-      '</ul>')
-  })
 })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,6 +32,7 @@ class CanIUseDBDataReplacementPlugin extends NormalModuleReplacementPlugin {
 module.exports = {
   entry: {
     wnako3: [path.join(srcPath, 'wnako3.js')], // plugin_system+plugin_browser含む
+    plugin_markup: [path.join(srcPath, 'plugin_markup.js')],
     plugin_turtle: [path.join(srcPath, 'plugin_turtle.js')],
     editor: [path.join(editorPath, 'edit_main.jsx')],
     version: [path.join(editorPath, 'version_main.jsx')]


### PR DESCRIPTION
ref. #489 

マークアップ言語関連の命令 (`マークダウンHTML変換`, `HTML整形`) を `plugin_markup` として分離します。