### PR TITLE
エディタの機能追加

### DIFF
--- a/demo/ace_editor.html
+++ b/demo/ace_editor.html
@@ -7,6 +7,7 @@
     <title>Nadesiko3 Editor</title>
     <link rel="stylesheet" href="../src/wnako3_editor.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.12/ace.js" integrity="sha512-GZ1RIgZaSc8rnco/8CXfRdCpDxRCphenIiZ2ztLy3XQfCbQUSCuk8IudvNHxkRA3oUg6q0qejgN/qqyG1duv5Q==" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.12/ext-language_tools.min.js" integrity="sha512-8qx1DL/2Wsrrij2TWX5UzvEaYOFVndR7BogdpOyF4ocMfnfkw28qt8ULkXD9Tef0bLvh3TpnSAljDC7uyniEuQ==" crossorigin="anonymous"></script>
     <script src="../release/wnako3.js"></script>
     <script src="../release/version.js"></script>
     <script src="../release/plugin_markup.js"></script>

--- a/demo/ace_editor.html
+++ b/demo/ace_editor.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="../src/wnako3_editor.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.12/ace.js" integrity="sha512-GZ1RIgZaSc8rnco/8CXfRdCpDxRCphenIiZ2ztLy3XQfCbQUSCuk8IudvNHxkRA3oUg6q0qejgN/qqyG1duv5Q==" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.12/ext-language_tools.min.js" integrity="sha512-8qx1DL/2Wsrrij2TWX5UzvEaYOFVndR7BogdpOyF4ocMfnfkw28qt8ULkXD9Tef0bLvh3TpnSAljDC7uyniEuQ==" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.12/ext-options.min.js" integrity="sha512-oHR+WVzBiVZ6njlMVlDDLUIOLRDfUUfRQ55PfkZvgjwuvGqL4ohCTxaahJIxTmtya4jgyk0zmOxDMuLzbfqQDA==" crossorigin="anonymous"></script>
     <script src="../release/wnako3.js"></script>
     <script src="../release/version.js"></script>
     <script src="../release/plugin_markup.js"></script>
@@ -19,7 +20,7 @@
     <script src="../release/plugin_webworker.js"></script>
 
     <!-- mochaを一番最後に読み込む必要がある -->
-    <script src="https://unpkg.com/mocha/mocha.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/mocha/8.3.0/mocha.min.js" integrity="sha512-LA/TpBXau/JNubKzHQhdi5vGkRLyQjs1vpuk2W1nc8WNgf/pCqBplD8MzlzeKJQTZPvkEZi0HqBDfRC2EyLMXw==" crossorigin="anonymous"></script>
 </head>
 <body>
 単純な例

--- a/demo/ace_editor.html
+++ b/demo/ace_editor.html
@@ -64,12 +64,20 @@ readonly
 1のエラー発生
 </div>
     <script>
+// text.repeat(n)
+function repeat(text, n) {
+    var s = ''
+    for (var i = 0; i < n; i++) {
+        s += text
+    }
+    return s
+}
 navigator.nako3.setupEditor("editor1")
 navigator.nako3.setupEditor("editor2")
 navigator.nako3.setupEditor("editor3")
 navigator.nako3.setupEditor("editor4")
 navigator.nako3.setupEditor("editor5")
-navigator.nako3.setupEditor("editor6").editor.setValue("A=1\nB=2\nA+Bを表示\n".repeat(200), -1)
+navigator.nako3.setupEditor("editor6").editor.setValue(repeat("A=1\nB=2\nA+Bを表示\n", 200), -1)
 const editor7 = navigator.nako3.setupEditor("editor7")
 const preCode = 'A=1\n'
 const code = editor7.editor.getValue()

--- a/editor/version_main.jsx
+++ b/editor/version_main.jsx
@@ -3,7 +3,11 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import VersionComponent from './version_component'
 
-// render
-for (const e of document.getElementsByClassName('version-component')) {
-  ReactDOM.render(<VersionComponent/>, e)
+// tryとArray.fromはIE11のため
+try {
+  for (const e of Array.from(document.getElementsByClassName('version-component'))) {
+    ReactDOM.render(<VersionComponent/>, e)
+  }
+} catch (e) {
+  console.error(e)
 }

--- a/src/nako3.js
+++ b/src/nako3.js
@@ -60,6 +60,11 @@ const lexer = new NakoLexer()
  *   endOffset?: unknown
  *   rawJosi?: unknown
  * }} Ast
+ * 
+ * @typedef {(
+ *     | { type: 'func', josi: string[][], pure?: boolean, fn?: Function }
+ *     | { type: 'var' | 'const', value: any}
+ * )} NakoFunction
  */
 
 class NakoCompiler {
@@ -78,7 +83,9 @@ class NakoCompiler {
     this.__locals = {}  // ローカル変数
     this.__self = this
     this.__vars = this.__varslist[2]
+    /** @type {Record<string, Record<string, NakoFunction>>} */
     this.__module = {} // requireなどで取り込んだモジュールの一覧
+    /** @type {Record<string, NakoFunction>} */
     this.funclist = {} // プラグインで定義された関数
     this.pluginfiles = {} // 取り込んだファイル一覧
     this.isSetter = false // 代入的関数呼び出しを管理(#290)

--- a/src/nako3.js
+++ b/src/nako3.js
@@ -227,7 +227,14 @@ class NakoCompiler {
     this.__v1 = this.__varslist[1]
     this.__vars = this.__varslist[2]
     this.__locals = {}
+    const old = this.funclist
+    this.funclist = {}
+    for (const name of Object.keys(this.__v0)) {
+      // プラグイン命令以外を削除
+      this.funclist[name] = old[name]
+    }
     this.gen.reset()
+    this.lexer.setFuncList(this.funclist)
   }
 
   /**

--- a/src/nako_gen.js
+++ b/src/nako_gen.js
@@ -184,6 +184,7 @@ class NakoGen {
     for (const key of /** @type {(keyof NakoGen['speedMode'])[]} */(Object.keys(this.speedMode))) {
       this.speedMode[key] = 0
     }
+    this.funclist = this.__self.funclist
   }
 
   /**

--- a/src/nako_indent.js
+++ b/src/nako_indent.js
@@ -8,19 +8,8 @@ const NakoPrepare = require('./nako_prepare')
  * @returns {{ code: string, insertedLines: number[], deletedLines: { lineNumber: number, len: number }[] }}
  */
 function convert(code, filename) {
-    // プログラム冒頭に「!インデント構文」があれば変換
-    const keywords = ['!インデント構文', '!ここまでだるい']
     // 最初の30行をチェック
-    const lines = code.split('\n', 30)
-    let bConv = false
-    lines.forEach((line) => {
-        const s9 = line.substr(0, 8).replace('！', '!')
-        if (keywords.indexOf(s9) >= 0) {
-            bConv = true
-            return true
-        }
-    })
-    if (bConv) {
+    if (isIndentSyntaxEnabled(code)) {
         return convertGo(code, filename)
     }
     return { code, insertedLines: [], deletedLines: [] }
@@ -29,6 +18,22 @@ function convert(code, filename) {
 // ありえない改行マークを定義
 const SpecialRetMark = '🌟🌟改行🌟🌟s4j#WjcSb😀/FcX3🌟🌟'
 
+/**
+ * @param {string} code
+ * @returns {boolean}
+ */
+function isIndentSyntaxEnabled(code) {
+    // プログラム冒頭に「!インデント構文」があればインデント構文が有効
+    const keywords = ['!インデント構文', '!ここまでだるい']
+    const lines = code.split('\n', 30)
+    for (const line of lines) {
+        const s9 = line.substr(0, 8).replace('！', '!')
+        if (keywords.indexOf(s9) >= 0) {
+            return true
+        }
+    }
+    return false
+}
 
 /**
  * ソースコードのある1行の中のコメントを全て取り除く。
@@ -468,5 +473,6 @@ module.exports = {
     getBlockStructure,
     getIndent,
     countIndent,
+    isIndentSyntaxEnabled,
 }
 

--- a/src/nako_indent.js
+++ b/src/nako_indent.js
@@ -437,7 +437,7 @@ function getBlockStructure(code) {
     for (const line of lines) {
         const numLines = line.split(SpecialRetMark).length
         const line2 = removeCommentsFromLine(line)
-        const current = (line2.replace(/^\s+/, '').replace(/\s+$/, '') === '')
+        const current = (line2.replace(/^[ 　・\t]+/, '') === '')
             ? prev
             : countIndent(line2)
         result.lines.push(...Array(numLines).fill(current))

--- a/src/wnako3_editor.css
+++ b/src/wnako3_editor.css
@@ -87,16 +87,18 @@
 
 /* 設定メニュー */
 #ace_settingsmenu > table {
-    border-spacing: 0 13px; /* 行間を広げる */
+    border-spacing: 0 8px;
+    font-size: 13px;
 }
 #ace_settingsmenu > table td {
-    height: 36px;
+    height: 30px;
 }
 #ace_settingsmenu > table td > div {
     height: 100%;
 }
-#ace_settingsmenu > table button {
+#ace_settingsmenu button, input {
     height: 100%;
+    font-size: 13px;
 }
 #ace_settingsmenu > table tr:last-child {
     display: none; /* なでしこのバージョンと紛らわしいため、aceのバージョン表示を消す */

--- a/src/wnako3_editor.css
+++ b/src/wnako3_editor.css
@@ -1,6 +1,8 @@
 .nako3_editor {
     height: 300px;
 }
+
+/* シンタックスハイライトの色の調整 */
 .nako3_editor .ace_name.ace_function {
     color: #996506;
 }
@@ -19,6 +21,8 @@
 .nako3_editor .ace_variable.ace_language {
     color: #2910D7;
 }
+
+/* エラー位置に付ける赤線 */
 .nako3_editor .marker-red {
     position: absolute;
 }
@@ -33,6 +37,7 @@
     background-position: left bottom;
 }
 
+/* readonlyなときのスタイル */
 .nako3_editor.readonly .ace_active-line {
     background: transparent;
 }
@@ -42,7 +47,15 @@
 .nako3_editor.readonly .ace_cursor {
     opacity: 0;
 }
+
+/* tooltipのスタイルの調整 */
 .nako3_editor .tooltip-plugin-name {
     margin-left: 10px;
     color: gray;
+}
+.ace_tooltip {
+    font-size: 13px;
+    padding-bottom: 6px;
+    padding-right: 10px;
+    opacity: 0.8;
 }

--- a/src/wnako3_editor.css
+++ b/src/wnako3_editor.css
@@ -111,6 +111,9 @@
 .settings-button:active {
     color: rgb(24, 24, 192);
 }
+.nako3_editor.readonly .settings-button {
+    display: none; /* readonlyのときは表示しない。 */
+}
 
 /* 設定メニュー */
 #ace_settingsmenu > table {

--- a/src/wnako3_editor.css
+++ b/src/wnako3_editor.css
@@ -67,22 +67,29 @@
     border: none;
 }
 
-/* 設定を開くボタンのスタイル */
+/* 「設定を開く」ボタンのスタイル */
 .settings-button {
-    position: absolute;
-    bottom: 11px; /* あまり低すぎるとスクロールバーで隠れてしまう。 */
-    right: 5px;
-    font-size: 13px;
-    color: gray;
-    white-space: nowrap;
-    cursor: pointer;
-    user-select: none;
+    /* 画面が狭いと設定メニューを閉じられないため、ボタンを表示しない */
+    display: none;
 }
-.settings-button:hover {
-    color: rgb(90, 90, 255);
-}
-.settings-button:active {
-    color: rgb(24, 24, 192);
+@media (min-width: 600px) {
+    .settings-button {
+        display: block;
+        position: absolute;
+        bottom: 11px; /* あまり低すぎるとスクロールバーで隠れてしまう。 */
+        right: 5px;
+        font-size: 13px;
+        color: gray;
+        white-space: nowrap;
+        cursor: pointer;
+        user-select: none;
+    }
+    .settings-button:hover {
+        color: rgb(90, 90, 255);
+    }
+    .settings-button:active {
+        color: rgb(24, 24, 192);
+    }
 }
 
 /* 設定メニュー */

--- a/src/wnako3_editor.css
+++ b/src/wnako3_editor.css
@@ -77,7 +77,8 @@
         display: block;
         position: absolute;
         bottom: 11px; /* あまり低すぎるとスクロールバーで隠れてしまう。 */
-        right: 5px;
+        right: 20px;
+        text-align: right;
         font-size: 13px;
         color: gray;
         white-space: nowrap;

--- a/src/wnako3_editor.css
+++ b/src/wnako3_editor.css
@@ -59,3 +59,10 @@
     padding-right: 10px;
     opacity: 0.8;
 }
+
+/* スニペットのプレースホルダのスタイル */
+.nako3_editor .ace_snippet-marker {
+    border-radius: 0;
+    background: rgba(0, 75, 255, 0.12);
+    border: none;
+}

--- a/src/wnako3_editor.css
+++ b/src/wnako3_editor.css
@@ -42,3 +42,7 @@
 .nako3_editor.readonly .ace_cursor {
     opacity: 0;
 }
+.nako3_editor .tooltip-plugin-name {
+    margin-left: 10px;
+    color: gray;
+}

--- a/src/wnako3_editor.css
+++ b/src/wnako3_editor.css
@@ -66,3 +66,38 @@
     background: rgba(0, 75, 255, 0.12);
     border: none;
 }
+
+/* 設定を開くボタンのスタイル */
+.settings-button {
+    position: absolute;
+    bottom: 11px; /* あまり低すぎるとスクロールバーで隠れてしまう。 */
+    right: 5px;
+    font-size: 13px;
+    color: gray;
+    white-space: nowrap;
+    cursor: pointer;
+    user-select: none;
+}
+.settings-button:hover {
+    color: rgb(90, 90, 255);
+}
+.settings-button:active {
+    color: rgb(24, 24, 192);
+}
+
+/* 設定メニュー */
+#ace_settingsmenu > table {
+    border-spacing: 0 13px; /* 行間を広げる */
+}
+#ace_settingsmenu > table td {
+    height: 36px;
+}
+#ace_settingsmenu > table td > div {
+    height: 100%;
+}
+#ace_settingsmenu > table button {
+    height: 100%;
+}
+#ace_settingsmenu > table tr:last-child {
+    display: none; /* なでしこのバージョンと紛らわしいため、aceのバージョン表示を消す */
+}

--- a/src/wnako3_editor.css
+++ b/src/wnako3_editor.css
@@ -67,30 +67,49 @@
     border: none;
 }
 
+/* 右下のボタン全体を囲むdiv */
+.button-container {
+    position: absolute;
+    bottom: 11px; /* あまり低すぎるとスクロールバーで隠れてしまう。 */
+    right: 20px;
+    text-align: right;
+    font-size: 13px;
+    cursor: pointer;
+}
+
+/* 処理時間が長いときのメッセージ */
+.slow-speed-message {
+    color: rgb(12, 10, 153);
+    max-width: 75vw;
+    opacity: 0;
+    transition: opacity 0.2s linear;
+}
+.slow-speed-message.visible {
+    opacity: 1;
+    display: inline-block;
+}
+.slow-speed-message > span {
+    display: inline-block;
+}
+
 /* 「設定を開く」ボタンのスタイル */
 .settings-button {
+    color: gray;
     /* 画面が狭いと設定メニューを閉じられないため、ボタンを表示しない */
     display: none;
+    user-select: none;
+    white-space: nowrap;
 }
 @media (min-width: 600px) {
     .settings-button {
-        display: block;
-        position: absolute;
-        bottom: 11px; /* あまり低すぎるとスクロールバーで隠れてしまう。 */
-        right: 20px;
-        text-align: right;
-        font-size: 13px;
-        color: gray;
-        white-space: nowrap;
-        cursor: pointer;
-        user-select: none;
+        display: inline-block;
     }
-    .settings-button:hover {
-        color: rgb(90, 90, 255);
-    }
-    .settings-button:active {
-        color: rgb(24, 24, 192);
-    }
+}
+.settings-button:hover {
+    color: rgb(90, 90, 255);
+}
+.settings-button:active {
+    color: rgb(24, 24, 192);
 }
 
 /* 設定メニュー */

--- a/src/wnako3_editor.js
+++ b/src/wnako3_editor.js
@@ -206,7 +206,6 @@ function tokenize (lines, nako3) {
     // 重要: beforeParseCallbackを無効化しないと、ページを見ただけでシンタックスハイライトのために
     // 取り込み文が実行されてfetchが飛んでしまい、セキュリティ的に危険。
     nako3.reset()
-    nako3.lexer.setFuncList(nako3.funclist)
     const lexerOutput = withoutBeforeParseCallback(nako3, () => nako3.lex(code, 'main.nako3'))
 
     // eol、eof、長さが1未満のトークン、位置を特定できないトークンを消す
@@ -864,7 +863,6 @@ class LanguageFeatures {
             // 現在の行のカーソルより前の部分をlexerにかける。速度を優先して1行だけ処理する。
             try {
                 nako3.reset()
-                nako3.lexer.setFuncList(nako3.funclist)
                 tokens = withoutBeforeParseCallback(nako3, () => nako3.lex(line, 'completion.nako3').tokens)
                     .filter((t) => t.type !== 'eol' && t.type !== 'eof')
             } catch (e) {

--- a/test/wnako3_editor_test.js
+++ b/test/wnako3_editor_test.js
@@ -82,8 +82,7 @@ describe('wnako3_editor_test', () => {
             const token = tokenize('1をF'.split('\n'), nako3)
                 .editorTokens[0]
                 .find((t) => t.value === 'F')
-            assert(!token.docHTML.includes('（Aを）'))
-
+            assert.strictEqual(token.docHTML, null)
         })
     })
     describe('行コメントのトグル', () => {

--- a/test/wnako3_editor_test.js
+++ b/test/wnako3_editor_test.js
@@ -1,67 +1,162 @@
 const assert = require('assert')
-const WebNakoCompiler = require('../src/wnako3')
-const { tokenize, LanguageFeatures } = require('../src/wnako3_editor')
+const NakoCompiler = require('../src/nako3')
+const { tokenize, LanguageFeatures, BackgroundTokenizer } = require('../src/wnako3_editor')
 
 describe('wnako3_editor_test', () => {
-    it('コードを分割する', () => {
-        const tokens = tokenize('A=1\nA+1を表示'.split('\n'), new WebNakoCompiler())
-
-        // 1行目
-        assert.strictEqual(tokens[0][0].value, 'A')
-        assert.strictEqual(tokens[0][1].value, '=')
-        assert.strictEqual(tokens[0][2].value, '1')
-
-        // 2行目
-        assert.strictEqual(tokens[1][0].value, 'A')
-        assert.strictEqual(tokens[1][1].value, '+')
-        assert.strictEqual(tokens[1][2].value, '1を')
-        assert.strictEqual(tokens[1][3].value, '表示')
-    })
-    it('scopeを割り当てる', () => {
-        const tokens = tokenize('A=1\nA+1を表示'.split('\n'), new WebNakoCompiler())
-
-        // 1行目
-        assert(tokens[0][0].type.includes('variable'))
-        assert(tokens[0][1].type.includes('operator'))
-        assert(tokens[0][2].type.includes('numeric'))
-
-        // 2行目
-        assert(tokens[1][0].type.includes('variable'))
-        assert(tokens[1][1].type.includes('operator'))
-        assert(tokens[1][2].type.includes('numeric'))
-        assert(tokens[1][3].type.includes('function'))
-    })
-    const log = []
-    const doc = {
-        lines: [],
-        getLine: (row) => doc.lines[row],
-        insertInLine(position, text) { log.push(['insertInLine', position, text]) },
-        removeInLine(row, columnStart, columnEnd) { log.push(['removeInLine', row, columnStart, columnEnd]) },
+    class AceRange {
+        constructor(startLine, startColumn, endLine, endColumn) {
+            this.startLine = startLine
+            this.startColumn = startColumn
+            this.endLine = endLine
+            this.endColumn = endColumn
+        }
     }
-    it('行コメントのトグル - コメントアウト', () => {
-        log.length = 0
-        doc.lines = ['abc', '']
-        LanguageFeatures.toggleCommentLines('', { doc }, 0, 1)
-        assert.deepStrictEqual(log, [
-            [ 'insertInLine', { row: 0, column: 0 }, '// ' ],
-            [ 'insertInLine', { row: 1, column: 0 }, '// ' ],
-        ])
+    class AceDocument {
+        constructor(text) {
+            this.lines = text.split('\n')
+            this.log = []
+        }
+        getLine(row) { return this.lines[row] }
+        getAllLines() { return [...this.lines] }
+        insertInLine(position, text) { this.log.push(['insertInLine', position, text]) }
+        removeInLine(row, columnStart, columnEnd) { this.log.push(['removeInLine', row, columnStart, columnEnd]) }
+        replace(range, text) { this.log.push(['replace', range, text]) }
+    }
+    
+    describe('シンタックスハイライト', () => {
+        it('コードを分割する', () => {
+            const tokens = tokenize('A=1\nA+1を表示'.split('\n'), new NakoCompiler()).editorTokens
+
+            // 1行目
+            assert.strictEqual(tokens[0][0].value, 'A')
+            assert.strictEqual(tokens[0][1].value, '=')
+            assert.strictEqual(tokens[0][2].value, '1')
+    
+            // 2行目
+            assert.strictEqual(tokens[1][0].value, 'A')
+            assert.strictEqual(tokens[1][1].value, '+')
+            assert.strictEqual(tokens[1][2].value, '1を')
+            assert.strictEqual(tokens[1][3].value, '表示')
+        })
+        it('scopeを割り当てる', () => {
+            const tokens = tokenize('A=1\nA+1を表示'.split('\n'), new NakoCompiler()).editorTokens
+    
+            // 1行目
+            assert(tokens[0][0].type.includes('variable'))
+            assert(tokens[0][1].type.includes('operator'))
+            assert(tokens[0][2].type.includes('numeric'))
+    
+            // 2行目
+            assert(tokens[1][0].type.includes('variable'))
+            assert(tokens[1][1].type.includes('operator'))
+            assert(tokens[1][2].type.includes('numeric'))
+            assert(tokens[1][3].type.includes('function'))
+        })
     })
-    it('行コメントのトグル - アンコメント', () => {
-        log.length = 0
-        doc.lines = ['// abc', '', '※def']
-        LanguageFeatures.toggleCommentLines('', { doc }, 0, 2)
-        assert.deepStrictEqual(log, [
-            [ 'removeInLine', 0, 0, 3 ], // '// ' を削除
-            [ 'removeInLine', 2, 0, 1 ], // '※' を削除
-        ])
+    describe('ドキュメントのホバー', () => {
+        it('プラグイン関数の助詞のドキュメントを表示する', () => {
+            const nako3 = new NakoCompiler()
+            nako3.addPluginObject('PluginEditorTest', {
+                'プラグイン関数テスト': {
+                    type: 'func',
+                    josi: [['を', 'と'], ['に', 'は']],
+                    fn: () => {}
+                }
+            })
+
+            const token = tokenize('XをYにプラグイン関数テスト'.split('\n'), nako3)
+                .editorTokens[0]
+                .find((t) => t.value === 'プラグイン関数テスト')
+            assert(token.docHTML.includes('（Aを|Aと、Bに|Bは）'))
+            assert(token.docHTML.includes('PluginEditorTest'))
+        })
+        it('ユーザー定義関数の助詞のドキュメントを表示する', () => {
+            const token = tokenize('●（Aを）Fとは\nここまで\n1をF'.split('\n'), new NakoCompiler())
+                .editorTokens[2]
+                .find((t) => t.value === 'F')
+            assert(token.docHTML.includes('（Aを）'))
+        })
+        it('前回の実行結果の影響を受けない', () => {
+            const nako3 = new NakoCompiler()
+            tokenize('●（Aを）Fとは\nここまで\n1をF'.split('\n'), nako3)
+            const token = tokenize('1をF'.split('\n'), nako3)
+                .editorTokens[0]
+                .find((t) => t.value === 'F')
+            assert(!token.docHTML.includes('（Aを）'))
+
+        })
     })
-    it('行コメントのトグル - 中黒のある場合', () => {
-        log.length = 0
-        doc.lines = ['・・abc']
-        LanguageFeatures.toggleCommentLines('', { doc }, 0, 0)
-        assert.deepStrictEqual(log, [
-            [ 'insertInLine', { row: 0, column: 2 }, '// ' ], // 'abc' の直前に挿入
-        ])
+    describe('行コメントのトグル', () => {
+        it('コメントアウト', () => {
+            const doc = new AceDocument('abc\n')
+            LanguageFeatures.toggleCommentLines('', { doc }, 0, 1)
+            assert.deepStrictEqual(doc.log, [
+                [ 'insertInLine', { row: 0, column: 0 }, '// ' ],
+                [ 'insertInLine', { row: 1, column: 0 }, '// ' ],
+            ])
+        })
+        it('アンコメント', () => {
+            const doc = new AceDocument('// abc\n\n※def')
+            LanguageFeatures.toggleCommentLines('', { doc }, 0, 2)
+            assert.deepStrictEqual(doc.log, [
+                [ 'removeInLine', 0, 0, 3 ], // '// ' を削除
+                [ 'removeInLine', 2, 0, 1 ], // '※' を削除
+            ])
+        })
+        it('中黒のある場合', () => {
+            const doc = new AceDocument('・・abc')
+            LanguageFeatures.toggleCommentLines('', { doc }, 0, 0)
+            assert.deepStrictEqual(doc.log, [
+                [ 'insertInLine', { row: 0, column: 2 }, '// ' ], // 'abc' の直前に挿入
+            ])
+        })
+    })
+    describe('auto outdent', () => {
+        it('「ここまで」を入力し終わった瞬間に発火する', () => {
+            assert(!LanguageFeatures.checkOutdent('start', '　ここ', 'ま'))
+            assert(LanguageFeatures.checkOutdent('start', '　ここま', 'で'))
+            assert(!LanguageFeatures.checkOutdent('start', '　ここまで', '\n'))
+
+            assert(!LanguageFeatures.checkOutdent('start', '・ここ', 'ま'))
+            assert(LanguageFeatures.checkOutdent('start', '・ここま', 'で'))
+            assert(!LanguageFeatures.checkOutdent('start', '・ここまで', '\n'))
+        })
+        it('1つ前の行がブロックの開始行なら、その行に合わせる', () => {
+            const doc = new AceDocument('    もしはいならば\n        ここまで')
+            // 2行目にauto outdentを実行
+            new LanguageFeatures(AceRange, new NakoCompiler()).autoOutdent('start', { doc }, 1)
+            // 2行目の0-8文字目が '    ' で置換される
+            assert.deepStrictEqual(doc.log, [[ 'replace', new AceRange(1, 0, 1, 8), '    ']])
+        })
+        it('1つ前の行がブロックの開始行でなければ、1段階インデントを下げる', () => {
+            const doc = new AceDocument('もしはいならば\n    もしはいならば\n        1を表示\n        ここまで')
+            // 4行目にauto outdentを実行
+            new LanguageFeatures(AceRange, new NakoCompiler()).autoOutdent('start', { doc }, 3)
+            // 2行目の0-8文字目が '    ' で置換される
+            assert.deepStrictEqual(doc.log, [[ 'replace', new AceRange(3, 0, 3, 8), '    ']])
+        })
+    })
+    describe('auto indent', () => {
+        it('0列目の場合', () => {
+            // 1段階インデントする
+            assert.strictEqual(
+                LanguageFeatures.getNextLineIndent('start', 'もしはいならば', '    '),
+                '    ',
+            )
+        })
+        it('4列目の場合', () => {
+            // 1段階インデントする
+            assert.strictEqual(
+                LanguageFeatures.getNextLineIndent('start', '    もしはいならば', '    '),
+                '        ',
+            )
+        })
+        it('ブロックの開始行ではない場合', () => {
+            // 1つ前の行と同じインデント幅を返す
+            assert.strictEqual(
+                LanguageFeatures.getNextLineIndent('start', '    もしはい', '    '),
+                '    ',
+            )
+        })
     })
 })


### PR DESCRIPTION
オートコンプリートと、設定メニューを開くボタンの実装です。
動作確認用のリンク: https://yy0931.github.io/nadesiko3-ace/

- オートコンプリートには ace/ext/language_tools.js、設定メニューには ace/ext/options.js を利用していて、それぞれscriptタグの追加が必要です。

- オートコンプリートはCtrl+Enterを打つか、漢字やカタカナを打つと起動します。スマートフォンでも表示されますが、選択すると変換中の文字列が消えてしまう場合があります。ただ邪魔にはならなそうです。直すにはace editorの実装を確認する必要があります。

- エディタの右下のボタンをクリックすると設定メニューが開きます。これはF1キーを押して `show settings menu` を打つと表示されるメニューを日本語化して項目を編集したものです。スマートフォンだとメニューを閉じられなかったため、ページ幅が狭いときは表示しません。

- スニペットも追加しました。日本語では挙動が微妙だったため英語からの変換のみです。エディタで `if` や `switch` などを入力してタブorエンターキーを押すとプレースホルダ付きで構文が展開され、その状態からタブキーを押すとカーソルが順にプレースホルダーを移動していきます。

- シンタックスハイライトの処理に220msより長くかかったときに自動的にシンタックスハイライトを無効化し、無効化した旨のメッセージを8秒間表示するようにしました。コードをコピーして数千行入力すると確認できると思います。PCであれば設定メニューから再度有効化できます。

- 同じNakoCompilerのインスタンスで複数回コンパイルを実行すると、reset() していても前回の実行時に存在したユーザー定義の関数がfunclistに残ってしまい、オートコンプリートがうまくいかない問題があったため、nako3.js のresetでfunclistから__v0に存在しない関数を消しています。問題の起こるコードの例:

1回目の実行:
```
●Fとは
    1を表示
ここまで
```

2回目の実行:
```
Fを表示  # 「関数Fは存在しません。」と表示される。一方で、FではなくAにするとundefinedが表示される。
```
