### PR TITLE
細かい高速化

### DIFF
--- a/src/nako_gen.js
+++ b/src/nako_gen.js
@@ -900,7 +900,11 @@ class NakoGen {
     if (func.return_none) {
       code = `${funcBegin}${code};${funcEnd}\n`
     } else {
-      code = `(function(){ ${funcBegin}const tmp=${this.sore}=${code}; return tmp;${funcEnd}; }).call(this)`
+      if (funcBegin === '' && funcEnd === '') {
+        code = `(${this.sore}=${code})`
+      } else {
+        code = `(function(){ ${funcBegin}const tmp=${this.sore}=${code}; return tmp;${funcEnd}; }).call(this)`
+      }
       // ...して
       if (node.josi === 'して'){code += ';\n'}
     }

--- a/src/nako_gen.js
+++ b/src/nako_gen.js
@@ -935,8 +935,12 @@ class NakoGen {
     let right = this._convGen(node.right)
     let left = this._convGen(node.left)
     if (NUM_OP_TBL[op]) {
-      left = `parseFloat(${left})`
-      right = `parseFloat(${right})`
+      if (node.left.type !== 'number') {
+        left = `parseFloat(${left})`
+      }
+      if (node.right.type !== 'number') {
+        right = `parseFloat(${right})`
+      }
     }
     // 階乗
     if (op === '^')

--- a/src/nako_gen.js
+++ b/src/nako_gen.js
@@ -932,13 +932,10 @@ class NakoGen {
       'shift_r': '>>',
       'shift_r0': '>>>'
     }
-    const NUM_OP_TBL = { // 数値限定演算子
-      '+': true, '-': true, '*': true, '/': true, '%': true, '^': true
-    }
     let op = node.operator // 演算子
     let right = this._convGen(node.right)
     let left = this._convGen(node.left)
-    if (NUM_OP_TBL[op]) {
+    if (op === '+') {
       if (node.left.type !== 'number') {
         left = `parseFloat(${left})`
       }


### PR DESCRIPTION
- *, /, %, -, pow はすべて両辺に暗黙的にToNumber操作を適用する（仕様: [*, /, %](https://262.ecma-international.org/5.1/#sec-11.5), [-](https://262.ecma-international.org/5.1/#sec-11.6.2), [pow](https://262.ecma-international.org/5.1/#sec-15.8.2)）ため、parseFloatを消しました。たとえば `"20" - "1.3"` を実行すると `18.7` が返ります。

- 2項演算子の [+](https://262.ecma-international.org/5.1/#sec-11.6.1) に数値リテラルが直接渡されたとき、そのノードのparseFloatを省略します。

- 可能な場合、関数呼び出しで `(function(){ const tmp=__vars["それ"]=...; return tmp; }).call(this)` の代わりに `(__vars["それ"]=...)` を出力します。
