### PR TITLE
babelへの設定が適用されるよう修正。

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,0 +1,14 @@
+{
+  "sourceType": "script",
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "useBuiltIns": "usage",
+        "corejs": 3,
+        "debug": true,
+        "modules": false
+      }
+    ]
+  ]
+}

--- a/editor/.babelrc.json
+++ b/editor/.babelrc.json
@@ -1,0 +1,6 @@
+{
+  "sourceType": "module",
+  "presets": [
+    "@babel/preset-react"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -46,19 +46,6 @@
   "bugs": {
     "url": "https://github.com/kujirahand/nadesiko3/issues"
   },
-  "babel": {
-    "presets": [
-      [
-        "@babel/preset-env",
-        {
-          "useBuiltIns": "usage",
-          "corejs": 3,
-          "debug": true
-        }
-      ],
-      "@babel/preset-react"
-    ]
-  },
   "browserslist": [
     "> 0.5%",
     "> 0.5% in JP",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,28 +60,22 @@ module.exports = {
         test: /\.jsx$/,
         loader: 'babel-loader',
         exclude: /node_modules/,
-        include: [editorPath, srcPath],
-        query: {
-          presets: ['@babel/preset-env', '@babel/preset-react']
-        }
+        include: [editorPath, srcPath]
       },
       // .js file
       {
-        loader: 'babel-loader',
         test: /\.js$/,
+        loader: 'babel-loader',
         exclude: /node_modules/,
-        include: [srcPath],
-        query: {
-          presets: ['@babel/preset-env']
-        }
+        include: [srcPath]
       },
       {
-        loaders: ['style-loader', 'css-loader'],
-        test: /\.css$/
+        test: /\.css$/,
+        use: ['style-loader', 'css-loader']
       },
       {
-        loaders: 'url-loader',
-        test: /\.(jpg|png)$/
+        test: /\.(jpg|png)$/,
+        loader: 'url-loader'
       }
     ]
   },


### PR DESCRIPTION
babel-loaderに直接options(query)を指定すると、ほかの標準的な設定の記載場所を探しに行かなくなるため、webpack.configからオプションを削除。
babelの設定をpackage.jsonから外部ファイル化。その際、reactは全体には不要なので削除。
editor/にのみreactがかかるよう.babelrc.jsonを配置。
webpackの古い記述方法を修正(rule.loaders v5準備)

外部ファイル化したpreset-envの設定は、元のpackage.jsonから引き継いでcodejs:3,debug:trueのまま変更無し（本PRの領域外と判断）
