### PR TITLE
ワーカーのコマンドを修正

### DIFF
--- a/src/plugin_webworker.js
+++ b/src/plugin_webworker.js
@@ -22,31 +22,110 @@ const PluginWebWorker = {
                 break;
             }
           }
+        },
+        inWorker: () => {
+          return typeof WorkerGlobalScope !== "undefined" && self instanceof WorkerGlobalScope
+        },
+        getBaseUrlFromTag: () => {
+          if (!self.document) {return ''}
+          const pluginName = 'plugin_webworker.js'
+          let path = location.pathname
+          if (path.substr(path.length - 1, 1) !== '/') { 
+            const paths = path.split('/')
+            path = paths.slice(paths.length - 1, 1).join('/') & '/'
+          }
+          let scripts = document.querySelectorAll('script')
+          for (let i = 0; i < scripts.length; i++) {
+            let script = scripts[i]
+            let src = script.src || ''
+            let index = src.indexOf(pluginName)
+            if (index >= 0) {
+              if (src.length - index === pluginName.length ||
+                  "?&#".indexOf(src.substr(index + pluginName.length, 1)) >= 0) {
+                src = src.substring(0, index)
+                if (src.substring(0, 1) == '/') {
+                  // スクリプトソースはorigin無しの絶対パス
+                  return location.origin + src
+                }
+                if (/^[a-zA-Z]+:\/\//.test(src)) {
+                  // スクリプトソースは絶対URI
+                  return src
+                }
+                // スクリプトソースはorigin無しの相対パス
+                return location.origin + path + src
+              }
+            }
+          }
+          // スクリプトソースが見つからなかったのでドキュメントのURIを返す
+          return location.origin + path
         }
       }
+      sys.__v0['ワーカーURL'] = sys._webworker.getBaseUrlFromTag()
     }
   },
-
   // @イベント用定数
   '対象イベント': {type:'const', value: ''}, // @たいしょういべんと
   '受信データ': {type:'const', value: ''}, // @たいしょういべんと
+
+  'ワーカーURL': {type:'const', value: ''}, // @わーかーURL
+  'ワーカーURL設定': { // @なでしこv3のファイルのあるURLを設定 // @わーかーURLせってい
+    type: 'func',
+    josi: [['に', 'へ', 'と']],
+    fn: function (url, sys) {
+      if (url && url.substring(url.length - 1) !== '/') {
+        url += '/'
+      }
+      sys.__v0['ワーカーURL'] = url
+    },
+    return_none: true
+  },
 
   'ワーカー起動': { // @指定したURLでWebWorkerを起動する。ワーカオブジェクトを返す。 // @わーかーきどう
     type: 'func',
     josi: [['で','を','の']],
     fn: function (url, sys) {
-      return myWorker = new Worker(url)
+      return new Worker(url)
+    },
+    return_none: false
+  },
+  'ワーカーJS起動': { // @指定したJavascriptのソースでWebWorkerを起動する。ワーカオブジェクトを返す。 // @わーかーJSきどう
+    type: 'func',
+    josi: [['で','を','の']],
+    fn: function (src, sys) {
+      const blob = new Blob([src], {type: 'application/javascript'})
+      const url = URL.createObjectURL(blob)
+      return new Worker(url)
     },
     return_none: false
   },
   'NAKOワーカー起動': { // @指定したなでしこ３のWebWorkerを起動する。ワーカオブジェクトを返す。 // @NAKOわーかーきどう
     type: 'func',
-    josi: [],
-    fn: function (sys) {
-      return myWorker = new Worker('wwnako3.js')
+    josi: [['で']],
+    isVariableJosi: true,
+    fn: function (plugins, sys) {
+      let url
+      if (typeof sys === 'undefined') {sys = plugins; plugins = undefined}
+      if (plugins !== undefined) {
+        if (!plugins instanceof Array) {
+          throw new Error('プラグインはファイル名を配列で指定してください')
+        }
+        const baseurl = sys.__v0["ワーカーURL"]
+        let code = `importScripts('${baseurl}wnako3webworker.js')\n`
+        const l = plugins.length
+        let i
+        for (i = 0;i < l;i++) {
+          code += `importScripts('${baseurl}${plugins[i]}')\n`
+        }
+        const blob = new Blob([code], {type: 'application/javascript'})
+        url = URL.createObjectURL(blob)
+      } else {
+        url = sys.__v0['ワーカーURL'] + 'wnako3webworker.js'
+      }
+      myWorker = new Worker(url)
       if (myWorker) {
         sys._webworker.setNakoHandler(myWorker)
       }
+      return myWorker
     },
     return_none: false
   },
@@ -58,10 +137,12 @@ const PluginWebWorker = {
     },
     return_none: true
   },
-  'NAKOワーカーデータ返信受信時': { // @無名関数Fでなでしこv3エンジンに対してワーカーメッセージによりデータを受信した時に実行するイベントを設定。『受信データ』に受信したデータ。『対象イベント』にイベント引数。 // @NAKOわーかーでーたへんしんじゅしんしたとき
+  'NAKOワーカーデータ受信時': { // @無名関数Fでなでしこv3エンジンに対してワーカーメッセージによりデータを受信した時に実行するイベントを設定。『受信データ』に受信したデータ。『対象イベント』にイベント引数。 // @NAKOわーかーでーたじゅしんしたとき
     type: 'func',
-    josi: [['で'], ['を', 'の']],
+    josi: [['で'], ['から']],
+    isVariableJosi: true,
     fn: function (func, work, sys) {
+      if (typeof sys === 'undefined') {sys = work; work = self}
       func = sys.__findVar(func, null) // 文字列指定なら関数に変換
       work.ondata = (data, e) => {
         sys.__v0['受信データ'] = data
@@ -73,7 +154,7 @@ const PluginWebWorker = {
   },
   'NAKOワーカー表示時': { // @無名関数Fでなでしこv3エンジンに対してワーカーメッセージにより表示データを受信した時に実行するイベントを設定。『受信データ』に表示しようとしたデータ。『対象イベント』にイベント引数。 // @NAKOわーかーひょうじしたとき
     type: 'func',
-    josi: [['で'], ['を', 'の']],
+    josi: [['で'], ['から']],
     fn: function (func, work, sys) {
       func = sys.__findVar(func, null) // 文字列指定なら関数に変換
       work.onoutput = (data, e) => {
@@ -84,10 +165,12 @@ const PluginWebWorker = {
     },
     return_none: true
   },
-  'ワーカーメッセージ返信受信時': { // @無名関数Fでworkに対してメッセージを受信した時に実行するイベントを設定。『受信データ』に受信したデータ。『対象イベント』にイベント引数。 // @わーかーめっせーへんしんじじゅしんしたとき
+  'ワーカーメッセージ受信時': { // @無名関数Fでworkに対してメッセージを受信した時に実行するイベントを設定。『受信データ』に受信したデータ。『対象イベント』にイベント引数。 // @わーかーめっせーじじゅしんしたとき
     type: 'func',
-    josi: [['で'], ['を', 'の']],
+    josi: [['で'], ['から']],
+    isVariableJosi: true,
     fn: function (func, work, sys) {
+      if (typeof sys === 'undefined') {sys = work; work = self}
       func = sys.__findVar(func, null) // 文字列指定なら関数に変換
       work.onmessage = (e) => {
         sys.__v0['受信データ'] = e.data
@@ -97,7 +180,7 @@ const PluginWebWorker = {
     },
     return_none: true
   },
-  'NAKOワーカープログラム起動': { // @WORKERに固有の形式でプログラムの転送と実行行う。 // @NAKOぷろぐらむきどう
+  'NAKOワーカープログラム起動': { // @WORKERに固有の形式でプログラムの転送と実行行う。 // @NAKOわーかーぷろぐらむきどう
     type: 'func',
     josi: [['に','で'],['を']],
     fn: function (work, data, sys) {
@@ -124,7 +207,9 @@ const PluginWebWorker = {
   'ワーカー終了': { // @WORKERを終了する。 // @わーかーしゅうりょう
     type: 'func',
     josi: [['を']],
+    isVariableJosi: true,
     fn: function (work, sys) {
+      if (typeof sys === 'undefined') {sys = work; work = self}
       work.terminate()
     },
     return_none: true
@@ -132,7 +217,12 @@ const PluginWebWorker = {
   'NAKOワーカー終了': { // @WORKERを終了する。 // @NAKOわーかーしゅうりょう
     type: 'func',
     josi: [['を']],
+    isVariableJosi: true,
     fn: function (work, sys) {
+      if (typeof sys === 'undefined') {
+        self.close()
+        return
+      }
       const msg = {
         type: 'close',
         data: ''
@@ -143,8 +233,10 @@ const PluginWebWorker = {
   },
   'NAKOワーカーデータ送信': { // @WORKERに固有の形式でデータを送信する。 // @NAKOわーかーでーたそうしん
     type: 'func',
-    josi: [['に'],['を']],
-    fn: function (work, data, sys) {
+    josi: [['を'], ['に','へ']],
+    isVariableJosi: true,
+    fn: function (data, work, sys) {
+      if (typeof sys === 'undefined') {sys = work; work = self}
       const msg = {
         type: 'data',
         data: data
@@ -155,8 +247,10 @@ const PluginWebWorker = {
   },
   'ワーカーメッセージ送信': { // @WORKERにメッセージを送信する。 // @わーかーめっせーじそうしん
     type: 'func',
-    josi: [['に'],['を']],
-    fn: function (work, msg, sys) {
+    josi: [['を'], ['に','へ']],
+    isVariableJosi: true,
+    fn: function (msg, work, sys) {
+      if (typeof sys === 'undefined') {sys = work; work = self}
       work.postMessage(msg)
     },
     return_none: true

--- a/src/plugin_worker.js
+++ b/src/plugin_worker.js
@@ -3,11 +3,15 @@ const PluginWorker = {
     type: 'func',
     josi: [],
     fn: function(sys) {
+      sys.__v0['SELF'] = self || {}
+      sys.__v0['依頼主'] = self || {}
     }
   },
 
   '対象イベント': {type:'const', value: ''}, // @たいしょういべんと
   '受信データ': {type:'const', value: ''}, // @たいしょういべんと
+  'SELF': {type:'const', value: ''}, // @SELF
+  '依頼主': {type:'const', value: ''}, // @SELF
 
   'NAKOワーカーデータ受信時': { // @無名関数Fでなでしこv3エンジンに対してワーカーメッセージによりデータを受信した時に実行するイベントを設定。『受信データ』に受信したデータM。『対象イベント』にイベント引数。 // @NAKOわーかーでーたじゅしんしたとき
     type: 'func',
@@ -35,7 +39,7 @@ const PluginWorker = {
     },
     return_none: true
   },
-  'NAKOワーカーデータ返信': { // @起動もとに固有の形式でデータを送信する。 // @NAKOわーかーでーたへんしん
+  'NAKOワーカーデータ送信': { // @起動もとに固有の形式でデータを送信する。 // @NAKOわーかーでーたへんしん
     type: 'func',
     josi: [['を']],
     fn: function (data, sys) {
@@ -47,7 +51,7 @@ const PluginWorker = {
     },
     return_none: true
   },
-  'ワーカーメッセージ返信': { // @起動もとにメッセージを送信する。 // @わーかーめっせーじへんしん
+  'ワーカーメッセージ送信': { // @起動もとにメッセージを送信する。 // @わーかーめっせーじへんしん
     type: 'func',
     josi: [['を']],
     fn: function (msg, sys) {

--- a/src/wnako3webworker.js
+++ b/src/wnako3webworker.js
@@ -3,7 +3,6 @@
 const NakoCompiler = require('./nako3')
 const NakoRequire = require('./nako_require_helper')
 const PluginBrowserInWorker = require('./plugin_browser_in_worker')
-const PluginWebWorker = require('./plugin_webworker')
 const PluginWorker = require('./plugin_worker')
 const NAKO_SCRIPT_RE = /^(なでしこ|nako|nadesiko)3?$/
 
@@ -116,7 +115,6 @@ class WebWorkerNakoCompiler extends NakoCompiler {
 if (typeof (navigator) === 'object' && self && self instanceof WorkerGlobalScope) {
   const nako3 = navigator.nako3 = new WebWorkerNakoCompiler()
   nako3.addPluginObject('PluginBrowserInWorker', PluginBrowserInWorker)
-  nako3.addPluginObject('PluginWebWorker', PluginWebWorker)
   nako3.addPluginObject('PluginWorker', PluginWorker)
 
   self.onmessage = (event) => {

--- a/test_browser/karma.config.js
+++ b/test_browser/karma.config.js
@@ -109,13 +109,13 @@ module.exports = function(config) {
   config.set({
     frameworks: ['mocha'],
     files: [
-      {pattern: 'test/wwnako3.js', included: false},
+      {pattern: 'test/wnako3webworker.js', included: false},
       'test/*_test.js',
       'test/html/*.html',
       {pattern: 'test/image/*.png', included: false, served: true, watched: false, nocache: false}
     ],
     proxies: {
-       '/wwnako3.js': '/base/test/wwnako3.js',
+       '/wnako3webworker.js': '/base/test/wnako3webworker.js',
        '/turtle.png': '/base/test/image/turtle_kana.png',
        '/turtle-elephant.png': '/base/test/image/elephant_kana.png',
        '/turtle-panda.png': '/base/test/image/panda_kana.png',
@@ -149,7 +149,7 @@ module.exports = function(config) {
         }
     },
     preprocessors: {
-      'test/wwnako3.js': ['webpack'],
+      'test/wnako3webworker.js': ['webpack'],
       'test/*_test.js': ['webpack'],
       'test/html/*.html': ['html2js']
     },

--- a/test_browser/test/plugin_webworker_test.js
+++ b/test_browser/test/plugin_webworker_test.js
@@ -38,17 +38,17 @@ describe('plugin_webworker_test', () => {
     nako.addFunc('報告', [['を']], (msg) => {
       msgs.push(msg)
     })
-    const code = `Wは「/wwnako3.js」をワーカー起動
+    const code = `Wは「/wnako3webworker.js」をワーカー起動
 WにNAKOワーカーハンドラ設定
-WのNAKOワーカーデータ返信受信した時には、
+WからNAKOワーカーデータ受信した時には、
 　受信データを報告
 　Wをワーカー終了
 ここまで
-WのNAKOワーカー表示した時には、
+WからNAKOワーカー表示した時には、
 　受信データを報告
 ここまで
 
-Wで「"かかかかか"を表示する;"<>?"をHTML変換して表示する;"おわり"をNAKOワーカーデータ返信」をNAKOワーカープログラム起動
+Wで「"かかかかか"を表示する;"<>?"をHTML変換して表示する;"おわり"をNAKOワーカーデータ送信」をNAKOワーカープログラム起動
 Wに「あいうえお」をNAKOワーカーデータ送信
 `
     nako.runReset(code)

--- a/test_browser/test/wnako3webworker.js
+++ b/test_browser/test/wnako3webworker.js
@@ -1,0 +1,1 @@
+import '../../src/wnako3webworker.js'

--- a/test_browser/test/wwnako3.js
+++ b/test_browser/test/wwnako3.js
@@ -1,1 +1,0 @@
-import '../../src/wwnako3.js'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,7 @@ class CanIUseDBDataReplacementPlugin extends NormalModuleReplacementPlugin {
 module.exports = {
   entry: {
     wnako3: [path.join(srcPath, 'wnako3.js')], // plugin_system+plugin_browser含む
-    wwnako3: [path.join(srcPath, 'wwnako3.js')], // plugin_system+plugin_webworker含む
+    wnako3webworker: [path.join(srcPath, 'wnako3webworker.js')], // plugin_system+plugin_browser_in_worker含む
     plugin_kansuji: [path.join(srcPath, 'plugin_kansuji.js')],
     plugin_markup: [path.join(srcPath, 'plugin_markup.js')],
     plugin_turtle: [path.join(srcPath, 'plugin_turtle.js')],


### PR DESCRIPTION
親から子と子から親でコマンド名を同じになるよう修正。
NAKOワーカーの起動の際にpluginを指定できるよう修正。
ワーカーの起動の際、URLではなくjavascriptのソースを指定する命令を追加。