### PR TITLE
尋ねるをキャンセルした際に空が返るようにする

### DIFF
--- a/src/plugin_browser.js
+++ b/src/plugin_browser.js
@@ -93,9 +93,11 @@ const PluginBrowser = {
   '尋': { // @メッセージSと入力ボックスを出して尋ねる // @たずねる
     type: 'func',
     josi: [['と', 'を']],
-    fn: function (s) {
+    fn: function (s, sys) {
       const r = window.prompt(s)
-      if (r.match(/^[0-9.]+$/)) {return parseFloat(r)}
+      if (!r) {
+        return sys.__v0['空']
+      } else if (r.match(/^[0-9.]+$/)) {return parseFloat(r)}
       return r
     }
   },


### PR DESCRIPTION
`尋ねる` で表示されたプロンプトのキャンセルボタンを押下した際に、 `空` が返るようにします。

<確認手順>

1. 以下のコードを実行
    ```
    「あなたの名前は？」と尋ねる。
    「こんにちは、{それ}さん！」と言う。
    ```
1. プロンプトのキャンセルボタン押下
1. `こんにちは、さん！` と表示される