### PR TITLE
NAKOワーカー転送の命令とそのテストを追加

### DIFF
--- a/src/plugin_webworker.js
+++ b/src/plugin_webworker.js
@@ -22,6 +22,9 @@ const PluginWebWorker = {
                 break;
             }
           }
+          work.onerror = (event) => {
+            throw new Error(event.message)
+          }
         },
         inWorker: () => {
           return typeof WorkerGlobalScope !== "undefined" && self instanceof WorkerGlobalScope
@@ -121,7 +124,7 @@ const PluginWebWorker = {
       } else {
         url = sys.__v0['ワーカーURL'] + 'wnako3webworker.js'
       }
-      myWorker = new Worker(url)
+      const myWorker = new Worker(url)
       if (myWorker) {
         sys._webworker.setNakoHandler(myWorker)
       }
@@ -252,6 +255,43 @@ const PluginWebWorker = {
     fn: function (msg, work, sys) {
       if (typeof sys === 'undefined') {sys = work; work = self}
       work.postMessage(msg)
+    },
+    return_none: true
+  },
+  'NAKOワーカー転送': { // @WORKERにユーザー定義関数またはユーザ定義のグローバル変数を転送する。 // @NAKOわーかーてんそう
+    type: 'func',
+    josi: [['を'], ['に','へ']],
+    isVariableJosi: true,
+    fn: function (datas, work, sys) {
+      if (typeof sys === 'undefined') {sys = work; work = self}
+      const obj = []
+      if (typeof datas === 'string') {datas = [datas]}
+      datas.forEach(data => {
+        if (typeof sys.__varslist[2][data] !== 'undefined') {
+          obj.push({
+            type: 'val',
+            name: data,
+            content: sys.__varslist[2][data]
+          })
+        } else
+        if (typeof sys.__varslist[1][data] !== 'undefined') {
+          obj.push({
+            type: 'func',
+            name: data,
+            content: {
+              meta: sys.gen.nako_func[data],
+              func: Object.assign({}, sys.funclist[data], { fn: null })
+            }
+          })
+        }
+      })
+      if (obj.length > 0) {
+        const msg = {
+          type: 'trans',
+          data: obj
+        }
+        work.postMessage(msg)
+      }
     },
     return_none: true
   }

--- a/src/wnako3webworker.js
+++ b/src/wnako3webworker.js
@@ -130,7 +130,21 @@ if (typeof (navigator) === 'object' && self && self instanceof WorkerGlobalScope
         self.close()
         break
       case 'run':
-        nako3.run(value)
+        nako3.runEx(value, undefined, {resetEnv: false, resetLog: false})
+        break
+      case 'trans':{
+          const codes = []
+          value.forEach(o => {
+            if (o.type === 'func') {
+              nako3.gen.nako_func[o.name] = o.content.meta
+              nako3.funclist[o.name] = o.content.func
+              nako3.__varslist[1][o.name] = () => {}
+            } else
+            if (o.type === 'val') {
+              nako3.__varslist[2][o.name] = o.content
+            }
+          })
+        }
         break
       case 'data':
         if (nako3.ondata) {

--- a/test_browser/test/plugin_webworker_test.js
+++ b/test_browser/test/plugin_webworker_test.js
@@ -1,5 +1,6 @@
 import { strict as assert } from 'assert'
 import NakoCompiler from '../../src/nako3.js'
+import PluginBrowser from '../../src/plugin_browser'
 import { importStatus } from './import_plugin_checker.js'
 import PluginWebWorker from '../../src/plugin_webworker'
 
@@ -20,6 +21,7 @@ describe('plugin_webworker_test', () => {
     nako = new NakoCompiler()
     // const pluginClone = Object.assign({}, PluginWebWorker)
     // nako.addPluginFile('PluginWebWorker', 'plugin_webworker.js', pluginClone)
+    nako.addPluginFile('PluginBrowser', 'plugin_browser.js', PluginBrowser)
     nako.addPluginFile('PluginWebWorker', 'plugin_webworker.js', PluginWebWorker)
     nako.debug = false
   })
@@ -56,5 +58,42 @@ Wに「あいうえお」をNAKOワーカーデータ送信
     await waitTimer(1)
 
     assert.equal(JSON.stringify(msgs), '["かかかかか","&lt;&gt;?","おわり"]')
+  })
+
+  it('web worker transport', async () => {
+    const msgs = []
+    nako.addFunc('報告', [['を']], (msg) => {
+      msgs.push(msg)
+    })
+    const code = `Wは「/wnako3webworker.js」をワーカー起動
+WにNAKOワーカーハンドラ設定
+WからNAKOワーカーデータ受信した時には、
+　受信データを報告
+　WをNAKOワーカー終了
+ここまで
+WからNAKOワーカー表示した時には、
+　受信データを報告
+ここまで
+
+ワーカー側値は「おわり」
+●ワーカ内処理とは
+　NAKOワーカーデータ受信した時には、
+　　受信データを表示
+　　「<>?」をHTML変換して表示する
+　　ワーカー側値をNAKOワーカーデータ送信
+　ここまで
+ここまで
+
+Wに["ワーカ内処理","ワーカー側値"]をNAKOワーカー転送
+ワーカー側値は「始まり」
+
+Wで「ワーカ内処理する」をNAKOワーカープログラム起動
+Wに「あいうえお」をNAKOワーカーデータ送信
+`
+    nako.runReset(code)
+
+    await waitTimer(1)
+
+    assert.equal(JSON.stringify(msgs), '["あいうえお","&lt;&gt;?","おわり"]')
   })
 })


### PR DESCRIPTION
NAKOワーカー転送の命令を追加
NAKOワーカー転送のテストをtest:browserに追加

コンパイル済みのmetaと実体をワーカーに転送する。
転送できるのは、__varslistの1（ユーザ定義命令)と2(ユーザ定義のグローバル変数)。
（条件として、シリアアライズ可能であること）
メリット
・ワーカーで実行する内容を別ファイルにした読み込んだり、文字列の塊として定義しなくてよい。
・ブラウザ側でコンパイルがかかるため、ブラウザ側でコンパイルエラーが受け取れる。
デメリット
・ワーカー側でしか使用しないpluginをブラウザ側にも読み込む必要がある。
　（ブラウザ側にない機能なら、ブラウザ側は最低限コンパイル可能な定義の枠だけでも可）

nako3storageのような、単一ファイルである必要がある場所でワーカーを使うときは便利。なはず。
