### PR TITLE
インデント構文で「ここまで」を使ったらエラーを投げる

### DIFF
--- a/src/nako3.js
+++ b/src/nako3.js
@@ -114,12 +114,13 @@ class NakoCompiler {
    * コードを単語に分割する
    * @param {string} code なでしこのプログラム
    * @param {number} line なでしこのプログラムの行番号
+   * @param {string} filename
    * @returns {TokenWithSourceMap[]} トークンのリスト
    * @throws {LexErrorWithSourceMap}
    */
   rawtokenize (code, line, filename) {
     // インデント構文 (#596)
-    const { code: code2, insertedLines, deletedLines } = NakoIndent.convert(code)
+    const { code: code2, insertedLines, deletedLines } = NakoIndent.convert(code, filename)
 
     // 全角半角の統一処理
     const preprocessed = this.prepare.convert(code2)

--- a/src/nako_indent_error.js
+++ b/src/nako_indent_error.js
@@ -1,0 +1,16 @@
+const nakoVersion = require("./nako_version")
+
+class NakoIndentError extends Error {
+    /**
+     * @param {string} msg
+     * @param {number} line
+     * @param {string} fname
+     */
+    constructor(msg, line, fname) {
+        const fname2 = fname === undefined ? '' : fname
+        super(`[インデントエラー]${fname2}(${line + 1}行目): ${msg}\n` +
+              `[バージョン] ${nakoVersion.version}`)
+    }
+}
+
+module.exports = NakoIndentError

--- a/test/error_message_test.js
+++ b/test/error_message_test.js
@@ -1,6 +1,5 @@
 const assert = require('assert')
 const NakoCompiler = require('../src/nako3')
-const { NakoSyntaxError } = require('../src/nako_syntax_error')
 
 describe('error_message', () => {
   const nako = new NakoCompiler()
@@ -74,6 +73,14 @@ describe('error_message', () => {
     cmp(
       '「x.y」をJS実行', [
       '関数『JS実行』でエラー『ReferenceError: x is not defined』が発生しました'
+    ])
+  })
+  it('インデント構文中に『ここまで』を使用', () => {
+    cmp(
+      '！インデント構文\n' +
+      'もしはいならば\n' +
+      'ここまで\n', [
+      'インデント構文が有効化されているときに『ここまで』を使うことはできません。'
     ])
   })
 })


### PR DESCRIPTION
nako_indent の段階で、「ここまで」を見つけたらエラーを投げます。修正前は、「ここまで」があっても、if文の本体が無いなど一部の場合でコンパイルが通っていました。

それとは関係ないですが、[..ch2] は互換性に自信がなかったため ch2.split('') に変えました。