### PR TITLE
webpackのモジュール解決時の優先度を変更

### DIFF
--- a/src/plugin_browser.js
+++ b/src/plugin_browser.js
@@ -2,7 +2,7 @@
 require('es6-promise').polyfill()
 require('node-fetch')
 
-const hotkeys = require('hotkeys-js/index.js')
+const hotkeys = require('hotkeys-js')
 
 const errMsgCanvasInit = '描画を行うためには、HTML内にcanvasを配置し、idを振って『描画開始』命令に指定します。'
 
@@ -1200,7 +1200,7 @@ const PluginBrowser = {
           }
         }
       }
-      
+
       if (!sys.__ctx) {throw new Error(errMsgCanvasInit)}
       const drawFunc = (im, ctx) => {
         if (!dxy){
@@ -1521,7 +1521,7 @@ const PluginBrowser = {
     },
     return_none: true
   },
-  
+
   // @ホットキー
   'ホットキー登録': { // @ホットキーKEYにEVENTを登録する // @ほっときーとうろく
     type: 'func',
@@ -1540,7 +1540,7 @@ const PluginBrowser = {
       hotkeys.unbind(key)
     }
   },
-  
+
   // @グラフ描画_CHARTJS
   'グラフ描画': { // @ Chart.jsを利用して、DATAのグラフを描画 // @ぐらふびょうが
     type: 'func',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -82,7 +82,8 @@ module.exports = {
   },
 
   resolve: {
-    extensions: ['*', '.webpack.js', '.web.js', '.js', '.jsx']
+    extensions: ['*', '.webpack.js', '.web.js', '.js', '.jsx'],
+    mainFields: ['browser', 'main', 'module']
   },
 
   optimization: {


### PR DESCRIPTION
Webpackで `require` を解決する際、 `webpack.config.js` の `resolve.mainFields` に記述されている順に `package.json` の項目を見に行き、そこに記述されているファイルを使用するようになっています。
この設定はデフォルトでは以下のようになっています。

```js
    mainFields: ['browser', 'module', 'main'],
```

そして `hotkeys-js` の `package.json` には以下のように記述されています。
https://github.com/jaywcjlove/hotkeys/blob/master/package.json
```json
  "main": "index.js",
  ...
  "module": "dist/hotkeys.esm.js",
```

これらから、 `hotkeys-js` を `require` した場合 `dist/hotkeys.esm.js` がインポートされますが、ESModules形式で記述されているため、そのままではうまく扱うことができません。
したがって、 `resolve.mainFields` の順番を並び替え、CommonJS形式の `index.js` がインポートされるようにします。

参考: https://fringe.co.jp/webpack%E3%81%8C%E3%83%A2%E3%82%B8%E3%83%A5%E3%83%BC%E3%83%AB%E3%81%AEimport%E3%82%92%E8%A7%A3%E6%B1%BA%E3%81%99%E3%82%8B%E4%BB%95%E7%B5%84%E3%81%BF/