### PR TITLE
Dependabotの設定ファイル削除

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,8 +1,0 @@
-version: 1
-update_configs:
-  - package_manager: "javascript"
-    directory: "/"
-    update_schedule: "live"
-    allowed_updates:
-      - match:
-          update_type: "security"


### PR DESCRIPTION
https://help.github.com/en/github/managing-security-vulnerabilities/configuring-github-dependabot-security-updates#managing-github-dependabot-security-updates-for-your-repository

Dependabotによるセキュリティーアップデートの設定はリポジトリの設定に移ったため、Dependabotの設定ファイルを削除します。