### PR TITLE
  エラーメッセージでノードを再帰的に表示する

### DIFF
--- a/src/nako_parser3.js
+++ b/src/nako_parser3.js
@@ -734,10 +734,8 @@ class NakoParser extends NakoParserBase {
     } // end of while
     // 助詞が余ってしまった場合
     if (this.stack.length > 0) {
-      let names = ''
       let line = 0
       this.stack.forEach(n => {
-        names += this.nodeToStr(n)
         line = n.line
       })
       if (this.debug) {
@@ -745,10 +743,15 @@ class NakoParser extends NakoParserBase {
         console.log(JSON.stringify(this.stack, null, 2))
         console.log('peek: ', JSON.stringify(this.peek(), null, 2))
       }
-      let msg = `${names}がありますが使い方が分かりません。`
-      if (names.indexOf('演算子') > 0 || names.match(/^『\d+』$/)) {
-        msg = `${names}がありますが文が解決していません。『代入』や『表示』などと一緒に使ってください。`
+      let msg = `不完全な文です。${this.stack.map((n) => this.nodeToStr(n, 0)).join('、')}が解決していません。`
+
+      // 各ノードについて、更に詳細な情報があるなら表示
+      for (const n of this.stack) {
+        if (this.nodeToStr(n, 0) !== this.nodeToStr(n, 1)) {
+          msg += `${this.nodeToStr(n, 0)}は${this.nodeToStr(n, 1)}として使われています。`
+        }
       }
+
       throw new NakoSyntaxError(msg, line, this.filename)
     }
     return this.popStack([])

--- a/src/nako_parser_base.js
+++ b/src/nako_parser_base.js
@@ -172,11 +172,13 @@ class NakoParserBase {
   }
 
   /**
-   * @param {number} depth 表示する深さ
+   * depth: 表示する深さ
+   * typeName: 先頭のtypeの表示を上書きする場合に設定する
+   * @param {{ depth: number, typeName?: string }} opts
    */
-  nodeToStr (node, depth = 0) {
-    depth--
-
+  nodeToStr (node, opts) {
+    const depth = opts.depth - 1
+    const typeName = (name) => opts.typeName !== undefined ? opts.typeName : name
     const debug = this.debug ? (' debug: ' + JSON.stringify(node, null, 2)) : ''
     if (!node) {
       return `(NULL)`
@@ -184,9 +186,9 @@ class NakoParserBase {
     switch (node.type) {
       case 'not':
         if (depth >= 0) {
-          return `『${this.nodeToStr(node.value, depth)}に演算子『not』を適用した式${debug}』`
+          return `${typeName('')}『${this.nodeToStr(node.value, { depth })}に演算子『not』を適用した式${debug}』`
         } else {
-          return `演算子『not』`
+          return `${typeName('演算子')}『not』`
         }
       case 'op': {
         let operator = node.operator
@@ -195,26 +197,32 @@ class NakoParserBase {
           operator = table[operator]
         }
         if (depth >= 0) {
-          const left = this.nodeToStr(node.left, depth)
-          const right = this.nodeToStr(node.right, depth)
+          const left = this.nodeToStr(node.left, { depth })
+          const right = this.nodeToStr(node.right, { depth })
           if (node.operator == 'eq') {
-            return `『${left}と${right}が等しいかどうかの比較${debug}』`
+            return `${typeName('')}『${left}と${right}が等しいかどうかの比較${debug}』`
           }
-          return `『${left}と${right}に演算子『${operator}』を適用した式${debug}』`
+          return `${typeName('')}『${left}と${right}に演算子『${operator}』を適用した式${debug}』`
         } else {
-          return `演算子『${operator}${debug}』`
+          return `${typeName('演算子')}『${operator}${debug}』`
         }
       } case 'number':
-        return `数値${node.value}`
+        return `${typeName('数値')}${node.value}`
       case 'string':
-        return `文字列『${node.value}${debug}』`
+        return `${typeName('文字列')}『${node.value}${debug}』`
       case 'word':
-        return `単語『${node.value}${debug}』`
+        return `${typeName('単語')}『${node.value}${debug}』`
+      case 'func':
+        return `${typeName('関数')}『${node.value}${debug}}』`
+      case 'eol':
+        return `行の末尾`
+      case 'eol':
+        return `ファイルの末尾`
       default: {
         let name = node.name
         if (!name) {name = node.value}
         if (typeof name !== 'string') {name = node.type}
-        return `『${name}${debug}』`
+        return `${typeName('')}『${name}${debug}』`
       }
     }
   }

--- a/test/error_message_test.js
+++ b/test/error_message_test.js
@@ -1,0 +1,64 @@
+const assert = require('assert')
+const NakoCompiler = require('../src/nako3')
+const NakoSyntaxError = require('../src/nako_syntax_error')
+
+describe('error_message', () => {
+  const nako = new NakoCompiler()
+  // nako.debug = true;
+
+  /**
+   * エラーメッセージがresArrの全ての要素を含むことを確認する。
+   */
+  const cmp = (code, resArr) => {
+    if (nako.debug) {
+      console.log('code=' + code)
+    }
+    assert.throws(
+      () => nako.runReset(code),
+      err => {
+        console.log(err)
+        assert(err instanceof NakoSyntaxError)
+        for (const res of resArr) {
+          if (err.message.indexOf(res) === -1) {
+            throw new Error(`${JSON.stringify(err.message)} が ${JSON.stringify(res)} を含みません。`)
+          }
+        }
+        return true
+      }
+    )
+  }
+  it('比較', () => {
+    cmp('「こんにち」はを表示', [
+      '不完全な文です。',
+      '演算子『＝』が解決していません。',
+      '演算子『＝』は『文字列『こんにち』と単語『を表示』が等しいかどうかの比較』として使われています。',
+    ])
+  })
+  it('単項演算子', () => {
+    cmp('!(はい + 1)', [
+      '不完全な文です。',
+      '演算子『not』が解決していません。',
+      '演算子『not』は『演算子『+』に演算子『not』を適用した式』として使われています。',
+    ])
+  })
+  it('2項演算子', () => {
+    cmp('1 + 2', [
+      '不完全な文です。',
+      '演算子『+』が解決していません。',
+      '演算子『+』は『数値1と数値2に演算子『+』を適用した式』として使われています。',
+    ])
+  })
+  it('変数のみの式', () => {
+    cmp('A', [
+      '不完全な文です。',
+      '単語『A』が解決していません。',
+    ])
+  })
+  it('複数のノードが使われていない場合', () => {
+    cmp('あ「こんにちは」はは表示', [
+      '不完全な文です。',
+      '単語『あ』、演算子『＝』が解決していません。',
+      '演算子『＝』は『文字列『こんにちは』と単語『は表示』が等しいかどうかの比較』として使われています。',
+    ])
+  })
+})

--- a/test/error_message_test.js
+++ b/test/error_message_test.js
@@ -16,7 +16,6 @@ describe('error_message', () => {
     assert.throws(
       () => nako.runReset(code),
       err => {
-        console.log(err)
         assert(err instanceof NakoSyntaxError)
         for (const res of resArr) {
           if (err.message.indexOf(res) === -1) {
@@ -59,6 +58,11 @@ describe('error_message', () => {
       '不完全な文です。',
       '単語『あ』、演算子『＝』が解決していません。',
       '演算子『＝』は『文字列『こんにちは』と単語『は表示』が等しいかどうかの比較』として使われています。',
+    ])
+  })
+  it('関数の宣言でエラー', () => {
+    cmp('●30とは', [
+      '関数30の宣言でエラー。',
     ])
   })
 })


### PR DESCRIPTION
https://github.com/kujirahand/nadesiko3/issues/756 の実装です。

細かいケースに対処していくときりがなかったため、少し冗長なメッセージが表示されます。

nodeToStrの表示形式を変えたせいで不自然なエラーメッセージ（例: `関数数値20の宣言`）が生じたため、2つめのコミットで全てのnodeToStr呼び出し部分を書き換えています。

