### PR TITLE
plugin_node_testがたまにタイムアウトするのを修正

### DIFF
--- a/test/plugin_node_test.js
+++ b/test/plugin_node_test.js
@@ -60,7 +60,7 @@ describe('plugin_node_test', () => {
       'S1=「{TMP}/plugin_node_test.js」を読む。\n' +
       'S2=FINを読む。\n' +
       'もし(S1＝S2)ならば、"OK"と表示。\n', 'OK')
-  })
+  }).timeout(3000)
   it('ファイルサイズ取得', () => {
     cmp('「' + testFileMe + '」のファイルサイズ取得;もし、それが2000以上ならば;「OK」と表示。違えば「NG」と表示。', 'OK')
   })


### PR DESCRIPTION
既定が2秒なので3秒を設定。
タイムアウトが伸びるだけなので、普段通り(200msec程度)で終わっている限りは
テストが遅くなることは無い。