### PR TITLE
hotkeysのimport時に拡張子を明示的に指定

### DIFF
--- a/src/plugin_browser.js
+++ b/src/plugin_browser.js
@@ -2,7 +2,7 @@
 require('es6-promise').polyfill()
 require('node-fetch')
 
-const hotkeys = require('hotkeys-js')
+const hotkeys = require('hotkeys-js/index.js')
 
 const errMsgCanvasInit = '描画を行うためには、HTML内にcanvasを配置し、idを振って『描画開始』命令に指定します。'
 


### PR DESCRIPTION
import時にライブラリを拡張子付きで記述することで、CommonJS形式でimportすることを明示し、エラーが発生しないようにします。

参考: https://qiita.com/shimataro999/items/8a63ec06f33ccd2ea9ca