### PR TITLE
プラグイン関数内でエラーが発生した際に関数名が表示されるよう実装

### DIFF
--- a/src/nako3.js
+++ b/src/nako3.js
@@ -157,9 +157,13 @@ class NakoCompiler {
       eval(js) // eslint-disable-line
     } catch (e) {
       this.js = js
-      throw new NakoRuntimeError(
-        e.name + ':' +
-        e.message, this)
+      if (e instanceof NakoRuntimeError) {
+        throw e
+      } else {
+        throw new NakoRuntimeError(
+          e.name + ':' +
+          e.message, this)
+      }
     }
     return this
   }
@@ -214,7 +218,13 @@ class NakoCompiler {
       const v = po[key]
       this.funclist[key] = v
       if (v.type === 'func') {
-        __v0[key] = v.fn
+        __v0[key] = (...args) => {
+          try {
+            v.fn(...args)
+          } catch (e) {
+            throw new NakoRuntimeError('関数『' + key + '』:' + e.name + ':' + e.message, this)
+          }
+        }
       } else if (v.type === 'const' || v.type === 'var') {
         __v0[key] = v.value
         __v0.meta[key] = {


### PR DESCRIPTION
プラグイン関数内でエラーが発生した際、以下のように関数名が表示されるよう実装しました。

```
$ git  diff
diff --git a/src/plugin_system.js b/src/plugin_system.js
index 1565abe..50beff1 100644
--- a/src/plugin_system.js
+++ b/src/plugin_system.js
@@ -134,6 +134,7 @@ const PluginSystem = {
     type: 'func',
     josi: [['に', 'と'], ['を']],
     fn: function (a, b) {
+      throw new Error('xxxxx')
       return a + b
     }
   },
$ node ./src/cnako3.js -e "1に2と3を足して表示"
[実行時エラー] 関数『足』:Error:xxxxx
```