### PR TITLE
変数のスコープのバグの修正

### DIFF
--- a/src/plugin_system.js
+++ b/src/plugin_system.js
@@ -15,7 +15,8 @@ const PluginSystem = {
       // 全ての関数・変数を見つけて返す
       sys.__findVar = function (nameStr, def) {
         if (typeof nameStr === 'function') {return nameStr}
-        for (let i = sys.__varslist.length - 1; i >= 0; i--) {
+        if (sys.__vars[nameStr]) {return sys.__vars[nameStr]}
+        for (let i = 2; i >= 0; i--) {
           let scope = sys.__varslist[i]
           if (scope[nameStr]) {return scope[nameStr]}
         }


### PR DESCRIPTION
変数を参照するときに __varslist[0], [1], [2] とローカル変数のみを探索するように変更しました。

加えて、__varslistに関数呼び出しのたびに値をpushする必要がなくなったため、実行速度を短縮しました。手元での測定ではFIB(33)が9%程度速くなりました。

たとえばこのコードにたいして

```
●（AとBを）足すとは
    A+Bを戻す
ここまで

1と2を足す
```

次のJavaScriptコードを出力します。

```javascript
const __self = this.__self = this;
const __varslist = this.__varslist;
const __module = this.__module;
const __v0 = this.__v0 = this.__varslist[0];
const __v1 = this.__v1 = this.__varslist[1];
let __vars = this.__vars = this.__varslist[2];

__v1["足"] = (function () {
    var __vars_tmp = this.__vars  // 呼び出し元のvarsを保存
    this.__vars = { 'それ': '' };  // sys.findVarから参照するために、現在のローカル変数をthisに入れる必要がある。
    var __vars = this.__vars      // varsをローカル変数で持つことで、__varslistへのpush無しでローカル変数を保存できる。
    try {
        __vars['引数'] = arguments;
        __vars['A'] = arguments[0];
        __vars['B'] = arguments[1];
        return (parseFloat(__vars["A"]) + parseFloat(__vars["B"]));
    } finally {
        this.__vars = __vars_tmp  // 呼び出し元のvarsをthis.__varsに戻す
    }
});

__v0["!PluginSystem:初期化"](__self);
__v0["!PluginMath:初期化"](__self);
__vars["それ"] = '';
(function () {
    const tmp = __vars["それ"] = __varslist[1]["足"](1, 2, __self);
    return tmp;
}).call(this);
```
