### PR TITLE
エディタの機能追加

### DIFF
--- a/src/nako_indent.js
+++ b/src/nako_indent.js
@@ -264,6 +264,16 @@ function makeIndent(count) {
 }
 
 /**
+ * インデント部分を取り出す
+ * @param {string} line
+ * @returns {string}
+ */
+function getIndent(line) {
+    //@ts-ignore
+    return /^([ 　・\t]*)/.exec(removeCommentsFromLine(line))[1]
+}
+
+/**
  * インデントの個数を数える
  * @param {string} line 
  */
@@ -398,8 +408,65 @@ function replaceRetMark(src) {
     return result
 }
 
+/**
+ * コードのインデントの構造を取得する。
+ * 空白行や複数行にまたがる構文を考慮する。
+ * インデント構文が有効化されていない場合にも使われる。
+ * @param {string} code
+ */
+function getBlockStructure(code) {
+    /** @type {{ lines: number[], pairs: [number, number][], parents: number[], spaces: string[] }} */
+    const result = {
+        lines: [],  // 各行のインデント量
+        pairs: [],
+        parents: [],  // 各行の親の行
+        spaces: [],  // 各行のインデントの文字列
+    }
+
+    const lines = replaceRetMark(code).split('\n')
+
+    /** @type {number[]} */
+    const stack = []
+    let lineCount = 0
+    let prev = countIndent(lines[0])
+    for (const line of lines) {
+        const numLines = line.split(SpecialRetMark).length
+        const line2 = removeCommentsFromLine(line)
+        const current = (line2.replace(/^\s+/, '').replace(/\s+$/, '') === '')
+            ? prev
+            : countIndent(line2)
+        result.lines.push(...Array(numLines).fill(current))
+        //@ts-ignore
+        result.spaces.push(...Array(numLines).fill(getIndent(line2)))
+
+        if (prev < current) {
+            stack.push(lineCount - 1)
+        } else if (prev > current) {
+            const last = stack.pop()
+            if (last !== undefined) {
+                result.pairs.push([last, lineCount])
+            }
+        }
+
+        const parent = stack[stack.length - 1] !== undefined ? stack[stack.length - 1] : null
+        result.parents.push(...Array(numLines).fill(parent))
+
+        prev = current
+        lineCount += numLines
+    }
+
+    // スタックが余ったらコードの末尾とペアにする。
+    for (const item of stack) {
+        result.pairs.push([item, lineCount])
+    }
+
+    return result
+}
 
 module.exports = {
-    'convert': convert
+    convert,
+    getBlockStructure,
+    getIndent,
+    countIndent,
 }
 

--- a/test/indent_test.js
+++ b/test/indent_test.js
@@ -276,4 +276,52 @@ describe('indent', () => {
             { lineNumber: 13, len: 0 }
         ])
     })
+    it('ブロック構造の取得', () => {
+        assert.deepStrictEqual(
+            NakoIndent.getBlockStructure(
+                'もしはいならば\n' +
+                '    「こん\n' +
+                'にちは」を表示\n' +
+                'ここまで',
+            ),
+            {
+                lines: [0, 4, 4, 0], // 各行の高さは 0, 4, 4, 0
+                pairs: [[0, 3]],     // 0行目と3行目のペアがブロックを構成している。
+                parents: [null, 0, 0, null],
+                spaces: ['', '    ', '    ', '']
+            }
+        )
+    })
+    it('ブロック構造の取得 - 複数行にまたがる構文', () => {
+        // 複数行にまたがる文の2行目以降のインデントは、先頭行のインデントと等しいものとする。
+        // コメントのみの行のインデントは、直近の通常の行のインデントと等しいものとする。
+        assert.deepStrictEqual(
+            NakoIndent.getBlockStructure(
+                '！インデント構文\n' +
+                'Nを1から3まで繰り返す\n' +
+                '    「1行目\n' +
+                '2行目」を表示\n' +
+                '/*範囲コメント\n' +
+                '*/'
+            ),
+            {
+                lines: [0, 0, 4, 4, 4, 4],
+                pairs: [[1, 6]],
+                parents: [null, null, 1, 1, 1, 1],
+                spaces: ['', '', '    ', '    ', '', ''],
+            }
+        )
+    })
+    it('ブロック構造の取得 - 違えば', () => {
+        assert.deepStrictEqual(
+            NakoIndent.getBlockStructure(
+                'もしはいならば\n' +
+                '    a\n' +
+                '違えば\n' +
+                '    b\n' +
+                'ここまで',
+            ).pairs,
+            [[0, 2], [2, 4]],
+        )
+    })
 })


### PR DESCRIPTION
- 左のgutterのボタンを押すことでブロックを折りたためるようになりました。ASTではなくインデントの並びだけを見て動作します。nako_indent.js のコードを利用して、複数行にまたがる構文を認識できるようにしました。
- Ctrl + / で行コメントをトグル可能になりました。
- 「もし〜ならば」のなどの特定の条件で、改行時にインデントを1つ足すようにしました。[この正規表現](https://github.com/kujirahand/nadesiko3/compare/master...yy0931:master#diff-e4ebfef8406cf084f23dd4e9808b34a1c5fc732ab5ce8186e682a7151aa5a40aR539-R541) で判定しています。
