### PR TITLE
C言語風関数の閉じ括弧が無いときTypeErrorが飛ぶ問題の修正

### DIFF
--- a/src/nako_parser3.js
+++ b/src/nako_parser3.js
@@ -413,7 +413,7 @@ class NakoParser extends NakoParserBase {
     return stack.pop()
   }
 
-  yGetArgParen (func) { // C言語風呼び出しでカッコの中を取得
+  yGetArgParen (y) { // C言語風呼び出しでカッコの中を取得
     let isClose = false
     const si = this.stack.length
     while (!this.isEOF()) {
@@ -430,8 +430,8 @@ class NakoParser extends NakoParserBase {
       break
     }
     if (!isClose) {
-      throw new NakoSyntaxError(`C風関数『${func.value}』でカッコが閉じていません`,
-        func.line, this.filename)
+      throw new NakoSyntaxError(`C風関数『${y[0].value}』でカッコが閉じていません`,
+        y[0].line, this.filename)
     }
     const a = []
     while (si < this.stack.length) {

--- a/src/nako_parser_base.js
+++ b/src/nako_parser_base.js
@@ -138,7 +138,7 @@ class NakoParserBase {
       }
       if (typeof type === 'function') {
         const f = type.bind(this)
-        const r = f(null)
+        const r = f(y)
         if (r === null) {return rollback()}
         y[i] = r
         continue


### PR DESCRIPTION
#753 の修正です。fへの引数（常にnull）はyGetArgParen以外誰も使っていなかったため、それ以前のパース結果 y を渡して、次の `['func', 'word']` の部分を `y[0]` で取得するように変更しました。
```javascript
if (this.accept([['func', 'word'], '(', this.yGetArgParen, ')']))
```