### PR TITLE
取り込む命令の構造を変更してcnako/wnako対応

### DIFF
--- a/editor/editor_button_component.jsx
+++ b/editor/editor_button_component.jsx
@@ -8,22 +8,22 @@ export default class EditorButtonComponent extends React.Component {
     this.preCode = this.props.preCode + '\n'
   }
 
-  onRunButtonClick () {
+  async onRunButtonClick () {
     try {
       // なでしこの関数をカスタマイズ --- TODO: なでしこの追加命令は edit_main.jsxで書いているので別途関数を作ってそこでまとめるように
       this.props.nako3.setFunc('表示', [['と', 'を', 'の']], this.props.onInformationChanged)
       window.localStorage['nako3/editor/code'] = this.props.code
-      this.props.nako3.run(this.preCode + this.props.code)
+      await this.props.nako3.runAsync(this.preCode + this.props.code)
       this.props.onUsedFuncsChanged(this.props.nako3.usedFuncs)
     } catch (e) {
       this.props.onErrorChanged(e)
     }
   }
 
-  onTestButtonClick () {
+  async onTestButtonClick () {
     try {
       window.localStorage['nako3/editor/code'] = this.props.code
-      this.props.nako3.test(this.preCode + this.props.code)
+      await this.props.nako3.testAsync(this.preCode + this.props.code)
     } catch (e) {
       this.props.onErrorChanged(e)
     }

--- a/src/nako_lexer.js
+++ b/src/nako_lexer.js
@@ -21,36 +21,19 @@ class NakoLexer {
     this.result = []
   }
 
-  // プラグインの取り込みを行う
-  static checkRequire (tokens) {
-    let i = 0
-    while ((i + 2) < tokens.length) {
-      const tNot = tokens[i]
-      const tFile = tokens[i + 1]
-      const tTorikomu = tokens[i + 2]
-      if (tNot.type === 'not' && tTorikomu.value === '取込') {
-        tNot.type = 'require'
-        if (tFile.type === 'string' || tFile.type === 'string_ex')
-          {tFile.type = 'string'}
-         else
-          {throw new Error('[字句解析エラー] 『!「ファイル」を取り込む』の書式で記述してください。')}
-
-        i += 3
-        continue
-      }
-      i++
-    }
-  }
-
   setFuncList (listObj) {
     this.funclist = listObj
   }
 
-  setInput (code, isFirst, line) {
+  setInput (code, line) {
     // 最初に全部を区切ってしまう
     this.tokenize(code, line)
+    return this.result
+  }
+
+  setInput2 (tokens, isFirst) {
+    this.result = tokens
     // 関数の定義があれば funclist を更新
-    NakoLexer.checkRequire(this.result)
     this.preDefineFunc(this.result)
     this.replaceWord(this.result)
 

--- a/src/nako_require_plugin_helper.js
+++ b/src/nako_require_plugin_helper.js
@@ -1,0 +1,71 @@
+class NakoRequirePlugin {
+  constructor (nako3) {
+    this.nako3 = nako3
+  }
+
+  // プラグインの取り込み命令からplugin名のリストを取り出し返す
+  checkAndPickupRequirePlugin (tokens) {
+    let i = 0
+    const pluginlist = []
+    const l = tokens.length
+    while ((i + 2) < l) {
+      const tNot = tokens[i]
+      if (tNot.type === 'not') {
+        const tFile = tokens[i + 1]
+        if (tFile.type === 'string' || tFile.type === 'string_ex') {
+          const t3rd = tokens[i + 2]
+          if (t3rd.value === '取込') {
+            pluginlist.push(tFile.value)
+            tNot.type = 'eol'
+            tFile.type = 'eol'
+            t3rd.type = 'eol'
+            i += 3
+            continue
+          } else
+          if ((i + 3) < l) {
+            const t4th = tokens[i + 3]
+            if (t3rd.value === 'プラグイン' &&
+                t4th.value === '取込') {
+              pluginlist.push(tFile.value)
+              tNot.type = 'eol'
+              tFile.type = 'eol'
+              t3rd.type = 'eol'
+              t4th.type = 'eol'
+              i += 4
+              continue
+            }
+          }
+        }
+      }
+      i++
+    }
+    return pluginlist
+  }
+
+/*
+  // todo:for browser
+  // todo:merge logic from cnako
+  async preImport(nako3, tokens) {
+    const importlist = this.pickupImport( tokens )
+    
+    if (importlist.length > 0) {
+      const pluginpromise = []
+      importlist.forEach(filename => {
+        pluginpromise.push(import(filename));
+      });
+
+      const modules = await Promise.all(pluginpromise)
+      modules.forEach(module => {
+        Object.keys(module).forEach((key) => {
+          console.log('[Plugin]'+key)
+          nako3.addPluginObject(key, module[key])
+          this.result.push(key)
+        })
+      })
+    }
+    return this.result
+  }
+*/
+}
+
+module.exports = NakoRequirePlugin

--- a/src/plugin_kansuji.js
+++ b/src/plugin_kansuji.js
@@ -203,3 +203,7 @@ const 基本漢数字 = "〇一二三四五六七八九".split("")
 
 
 module.exports = PluginKansuji
+
+// scriptタグで取り込んだ時、自動で登録する
+if (typeof (navigator) === 'object')
+  {navigator.nako3.addPluginObject('PluginKansuji', PluginKansuji)}

--- a/src/wnako3.js
+++ b/src/wnako3.js
@@ -1,6 +1,9 @@
 // nadesiko for web browser
 // wnako3.js
+require('node-fetch')
+
 const NakoCompiler = require('./nako3')
+const NakoRequiePlugin = require('./nako_require_plugin_helper')
 const PluginBrowser = require('./plugin_browser')
 const NAKO_SCRIPT_RE = /^(なでしこ|nako|nadesiko)3?$/
 
@@ -8,6 +11,8 @@ class WebNakoCompiler extends NakoCompiler {
   constructor () {
     super()
     this.__varslist[0]['ナデシコ種類'] = 'wnako3'
+    this.beforeParseCallback = this.beforeParse
+    this.requirePlugin = new NakoRequiePlugin(this)
   }
 
   /**
@@ -70,6 +75,60 @@ class WebNakoCompiler extends NakoCompiler {
     }
 
     return code
+  }
+
+  // トークンリストからプラグインのインポートを抜き出して処理する
+  beforeParse (opts) {
+    const tokens = opts.tokens
+    const filelist = this.requirePlugin.checkAndPickupRequirePlugin(tokens)
+    if (filelist.length > 0) {
+      return new Promise((allresolve, allreject) => {
+        const nako3 = opts.nako3
+        const pluginpromise = []
+        filelist.forEach(filename => {
+          pluginpromise.push(new Promise((resolve, reject) => {
+            fetch(filename, { mode: 'no-cors' })
+            .then(res => {
+              if (res.ok) {
+                return res.text()
+              }
+              reject(new Error('fail load plugin'))
+            }).then(txt => {
+              resolve(txt)
+            }).catch(err => {
+              reject(err)
+            })
+          }))
+        })
+
+        Promise.all(pluginpromise).then(modules => {
+          modules.forEach(module => {
+            if (/navigator\.nako3\.addPluginObject/.test(module)) {
+              // for auto registration plugin, exetute only
+              window.eval(module)
+            } else
+            if (/module\.exports\s*=/.test(module)) {
+              // for commonjs structure plugin
+              allreject(new Error('no suppout type plugin(commonjs)'))
+            } else {
+              allreject(new Error('no suppout type plugin(unknown)'))
+            }
+            /*
+            // for module structure plugin, regist each expoted key
+            Object.keys(module).forEach((key) => {
+              console.log('[Plugin]' + key)
+              nako3.addPluginObject(key, module[key])
+            })
+            */
+          })
+          allresolve(tokens)
+        }).catch(err => {
+          allreject(err)
+        })
+        //  throw new Error('no support dynamic import at browser envrionment')
+      })
+    }
+    return tokens
   }
 }
 


### PR DESCRIPTION
付随して、以下を修正
・parseを同基/非同期の二種類に変更。あわせて、compile/run/testも連鎖して二種に。
・kansujiにブラウザ環境での自動addPlugin追加

気になる点
・セキュリティ的にどうか。
・pluginから名前を得る手段がない。exportはdefaultではなくnamedのが良いのか。
・sync/asyncで二重となったmethodがある。asyncに統一したほうがよいか（今までと非互換）
・bundleしたファイルでimportが使える時、変更の予定。
　時期は、
　・nodejs14が最低バージョンになりesmのままcnakoが動くこと。
　・webpack v5かrollupでesm形式のbundleを生成可能なこと。
　・依存しているパッケージがesmからの利用およびbundleが正常にできること
　が達成されたら。
