### PR TITLE
Webワーカー用の基本的な機能を追加

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -113,6 +113,7 @@
   <script src="../release/plugin_datetime.js"></script>
   <script src="../release/plugin_turtle.js"></script>
   <script src="../release/plugin_caniuse.js"></script>
+  <script src="../release/plugin_webworker.js"></script>
   <!-- Chart.js -->
   <script defer src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js"></script>
 

--- a/src/plugin_webworker.js
+++ b/src/plugin_webworker.js
@@ -1,0 +1,170 @@
+const PluginWebWorker = {
+  '初期化': {
+    type: 'func',
+    josi: [],
+    fn: function (sys) {
+      sys._webworker = {
+        setNakoHandler: function(work) {
+          work.onmessage = (event) => {
+            const data = event.data || { type: '', data: '' }
+            const type = data.type || ''
+            const value = data.data || ''
+            switch (type) {
+              case 'output':
+                if (work.onoutput) {
+                  work.onoutput.apply(sys, [value, event])
+                }
+                break;
+              case 'data':
+                if (work.ondata) {
+                  work.ondata.apply(sys, [value, event])
+                }
+                break;
+            }
+          }
+        }
+      }
+    }
+  },
+
+  // @イベント用定数
+  '対象イベント': {type:'const', value: ''}, // @たいしょういべんと
+  '受信データ': {type:'const', value: ''}, // @たいしょういべんと
+
+  'ワーカー起動': { // @指定したURLでWebWorkerを起動する。ワーカオブジェクトを返す。 // @わーかーきどう
+    type: 'func',
+    josi: [['で','を','の']],
+    fn: function (url, sys) {
+      return myWorker = new Worker(url)
+    },
+    return_none: false
+  },
+  'NAKOワーカー起動': { // @指定したなでしこ３のWebWorkerを起動する。ワーカオブジェクトを返す。 // @NAKOわーかーきどう
+    type: 'func',
+    josi: [],
+    fn: function (sys) {
+      return myWorker = new Worker('wwnako3.js')
+      if (myWorker) {
+        sys._webworker.setNakoHandler(myWorker)
+      }
+    },
+    return_none: false
+  },
+  'NAKOワーカーハンドラ設定': { // @ワーカーにNAKOワーカーのための設定を行う。 // @NAKOわーかーはんどらせってい
+    type: 'func',
+    josi: [['に','へ','の']],
+    fn: function (work, sys) {
+      sys._webworker.setNakoHandler(work)
+    },
+    return_none: true
+  },
+  'NAKOワーカーデータ返信受信時': { // @無名関数Fでなでしこv3エンジンに対してワーカーメッセージによりデータを受信した時に実行するイベントを設定。『受信データ』に受信したデータ。『対象イベント』にイベント引数。 // @NAKOわーかーでーたへんしんじゅしんしたとき
+    type: 'func',
+    josi: [['で'], ['を', 'の']],
+    fn: function (func, work, sys) {
+      func = sys.__findVar(func, null) // 文字列指定なら関数に変換
+      work.ondata = (data, e) => {
+        sys.__v0['受信データ'] = data
+        sys.__v0['対象イベント'] = e
+        return func(e, sys)
+      }
+    },
+    return_none: true
+  },
+  'NAKOワーカー表示時': { // @無名関数Fでなでしこv3エンジンに対してワーカーメッセージにより表示データを受信した時に実行するイベントを設定。『受信データ』に表示しようとしたデータ。『対象イベント』にイベント引数。 // @NAKOわーかーひょうじしたとき
+    type: 'func',
+    josi: [['で'], ['を', 'の']],
+    fn: function (func, work, sys) {
+      func = sys.__findVar(func, null) // 文字列指定なら関数に変換
+      work.onoutput = (data, e) => {
+        sys.__v0['受信データ'] = data
+        sys.__v0['対象イベント'] = e
+        return func(e, sys)
+      }
+    },
+    return_none: true
+  },
+  'ワーカーメッセージ返信受信時': { // @無名関数Fでworkに対してメッセージを受信した時に実行するイベントを設定。『受信データ』に受信したデータ。『対象イベント』にイベント引数。 // @わーかーめっせーへんしんじじゅしんしたとき
+    type: 'func',
+    josi: [['で'], ['を', 'の']],
+    fn: function (func, work, sys) {
+      func = sys.__findVar(func, null) // 文字列指定なら関数に変換
+      work.onmessage = (e) => {
+        sys.__v0['受信データ'] = e.data
+        sys.__v0['対象イベント'] = e
+        return func(e, sys)
+      }
+    },
+    return_none: true
+  },
+  'NAKOワーカープログラム起動': { // @WORKERに固有の形式でプログラムの転送と実行行う。 // @NAKOぷろぐらむきどう
+    type: 'func',
+    josi: [['に','で'],['を']],
+    fn: function (work, data, sys) {
+      const msg = {
+        type: 'run',
+        data: data
+      }
+      work.postMessage(msg)
+    },
+    return_none: true
+  },
+  'NAKOワーカーリセット': { // @WORKERに固有の形式でプログラムの転送と実行行う。 // @わーかーりせっと
+    type: 'func',
+    josi: [['を']],
+    fn: function (work, sys) {
+      const msg = {
+        type: 'reset',
+        data: ''
+      }
+      work.postMessage(msg)
+    },
+    return_none: true
+  },
+  'ワーカー終了': { // @WORKERを終了する。 // @わーかーしゅうりょう
+    type: 'func',
+    josi: [['を']],
+    fn: function (work, sys) {
+      work.terminate()
+    },
+    return_none: true
+  },
+  'NAKOワーカー終了': { // @WORKERを終了する。 // @NAKOわーかーしゅうりょう
+    type: 'func',
+    josi: [['を']],
+    fn: function (work, sys) {
+      const msg = {
+        type: 'close',
+        data: ''
+      }
+      work.postMessage(msg)
+    },
+    return_none: true
+  },
+  'NAKOワーカーデータ送信': { // @WORKERに固有の形式でデータを送信する。 // @NAKOわーかーでーたそうしん
+    type: 'func',
+    josi: [['に'],['を']],
+    fn: function (work, data, sys) {
+      const msg = {
+        type: 'data',
+        data: data
+      }
+      work.postMessage(msg)
+    },
+    return_none: true
+  },
+  'ワーカーメッセージ送信': { // @WORKERにメッセージを送信する。 // @わーかーめっせーじそうしん
+    type: 'func',
+    josi: [['に'],['を']],
+    fn: function (work, msg, sys) {
+      work.postMessage(msg)
+    },
+    return_none: true
+  }
+}
+
+if (typeof (navigator) === 'object' && typeof (navigator.nako3) === 'object') {
+  navigator.nako3.addPluginObject('PluginWebWorker', PluginWebWorker)
+} else {
+  module.exports = PluginWebWorker
+}

--- a/src/wwnako3.js
+++ b/src/wwnako3.js
@@ -1,0 +1,224 @@
+// nadesiko for web browser worker
+// wwnako3.js
+const NakoCompiler = require('./nako3')
+const NakoRequiePlugin = require('./nako_require_plugin_helper')
+const NakoRequieNako3 = require('./nako_require_nako3_helper')
+const PluginWebWorker = require('./plugin_webworker')
+const NAKO_SCRIPT_RE = /^(なでしこ|nako|nadesiko)3?$/
+
+class WebWorkerNakoCompiler extends NakoCompiler {
+  constructor () {
+    super()
+    this.__varslist[0]['ナデシコ種類'] = 'wwnako3'
+    this.beforeParseCallback = this.beforeParse
+    this.requirePluginHelper = new NakoRequiePlugin(this)
+    this.requireNako3Helper = new NakoRequieNako3(this)
+    this.ondata = (data, event) => {
+    }
+  }
+
+  requireNako3 (tokens, filepath, nako3) {
+    const resolveNako3 = (filename, basepath) => {
+      return filename
+    }
+    const importNako3 = filename => {
+      return new Promise((resolve, reject) => {
+        fetch(filename, { mode: 'no-cors' })
+        .then(res => {
+          if (res.ok) {
+            return res.text()
+          }
+          reject(new Error(`fail load nako3(${filename})`))
+        }).then(txt => {
+          const subtokens = nako3.rawtokenize(txt, 0, filename)
+          resolve(this.requireNako3Helper.affectRequireNako3(subtokens, filename, resolveNako3, importNako3))
+        }).catch(err => {
+          reject(err)
+        })
+      })
+    }
+    return this.requireNako3Helper.affectRequireNako3(tokens, filepath, resolveNako3, importNako3)
+  }
+
+  requirePlugin (tokens, nako3) {
+    const filelist = this.requirePluginHelper.checkAndPickupRequirePlugin(tokens)
+    if (filelist.length > 0) {
+      return new Promise((allresolve, allreject) => {
+        const pluginpromise = []
+        filelist.forEach(filename => {
+          pluginpromise.push(new Promise((resolve, reject) => {
+            fetch(filename, { mode: 'no-cors' })
+            .then(res => {
+              if (res.ok) {
+                return res.text()
+              }
+              reject(new Error(`fail load plugin(${filename})`))
+            }).then(txt => {
+              resolve(txt)
+            }).catch(err => {
+              reject(err)
+            })
+          }))
+        })
+
+        Promise.all(pluginpromise).then(modules => {
+          modules.forEach(module => {
+            if (/navigator\.nako3\.addPluginObject/.test(module)) {
+              // for auto registration plugin, exetute only
+              eval(module)
+            } else
+            if (/module\.exports\s*=/.test(module)) {
+              // for commonjs structure plugin
+              allreject(new Error('no suppout type plugin(commonjs)'))
+            } else {
+              allreject(new Error('no suppout type plugin(unknown)'))
+            }
+            /*
+            // for module structure plugin, regist each expoted key
+            Object.keys(module).forEach((key) => {
+              console.log('[Plugin]' + key)
+              nako3.addPluginObject(key, module[key])
+            })
+            */
+          })
+          allresolve(tokens)
+        }).catch(err => {
+          allreject(err)
+        })
+        //  throw new Error('no support dynamic import at browser envrionment')
+      })
+    }
+    return tokens
+  }
+
+  // トークンリストからプラグインのインポートを抜き出して処理する
+  beforeParse (opts) {
+    const tokens = opts.tokens
+    const nako3 = opts.nako3
+    const filepath = opts.filepath
+
+    this.requireNako3Helper.reset()
+
+    const rslt = this.requireNako3(tokens, filepath, nako3)
+    if (rslt instanceof Promise) {
+      return new Promise((resolve, reject) => {
+        rslt.then(subtokens => {
+          resolve(this.requirePlugin(subtokens, nako3))
+        }).catch(err => {
+          reject(err)
+        })
+      })
+    } else {
+      return this.requirePlugin(rslt, nako3)
+    }
+  }
+}
+
+const PluginWorker = {
+  '初期化': {
+    type: 'func',
+    josi: [],
+    fn: function(sys) {
+    }
+  },
+
+  '対象イベント': {type:'const', value: ''}, // @たいしょういべんと
+  '受信データ': {type:'const', value: ''}, // @たいしょういべんと
+
+  'NAKOワーカーデータ受信時': { // @無名関数Fでなでしこv3エンジンに対してワーカーメッセージによりデータを受信した時に実行するイベントを設定。『受信データ』に受信したデータM。『対象イベント』にイベント引数。 // @NAKOわーかーでーたじゅしんしたとき
+    type: 'func',
+    josi: [['で']],
+    fn: function (func, sys) {
+      func = sys.__findVar(func, null) // 文字列指定なら関数に変換
+      sys.ondata = (data, e) => {
+        sys.__v0['受信データ'] = data
+        sys.__v0['対象イベント'] = e
+        return func(e, sys)
+      }
+    },
+    return_none: true
+  },
+  'ワーカーメッセージ受信時': { // @無名関数Fでselfに対してメッセージを受信した時に実行するイベントを設定。『受信データ』に受信したデータ。『対象イベント』にイベント引数。 // @わーかーめっせーじじゅしんしたとき
+    type: 'func',
+    josi: [['で']],
+    fn: function (func, sys) {
+      func = sys.__findVar(func, null) // 文字列指定なら関数に変換
+      self.onmessage = (e) => {
+        sys.__v0['受信データ'] = e.data
+        sys.__v0['対象イベント'] = e
+        return func(e, sys)
+      }
+    },
+    return_none: true
+  },
+  'NAKOワーカーデータ返信': { // @起動もとに固有の形式でデータを送信する。 // @NAKOわーかーでーたへんしん
+    type: 'func',
+    josi: [['を']],
+    fn: function (data, sys) {
+      const msg = {
+        type: 'data',
+        data: data
+      }
+      postMessage(msg)
+    },
+    return_none: true
+  },
+  'ワーカーメッセージ返信': { // @起動もとにメッセージを送信する。 // @わーかーめっせーじへんしん
+    type: 'func',
+    josi: [['を']],
+    fn: function (msg, sys) {
+      postMessage(msg)
+    },
+    return_none: true
+  },
+  '表示': { // @メインスレッドに固有の形式で表示データを送信する。 // @ひょうじ
+    type: 'func',
+    josi: [['を']],
+    fn: function (data, sys) {
+      const msg = {
+        type: 'output',
+        data: data
+      }
+      postMessage(msg)
+    },
+    return_none: true
+  },
+  '終了': { // @ワーカーを終了する。 // @しゅうりょう
+    type: 'func',
+    josi: [],
+    fn: function (sys) {
+      close()
+    },
+    return_none: true
+  }
+}
+
+// ブラウザワーカーなら navigator.nako3 になでしこを登録
+if (typeof (navigator) === 'object' && self && self instanceof WorkerGlobalScope) {
+  const nako3 = navigator.nako3 = new WebWorkerNakoCompiler()
+  nako3.addPluginObject('PluginWebWorker', PluginWebWorker)
+  nako3.addPluginObject('PluginWorker', PluginWorker)
+
+  self.onmessage = (event) => {
+    const nako3 = navigator.nako3
+    const data = event.data || { type: '', data: '' }
+    const type = data.type || ''
+    const value = data.data || ''
+    switch (type) {
+      case 'reset':
+        nako3.reset()
+        break
+      case 'close':
+        self.close()
+        break
+      case 'run':
+        nako3.run(value)
+        break
+      case 'data':
+        if (nako3.ondata) {
+          nako3.ondata.apply(nako3, [value, event])
+        }
+        break;
+    }
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,12 +32,14 @@ class CanIUseDBDataReplacementPlugin extends NormalModuleReplacementPlugin {
 module.exports = {
   entry: {
     wnako3: [path.join(srcPath, 'wnako3.js')], // plugin_system+plugin_browser含む
+    wwnako3: [path.join(srcPath, 'wwnako3.js')], // plugin_system+plugin_webworker含む
     plugin_kansuji: [path.join(srcPath, 'plugin_kansuji.js')],
     plugin_markup: [path.join(srcPath, 'plugin_markup.js')],
     plugin_turtle: [path.join(srcPath, 'plugin_turtle.js')],
     plugin_csv: [path.join(srcPath, 'plugin_csv.js')],
     plugin_datetime: [path.join(srcPath, 'plugin_datetime.js')],
     plugin_caniuse: [path.join(srcPath, 'plugin_caniuse.js')],
+    plugin_webworker: [path.join(srcPath, 'plugin_webworker.js')],
     editor: [path.join(editorPath, 'edit_main.jsx')],
     version: [path.join(editorPath, 'version_main.jsx')]
   },


### PR DESCRIPTION
WebWorkerは、こんな感じの機能を想像してました。・・・という見本です。
demo/index.htmlにて、pluginの取り込みを追加しているので、run startから試せます。
「NAKOワーカー起動」で、ハンドラ付きで起動できるようにしたいのですが、参照パスの関係でhtmlと同じフォルダにwwnako3.jsが無いとなので、とりあえず、任意のファイルを起動する命令のほうで起動してます。
```
Wは「../release/wwnako3.js」をワーカー起動
WにNAKOワーカーハンドラ設定
WのNAKOワーカーデータ返信受信した時には、
　「受信した：{受信データ}」を表示
　Wをワーカー終了
ここまで
WのNAKOワーカー表示した時には、
　「表示した：{受信データ}」を表示
ここまで

Wで「"かかかかか"を表示する;"おわり"をNAKOワーカーデータ返信」をNAKOワーカープログラム起動
Wに「あいうえお」をNAKOワーカーデータ送信
```
