### PR TITLE
テストを連続で実行できるようにする #566

### DIFF
--- a/src/wnako3.js
+++ b/src/wnako3.js
@@ -63,6 +63,7 @@ class WebNakoCompiler extends NakoCompiler {
         'mocha.setup("bdd");\n' +
         'mocha.growl();\n'+
         'mocha.checkLeaks();\n' +
+        'mocha.cleanReferencesAfterRun(false);\n' +
         '\n' +
         code + '\n' +
         'mocha.run();// テスト実行\n'
@@ -80,6 +81,9 @@ if (typeof (navigator) === 'object') {
     const isAutoRun = nako3.checkScriptTagParam()
     if (isAutoRun) {nako3.runNakoScript()}
   }, false)
-} else 
+  window.addEventListener('beforeunload', (e) => {
+    mocha.dispose()
+  })
+} else
   {module.exports = WebNakoCompiler}
 


### PR DESCRIPTION
```
Error:Mocha instance is already disposed, cannot start a new test run. Please create a new mocha instance. Be sure to set disable `cleanReferencesAfterRun` when you want to reuse the same mocha instance for multiple test runs.
```

エディタのデフォルト設定では、テスト実行後インスタンスが破棄されるため、再度テストを実行しようとするとエラーになります。
そのため、インスタンスを破棄するタイミングをエディタを閉じるときに変更します。

ref: #566