### PR TITLE
nak3.runをevalでローカル変数を参照する方法からFunctionコンストラクタでthisを渡す方法に変更(fix #665)

### DIFF
--- a/src/nako3.js
+++ b/src/nako3.js
@@ -274,13 +274,10 @@ class NakoCompiler {
     this.reset()
     if (isReset) {this.clearLog()}
     let js = this.compile(code, isTest)
-    let __varslist = this.__varslist
-    let __vars = this.__vars = this.__varslist[2] // eslint-disable-line
-    let __self = this.__self // eslint-disable-line
-    let __module = this.__module // eslint-disable-line
     try {
-      __varslist[0].line = -1 // コンパイルエラーを調べるため
-      eval(js) // eslint-disable-line
+      this.__varslist[0].line = -1 // コンパイルエラーを調べるため
+      const func = new Function(js) // eslint-disable-line
+      func.apply(this)
     } catch (e) {
       this.js = js
       if (e instanceof NakoRuntimeError) {
@@ -298,13 +295,10 @@ class NakoCompiler {
     this.reset()
     if (isReset) {this.clearLog()}
     let js = await this.compileAsync(code, isTest)
-    let __varslist = this.__varslist
-    let __vars = this.__vars = this.__varslist[2] // eslint-disable-line
-    let __self = this.__self // eslint-disable-line
-    let __module = this.__module // eslint-disable-line
     try {
-      __varslist[0].line = -1 // コンパイルエラーを調べるため
-      eval(js) // eslint-disable-line
+      this.__varslist[0].line = -1 // コンパイルエラーを調べるため
+      const func = new Function(js) // eslint-disable-line
+      func.apply(this)
     } catch (e) {
       this.js = js
       if (e instanceof NakoRuntimeError) {

--- a/src/nako_gen.js
+++ b/src/nako_gen.js
@@ -166,8 +166,12 @@ class NakoGen {
   getDefFuncCode(isTest) {
     let code = ''
     // よく使う変数のショートカット
+    code += 'const __self = this.__self = this;\n'
+    code += 'const __varslist = this.__varslist;\n'
+    code += 'const __module = this.__module;\n'
     code += 'const __v0 = this.__v0 = this.__varslist[0];\n'
     code += 'const __v1 = this.__v1 = this.__varslist[1];\n'
+    code += 'let __vars = this.__vars;\n'
     // なでしこの関数定義を行う
     let nakoFuncCode = ''
     for (const key in this.nako_func) {


### PR DESCRIPTION
_runでの実行をeval(js)から、new Function(js)＋.apply(this)に変更。
nako_genでのショートカット変数の定義にて、thisからそのほかの変数を展開するよう修正。
付随する効果として、evalによるminify時の変数名の短縮への抑止がなくなりました。
（new Function()はグローバル上に関数を作成するため、「ローカル変数の覗き見」を考慮しなくてよい）