### PR TITLE
タッチイベントの座標がスクロール分ずれるのを修正(fix #634)

### DIFF
--- a/src/plugin_browser.js
+++ b/src/plugin_browser.js
@@ -549,8 +549,8 @@ const PluginBrowser = {
       const ts = []
       for (let i = 0; i < touches.length; i++) {
         const t = touches[i]
-        const tx = t.pageX - box.left
-        const ty = t.pageY - box.top
+        const tx = t.clientX - box.left
+        const ty = t.clientY - box.top
         if (i == 0) {
           sys.__v0['タッチX'] = tx
           sys.__v0['タッチY'] = ty


### PR DESCRIPTION
タッチイベントの座標計算用命令で参照している項目をpageX/YからclientX/Yに変更。