### PR TITLE
実行時エラーで行数が表示されない問題の修正

### DIFF
--- a/src/nako3.js
+++ b/src/nako3.js
@@ -67,6 +67,7 @@ class NakoCompiler {
     this.filename = 'inline'
     this.options = {}
     // 環境のリセット
+    /** @type {Record<string, any>[]} */
     this.__varslist = [{}, {}, {}] // このオブジェクトは変更しないこと (this.gen.__varslist と共有する)
     this.__self = this
     this.__vars = this.__varslist[2]
@@ -520,8 +521,9 @@ class NakoCompiler {
         throw e
       } else {
         throw new NakoRuntimeError(
-          e.name + ':' +
-          e.message, this)
+          e,
+          this.__v0 && typeof this.__v0.line === 'number' ? this.__v0.line : undefined,
+        )
       }
     }
     return this
@@ -550,8 +552,9 @@ class NakoCompiler {
         throw e
       } else {
         throw new NakoRuntimeError(
-          e.name + ':' +
-          e.message, this)
+          e,
+          this.__v0 && typeof this.__v0.line === 'number' ? this.__v0.line : undefined,
+        )
       }
     }
     return this
@@ -628,7 +631,11 @@ class NakoCompiler {
           try {
             return v.fn(...args)
           } catch (e) {
-            throw new NakoRuntimeError('関数『' + key + '』:' + e.name + ':' + e.message, this)
+            throw new NakoRuntimeError(
+              e,
+              this.__v0 && typeof this.__v0.line === 'number' ? this.__v0.line : undefined,
+              `関数『${key}』`,
+            )
           }
         }
       } else if (v.type === 'const' || v.type === 'var') {

--- a/src/nako_runtime_error.js
+++ b/src/nako_runtime_error.js
@@ -3,17 +3,30 @@
  * 実行時エラーのためのクラス
  */
 
+const nakoVersion = require("./nako_version")
+
 class NakoRuntimeError extends Error {
-  constructor (msg, env) {
-    const title = '[実行時エラー]'
-    if (env && env.__v0 && env.__v0.line) {
-      const line = env.__v0.line + 1
-      msg = title + '(' + line + ') ' + msg
-      super(msg, line)
-    } else {
-      msg = title + ' ' + msg
-      super(msg)
-    }
+  /**
+   * @param {Error | string} error エラー
+   * @param {number | undefined} line 発生行
+   * @param {string | undefined} [from] 発生箇所
+   */
+  constructor (error, line, from) {
+    const className =
+      (error instanceof Error &&
+       error.constructor !== Error &&
+       error.constructor !== NakoRuntimeError)
+      ? error.constructor.name + ": "
+      : ''
+    const from2 = from === undefined ? '' : `${from}で`
+    const line2 = line === undefined ? '' : `(${line + 1}行目)`
+    const msg = error instanceof Error ? error.message : error + ''
+
+    super(`[実行時エラー]${line2}: ${from2}エラー『${className}${msg}』が発生しました。\n` +
+          `[バージョン] ${nakoVersion.version}`)
+    this.msg = msg
+    this.line = line
+    this.from = from
   }
 }
 

--- a/src/plugin_datetime.js
+++ b/src/plugin_datetime.js
@@ -164,7 +164,10 @@ const PluginDateTime = {
         }
       }
 
-      throw new NakoRuntimeError('『和暦変換』は明治以前の日付には対応していません。')
+      throw new NakoRuntimeError(
+        '『和暦変換』は明治以前の日付には対応していません。',
+        sys.__v0 && typeof sys.__v0.line === 'number' ? sys.__v0.line : undefined,
+      )
     }
   },
   '年数差': { // @日付AとBの差を年数で求めて返す。A<Bなら正の数、そうでないなら負の数を返す (v1非互換)。 // @ねんすうさ

--- a/test/error_message_test.js
+++ b/test/error_message_test.js
@@ -16,7 +16,6 @@ describe('error_message', () => {
     assert.throws(
       () => nako.runReset(code),
       err => {
-        assert(err instanceof NakoSyntaxError)
         for (const res of resArr) {
           if (err.message.indexOf(res) === -1) {
             throw new Error(`${JSON.stringify(err.message)} が ${JSON.stringify(res)} を含みません。`)
@@ -63,6 +62,18 @@ describe('error_message', () => {
   it('関数の宣言でエラー', () => {
     cmp('●30とは', [
       '関数30の宣言でエラー。',
+    ])
+  })
+  it('実行時エラー - 「エラー発生」の場合', () => {
+    cmp(
+      '「エラーメッセージ」のエラー発生', [
+      '関数『エラー発生』でエラー『エラーメッセージ』が発生しました。',
+    ])
+  })
+  it('実行時エラー - 「JS実行」の場合', () => {
+    cmp(
+      '「x.y」をJS実行', [
+      '関数『JS実行』でエラー『ReferenceError: x is not defined』が発生しました'
     ])
   })
 })


### PR DESCRIPTION
以前の実装では、エラーの発生位置が1行目のとき `env && env.__v0 && env.__v0.line` がlineが0なため false になる問題や、`super(msg, line)` の第二引数が完全に無視されている問題がありました。（少なくとも firefox, node.js では無視されています）

それらの修正に加えて、エラーの表示形式を
```
[実行時エラー] 関数『JS実行』:ReferenceError:x is not defined
```
から
```
[実行時エラー](1行目): 関数『JS実行』でエラー『ReferenceError: x is not defined』が発生しました。
[バージョン] 3.1.16
```
の形式へ変更しました。
