### PR TITLE
test:bundledの実行テストをrunの非同期動作に対応

### DIFF
--- a/test_bundled/test/bundled_test.js
+++ b/test_bundled/test/bundled_test.js
@@ -41,17 +41,26 @@ describe('bundled test', () => {
         })
         run.dispatchEvent(evt)
 
-        const rsltHead = Array.from(el.querySelectorAll('.edit_head')).find(e => e.textContent === '実行結果:')
-        if (rsltHead) {
-          rslt = rsltHead.parentNode.querySelector('.info')
-          if (rslt) {
-            assert.ok(/こんにちは！\s*<br>\s*9/.test(rslt.innerHTML), 'no cntain "こんにちは！" and "9" in result area')
-          } else {
-            assert.fail('no element result area')
-          }
-        } else {
-          assert.fail('no element result header')
-        }
+        return new Promise((resolve, reject) => {
+          setTimeout(() => {
+            try {
+              const rsltHead = Array.from(el.querySelectorAll('.edit_head')).find(e => e.textContent === '実行結果:')
+              if (rsltHead) {
+                rslt = rsltHead.parentNode.querySelector('.info')
+                if (rslt) {
+                  assert.ok(/こんにちは！\s*<br>\s*9/.test(rslt.innerHTML), 'no cntain "こんにちは！" and "9" in result area')
+                  resolve()
+                } else {
+                  assert.fail('no element result area')
+                }
+              } else {
+                assert.fail('no element result header')
+              }
+            } catch (err) {
+              reject(err)
+            }
+          }, 500)
+        })
       } else {
         assert.fail('no element 実行 button-component class')
       }


### PR DESCRIPTION
実行ボタンのclickイベントが同期実行される前提から、clickイベントのエミュレート後に
500msecの待ち後に、実行結果を確認するよう修正。

下記のissues、
#665 _runAsync()にてなでしこのプログラムが動かないことがある
によりbundled後のファイルでの実行がエラーとなる場合は、test:bundledが
失敗するようになるので、test:bundledを確認に使うことも可能。
