### PR TITLE
正確なエラー位置の表示

### DIFF
--- a/src/nako3.js
+++ b/src/nako3.js
@@ -12,7 +12,7 @@ const PluginMath = require('./plugin_math')
 const PluginTest = require('./plugin_test')
 const { SourceMappingOfTokenization, SourceMappingOfIndentSyntax } = require("./nako_source_mapping")
 const { NakoSyntaxError } = require('./nako_parser_base')
-const { LexErrorWithSourceMap } = require('./nako_lex_error')
+const { LexError, LexErrorWithSourceMap } = require('./nako_lex_error')
 const { NakoSyntaxErrorWithSourceMap } = require('./nako_syntax_error')
 
 /**
@@ -163,6 +163,8 @@ class NakoCompiler {
           err.preprocessedCodeEndOffset,
           dest.startOffset,
           dest.endOffset,
+          err.line,
+          filename,
       )
     }
   }

--- a/src/nako3.js
+++ b/src/nako3.js
@@ -2,7 +2,7 @@
  * nadesiko v3
  */
 const Parser = require('./nako_parser3')
-const { LexError, NakoLexer } = require('./nako_lexer')
+const NakoLexer = require('./nako_lexer')
 const Prepare = require('./nako_prepare')
 const NakoGen = require('./nako_gen')
 const NakoRuntimeError = require('./nako_runtime_error')
@@ -12,29 +12,9 @@ const PluginMath = require('./plugin_math')
 const PluginTest = require('./plugin_test')
 const { SourceMappingOfTokenization, SourceMappingOfIndentSyntax } = require("./nako_source_mapping")
 const { NakoSyntaxError } = require('./nako_parser_base')
+const { LexErrorWithSourceMap } = require('./nako_lex_error')
+const { NakoSyntaxErrorWithSourceMap } = require('./nako_syntax_error')
 
-class LexErrorWithSourceMap extends LexError {
-  /**
-   * @param {string} reason
-   * @param {number} preprocessedCodeStartOffset
-   * @param {number} preprocessedCodeEndOffset
-   * @param {number | null} startOffset
-   * @param {number | null} endOffset
-   */
-  constructor(
-      reason,
-      preprocessedCodeStartOffset,
-      preprocessedCodeEndOffset,
-      startOffset,
-      endOffset,
-  ) {
-      super(reason, preprocessedCodeStartOffset, preprocessedCodeEndOffset)
-      /** @readonly */
-      this.startOffset = startOffset
-      /** @readonly */
-      this.endOffset = endOffset
-  }
-}
 /**
  * @typedef {{
  *   type: string;
@@ -54,26 +34,6 @@ class LexErrorWithSourceMap extends LexError {
 const prepare = new Prepare()
 const parser = new Parser()
 const lexer = new NakoLexer()
-
-class NakoSyntaxErrorWithSourceMap extends NakoSyntaxError {
-  /**
-   *@param {TokenWithSourceMap} token
-   *@param {number} startOffset
-   *@param {number} endOffset
-   *@param {NakoSyntaxError} error
-   */
-  constructor(token, startOffset, endOffset, error) {
-      super(error.msg, error.line, error.fname)
-      /** @readonly */
-      this.token = token
-      /** @readonly */
-      this.startOffset = startOffset
-      /** @readonly */
-      this.endOffset = endOffset
-      /** @readonly */
-      this.error = error
-  }
-}
 
 /**
  * 一部のプロパティのみ。

--- a/src/nako3.js
+++ b/src/nako3.js
@@ -209,7 +209,7 @@ class NakoCompiler {
 
   /**
    * 単語の属性を構文解析に先立ち補正する
-   * @param tokens トークンのリスト
+   * @param {TokenWithSourceMap[]} tokens トークンのリスト
    * @param isFirst 最初の呼び出しかどうか
    * @returns コード (なでしこ)
    */

--- a/src/nako_lex_error.js
+++ b/src/nako_lex_error.js
@@ -1,15 +1,23 @@
-
 class LexError extends Error {
   /**
    * @param {string} reason
    * @param {number} preprocessedCodeStartOffset
    * @param {number} preprocessedCodeEndOffset
+   * @param {number | undefined} [line]
+   * @param {string | undefined} [fname]
    */
-  constructor(reason, preprocessedCodeStartOffset, preprocessedCodeEndOffset) {
-    super(`LexError: ${reason}`)
+  constructor(reason, preprocessedCodeStartOffset, preprocessedCodeEndOffset, line, fname) {
+    const fname2 = fname === undefined ? '' : fname
+    const line2 = line === undefined ? '' : `(${line + 1}行目)`
+    const nakoVersion = require('./nako_version')
+    const message = `[字句解析エラー]${fname2}${line2}: ${reason}\n` +
+      `[バージョン] ${nakoVersion.version}`
+    super(message)
     this.reason = reason
     this.preprocessedCodeStartOffset = preprocessedCodeStartOffset
     this.preprocessedCodeEndOffset = preprocessedCodeEndOffset
+    this.line = line
+    this.fname = fname
   }
 }
 
@@ -19,7 +27,9 @@ class LexErrorWithSourceMap extends LexError {
    * @param {number} preprocessedCodeStartOffset
    * @param {number} preprocessedCodeEndOffset
    * @param {number | null} startOffset
-   * @param {number | null} endOffset
+   * @param {number | null} endOffset,
+   * @param {number | undefined} line
+   * @param {string | undefined} filename
    */
   constructor(
     reason,
@@ -27,8 +37,10 @@ class LexErrorWithSourceMap extends LexError {
     preprocessedCodeEndOffset,
     startOffset,
     endOffset,
+    line,
+    filename,
   ) {
-    super(reason, preprocessedCodeStartOffset, preprocessedCodeEndOffset)
+    super(reason, preprocessedCodeStartOffset, preprocessedCodeEndOffset, line, filename)
     /** @readonly */
     this.startOffset = startOffset
     /** @readonly */

--- a/src/nako_lex_error.js
+++ b/src/nako_lex_error.js
@@ -1,0 +1,42 @@
+
+class LexError extends Error {
+  /**
+   * @param {string} reason
+   * @param {number} preprocessedCodeStartOffset
+   * @param {number} preprocessedCodeEndOffset
+   */
+  constructor(reason, preprocessedCodeStartOffset, preprocessedCodeEndOffset) {
+    super(`LexError: ${reason}`)
+    this.reason = reason
+    this.preprocessedCodeStartOffset = preprocessedCodeStartOffset
+    this.preprocessedCodeEndOffset = preprocessedCodeEndOffset
+  }
+}
+
+class LexErrorWithSourceMap extends LexError {
+  /**
+   * @param {string} reason
+   * @param {number} preprocessedCodeStartOffset
+   * @param {number} preprocessedCodeEndOffset
+   * @param {number | null} startOffset
+   * @param {number | null} endOffset
+   */
+  constructor(
+    reason,
+    preprocessedCodeStartOffset,
+    preprocessedCodeEndOffset,
+    startOffset,
+    endOffset,
+  ) {
+    super(reason, preprocessedCodeStartOffset, preprocessedCodeEndOffset)
+    /** @readonly */
+    this.startOffset = startOffset
+    /** @readonly */
+    this.endOffset = endOffset
+  }
+}
+
+module.exports = {
+  LexError,
+  LexErrorWithSourceMap,
+}

--- a/src/nako_lexer.js
+++ b/src/nako_lexer.js
@@ -14,6 +14,8 @@ const josiRE = josi.josiRE
 const lexRules = require('./nako_lex_rules')
 const rules = lexRules.rules
 
+const {LexError} = require('./nako_lex_error')
+
 /**
  * @typedef {import('./nako3').TokenWithSourceMap} TokenWithSourceMap
  * @typedef {{
@@ -28,21 +30,7 @@ const rules = lexRules.rules
  *   meta?: any;
  * }} Token
  */
-
-class LexError extends Error {
-  /**
-   * @param {string} reason
-   * @param {number} preprocessedCodeStartOffset
-   * @param {number} preprocessedCodeEndOffset
-   */
-  constructor(reason, preprocessedCodeStartOffset, preprocessedCodeEndOffset) {
-      super(`LexError: ${reason}`)
-      this.reason = reason
-      this.preprocessedCodeStartOffset = preprocessedCodeStartOffset
-      this.preprocessedCodeEndOffset = preprocessedCodeEndOffset
-  }
-}
-
+ 
 class NakoLexer {
   constructor () {
     this.funclist = {}
@@ -456,7 +444,4 @@ class NakoLexer {
   }
 }
 
-module.exports = {
-  LexError,
-  NakoLexer,
-}
+module.exports = NakoLexer

--- a/src/nako_lexer.js
+++ b/src/nako_lexer.js
@@ -333,9 +333,10 @@ class NakoLexer {
             const list = this.splitStringEx(rp.res)
             if (list === null) {
               throw new LexError(
-                '字句解析エラー(' + (line + 1) + '): 展開あり文字列で値の埋め込み{...}が対応していません。',
+                '展開あり文字列で値の埋め込み{...}が対応していません。',
                 srcLength - src.length,
                 srcLength - rp.src.length,
+                line,
               )
             }
 
@@ -434,9 +435,10 @@ class NakoLexer {
         break
       }
       if (!ok) {
-        throw new LexError('字句解析で未知の語句(' + (line + 1) + '): ' + src.substr(0, 3) + '...',
+        throw new LexError('未知の語句: ' + src.substr(0, 3) + '...',
           srcLength - src.length,
           srcLength - srcLength + 3,
+          line,
         )
       }
     }

--- a/src/nako_parser_base.js
+++ b/src/nako_parser_base.js
@@ -2,7 +2,7 @@
  * なでしこの構文解析のためのユーティリティクラス
  */
 
-const NakoSyntaxError = require('./nako_syntax_error')
+const { NakoSyntaxError } = require('./nako_syntax_error')
 
 class NakoParserBase {
   constructor () {

--- a/src/nako_syntax_error.js
+++ b/src/nako_syntax_error.js
@@ -18,4 +18,27 @@ class NakoSyntaxError extends Error {
   }
 }
 
-module.exports = NakoSyntaxError
+class NakoSyntaxErrorWithSourceMap extends NakoSyntaxError {
+  /**
+   *@param {import('./nako3').TokenWithSourceMap} token
+   *@param {number} startOffset
+   *@param {number} endOffset
+   *@param {NakoSyntaxError} error
+   */
+  constructor(token, startOffset, endOffset, error) {
+      super(error.msg, error.line, error.fname)
+      /** @readonly */
+      this.token = token
+      /** @readonly */
+      this.startOffset = startOffset
+      /** @readonly */
+      this.endOffset = endOffset
+      /** @readonly */
+      this.error = error
+  }
+}
+
+module.exports = {
+  NakoSyntaxError,
+  NakoSyntaxErrorWithSourceMap,
+}

--- a/test/basic_test.js
+++ b/test/basic_test.js
@@ -142,4 +142,23 @@ describe('basic', () => {
       assert.strictEqual(e.endOffset, 8)
     }
   })
+  it('エラー位置の取得 - "_"がある場合', () => {
+    try {
+      nako.runReset(
+        `a = [ _\n` +
+        `    1, 2, 3\n` +
+        `]\n` +
+        `「こんにちは」」と表示する`
+      )
+    } catch (e) {
+      assert(e.message.indexOf('(4行目)') !== -1)
+    }
+  })
+  it('エラー位置の取得 - 字句解析エラーの場合', () => {
+    try {
+      nako.runReset(`\n「こんに{ちは」と表示する`)
+    } catch (e) {
+      assert(e.message.indexOf('[字句解析エラー](2行目): ') !== -1)
+    }
+  })
 })

--- a/test/error_message_test.js
+++ b/test/error_message_test.js
@@ -1,6 +1,6 @@
 const assert = require('assert')
 const NakoCompiler = require('../src/nako3')
-const NakoSyntaxError = require('../src/nako_syntax_error')
+const { NakoSyntaxError } = require('../src/nako_syntax_error')
 
 describe('error_message', () => {
   const nako = new NakoCompiler()


### PR DESCRIPTION
- 1つ目のコミットでは、lexerで、startOffset, endOffset が設定されないトークンが生成される場合がある問題を修正しました。
- 2つ目のコミットでは、LexError と LexErrorWithSourceMap を nako_lex_error.js へ、SyntaxErrorWithSourceMap を nako_syntax_error.js へ移動しました。
- 3つ目のコミットでは、LexErrorのエラーメッセージの形式がSyntaxErrorと一致していない問題を修正しました。`[字句解析エラー]test.nako3(3行目): ... [バージョン] ...` のように表示されます。
- 4つ目のコミットでは、OffsetToLineColumn クラスを追加し、rawtokenizeの段階でトークンのlineとcolumnをoffsetから再計算することで、エラーの行数表示がずれる問題を修正しました。修正前は、次のようなコードのエラー行数が実際より小さくなる問題がありました。

```
a = [ _
    1, _
    1, _
    1, _
    1, _
    1, _
]
「こんにちは」」と表示する
```