### PR TITLE
usedFuncのためのプラグインで定義された命令名の一覧を動的に保持するよう修正

### DIFF
--- a/src/nako3.js
+++ b/src/nako3.js
@@ -9,7 +9,6 @@ const NakoRuntimeError = require('./nako_runtime_error')
 const PluginSystem = require('./plugin_system')
 const PluginMath = require('./plugin_math')
 const PluginTest = require('./plugin_test')
-const commandList = require('./command_list.json')
 
 const prepare = new Prepare()
 const parser = new Parser()
@@ -32,6 +31,7 @@ class NakoCompiler {
     this.funclist = {} // プラグインで定義された関数
     this.pluginfiles = {} // 取り込んだファイル一覧
     this.isSetter = false // 代入的関数呼び出しを管理(#290)
+    this.commandlist = new Set() // プラグインで定義された定数・変数・関数の名前
     // 必要なオブジェクトを覚えておく
     this.prepare = prepare
     this.lexer = lexer
@@ -244,7 +244,7 @@ class NakoCompiler {
 
   deleteUnNakoFuncs () {
     for (const func of this.usedFuncs) {
-      if (!commandList.includes(func)) {
+      if (!this.commandlist.has(func)) {
         this.usedFuncs.delete(func)
       }
     }
@@ -395,6 +395,9 @@ class NakoCompiler {
         }
       } else {
         throw new Error('プラグインの追加でエラー。', null)
+      }
+      if (key !== '初期化') {
+        this.commandlist.add(key)
       }
     }
   }


### PR DESCRIPTION
src/command_list.jsonから取り込む代わりに、addPluginの際に一覧を動的に生成して利用するよう修正
これにより、取り込んでいないプラグインの命令と同じ名前の命令をユーザが定義した場合でも正しく判断されるようになります。
また、第三者が作成したプラグインの命令に対して利用命令一覧が対応が難しかった問題も解決します。

リポジトリからの、src/command_list.jsonの削除と、その生成部分の削除は含まれていません。