### PR TITLE
npm-check-updatesアップデートとactions/setup-nodeのダウングレード

### DIFF
--- a/.github/workflows/textlint.yml
+++ b/.github/workflows/textlint.yml
@@ -16,8 +16,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Set up Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2.1.1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1.4.4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
@@ -94,8 +94,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Set up Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2.1.1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1.4.4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "mocha": "^8.0.1",
     "mocha-css": "^1.0.1",
     "nadesiko3-hoge": "0.0.3",
-    "npm-check-updates": "^9.0.1",
+    "npm-check-updates": "^10.2.1",
     "prop-types": "^15.7.2",
     "pump": "^3.0.0",
     "react": "^17.0.1",


### PR DESCRIPTION
npm-check-updatesアップデート ( https://github.com/kujirahand/nadesiko3/pull/642 ) でtextlintのCIが失敗していたので、textlintのCIで使用している `actions/setup-node` を安定版に変更します。