### PR TITLE
node.js 14.xのCI追加

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [14.x, 12.x, 10.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
https://nodejs.org/ja/about/releases/

2020-04-21にnode.js 14がリリースされているため、CIに追加します。