### PR TITLE
ナデシコするの際に環境がクリアされてしまうのを修正

### DIFF
--- a/src/nako3.js
+++ b/src/nako3.js
@@ -154,6 +154,7 @@ class NakoCompiler {
     lexer.setFuncList(this.funclist)
     parser.setFuncList(this.funclist)
     parser.debug = this.debug
+    this.parser.filename = filename
     // 単語に分割
     let rawtokens = this.rawtokenize(code, 0, filename)
     if (this.beforeParseCallback) {
@@ -191,6 +192,7 @@ class NakoCompiler {
     lexer.setFuncList(this.funclist)
     parser.setFuncList(this.funclist)
     parser.debug = this.debug
+    this.parser.filename = filename
     // 単語に分割
     let rawtokens = this.rawtokenize(code, 0, filename)
     if (this.beforeParseCallback) {
@@ -281,9 +283,18 @@ class NakoCompiler {
   }
 
   _run(code, fname, isReset, isTest) {
-    this.reset()
-    if (isReset) {this.clearLog()}
-    let js = this.compile(code, fname, isTest)
+    const opts = {
+      resetLog: isReset,
+      testOnly: isTest
+    }
+    return this._runEx(code, fname, opts)
+  }
+
+  _runEx(code, fname, opts) {
+    opts = Object.assign({ resetEnv: true, resetLog: true, testOnly: false }, opts)
+    if (opts.resetEnv) {this.reset()}
+    if (opts.resetLog) {this.clearLog()}
+    let js = this.compile(code, fname, opts.testOnly)
     try {
       this.__varslist[0].line = -1 // コンパイルエラーを調べるため
       const func = new Function(js) // eslint-disable-line
@@ -302,9 +313,18 @@ class NakoCompiler {
   }
 
   async _runAsync(code, fname, isReset, isTest) {
-    this.reset()
-    if (isReset) {this.clearLog()}
-    let js = await this.compileAsync(code, fname, isTest)
+    const opts = {
+      resetLog: isReset,
+      testOnly: isTest
+    }
+    return this._runExAsync(code, fname, opts)
+  }
+
+  async _runExAsync(code, fname, opts) {
+    opts = Object.assign({ resetEnv: true, resetLog: true, testOnly: false }, opts)
+    if (opts.resetEnv) {this.reset()}
+    if (opts.resetLog) {this.clearLog()}
+    let js = await this.compileAsync(code, fname, opts.testOnly)
     try {
       this.__varslist[0].line = -1 // コンパイルエラーを調べるため
       const func = new Function(js) // eslint-disable-line
@@ -322,34 +342,36 @@ class NakoCompiler {
     return this
   }
 
+  runEx(code, fname, opts) {
+    return this._runEx(code, fname, opts)
+  }
+
+  async runExAsync(code, fname, opts) {
+    return this._runExAsync(code, fname, opts)
+  }
+
   test(code, fname) {
-    this.parser.filename = fname
-    return this._run(code, fname, false, true)
+    return this._runEx(code, fname, { testOnly: true })
   }
 
   run(code, fname) {
-    this.parser.filename = fname
-    return this._run(code, fname, false, false)
+    return this._runEx(code, fname, { resetLog: false })
   }
 
   runReset (code, fname) {
-    this.parser.filename = fname
-    return this._run(code, fname, true, false)
+    return this._runEx(code, fname, { resetLog: true })
   }
 
   async testAsync(code, fname) {
-    this.parser.filename = fname
-    return await this._runAsync(code, fname, false, true)
+    return await this._runExAsync(code, fname, { testOnly: true })
   }
 
   async runAsync(code, fname) {
-    this.parser.filename = fname
-    return await this._runAsync(code, fname, false, false)
+    return await this._runExAsync(code, fname, { resetLog: false })
   }
 
   async runResetAsync (code, fname) {
-    this.parser.filename = fname
-    return await this._runAsync(code, fname, true, false)
+    return await this._runExAsync(code, fname,  { resetLog: true })
   }
 
   clearLog () {

--- a/src/nako_gen.js
+++ b/src/nako_gen.js
@@ -171,7 +171,7 @@ class NakoGen {
     code += 'const __module = this.__module;\n'
     code += 'const __v0 = this.__v0 = this.__varslist[0];\n'
     code += 'const __v1 = this.__v1 = this.__varslist[1];\n'
-    code += 'let __vars = this.__vars;\n'
+    code += 'let __vars = this.__vars = this.__varslist[this.__varslist.length - 1];\n'
     // なでしこの関数定義を行う
     let nakoFuncCode = ''
     for (const key in this.nako_func) {

--- a/src/plugin_system.js
+++ b/src/plugin_system.js
@@ -263,7 +263,7 @@ const PluginSystem = {
     josi: [['を', 'で']],
     fn: function (code, sys) {
       sys.__varslist[0]['表示ログ'] = ''
-      sys.__self.run(code, true)
+      sys.__self.runEx(code, 'immediate-code.nako3', { resetEnv: false, resetLog: true })
       return sys.__varslist[0]['表示ログ']
     }
   },
@@ -271,7 +271,7 @@ const PluginSystem = {
     type: 'func',
     josi: [['を', 'で']],
     fn: function (code, sys) {
-      sys.__self.run(code, false)
+      sys.__self.run(code, 'immediate-code.nako3', { resetEnv: false, resetLog: false })
       return sys.__varslist[0]['表示ログ']
     }
   },
@@ -920,19 +920,20 @@ const PluginSystem = {
       return s.substr(s.length - a, a)
     }
   },
-  'ゼロ埋': { // @数値VをA桁の0で埋める // @ぜろうめ
+  '空白埋': { // @文字列VをA桁の空白で埋める // @くうはくうめ
     type: 'func',
     josi: [['を'], ['で']],
     fn: function (v, a) {
       v = String(v)
-      let z = '0'
-      for (let i = 0; i < a; i++) {z += '0'}
+      let z = ' '
+      for (let i = 0; i < a; i++) {z += ' '}
       a = parseInt(a)
       if (a < v.length) {a = v.length}
       const s = z + String(v)
       return s.substr(s.length - a, a)
     }
   },
+
   // @文字種類
   'かなか判定': { // @文字列Sの1文字目がひらがなか判定 // @かなかはんてい
     type: 'func',

--- a/test/plugin_system_test.js
+++ b/test/plugin_system_test.js
@@ -11,6 +11,13 @@ describe('plugin_system_test', () => {
 
     assert.equal(nako.runReset(code).log, res)
   }
+  const cmpex = (code, exinfo) => {
+    if (nako.debug) {
+      console.log('code=' + code)
+    }
+
+    assert.throws(() => { nako.runReset(code) }, exinfo)
+  }
   const cmd = (code) => {
     if (nako.debug) console.log('code=' + code)
     nako.runReset(code)
@@ -129,6 +136,13 @@ describe('plugin_system_test', () => {
     cmp('10を3でゼロ埋め。表示。', '010')
     cmp('123を5でゼロ埋め。表示。', '00123')
     cmp('12345を3でゼロ埋め。表示。', '12345')
+  })
+  it('空白埋め', () => {
+    cmp('10を3で空白埋め。表示。', ' 10')
+    cmp('「10」を3で空白埋め。表示。', ' 10')
+    cmp('「010」を4で空白埋め。表示。', ' 010')
+    cmp('「123」を5で空白埋め。表示。', '  123')
+    cmp('「12345」を3で空白埋め。表示。', '12345')
   })
   it('配列要素数', () => {
     cmp('A=[0,1,2,3];Aの配列要素数。表示。', '4')
@@ -362,5 +376,14 @@ describe('plugin_system_test', () => {
   it('HYPOTの問題 #603', () => {
     cmp('HYPOT(1,1)を表示。', '1.4142135623730951')
     cmp('HYPOT(10,5)を表示。', '11.180339887498949')
+  })
+  it('ナデシコする', () => {
+    cmp('「1+2を表示する。」をナデシコする。', '3')
+    cmp('Aは3;「1+Aを表示する。」をナデシコする。', '4')
+    cmp('Bは2;「BはB+3。Bを表示する。」をナデシコする。Bを表示する。', '5\n5')
+    cmp('●Cとは\n5を戻す\nここまで\n「1+C()を表示する。」をナデシコする。C()を表示する。', '6\n5')
+    cmp('「Dは4;Dを表示する。」をナデシコする。3+Dを表示する。', '4\n7')
+    cmp('Eは5;「Eは3;Eを表示する。」をナデシコする。5+Eを表示する。', '3\n8')
+    cmpex('「●Fとは\n2を戻す\nここまで\nF()を表示する。」をナデシコする。7+F()を表示する。', { name: 'Error', message: /関数『F』が見当たりません。/ })
   })
 })


### PR DESCRIPTION
nako._run/nako._runAsyncのオプションをoptsにまとめる。
なでしこする・なでしこ続けるのときは、環境をリセットしないよう変更。
なでしこするのテストを追加。
空白埋めを復元。空白埋めのテストを追加。