### PR TITLE
エディタのリサイズと全画面化

### DIFF
--- a/demo/ace_editor.html
+++ b/demo/ace_editor.html
@@ -55,6 +55,8 @@ readonly
 <div id="editor5" data-nako3-disable-marker="true">
 「{」を表示
 </div>
+エディタのリサイズ
+<div id="editor8" data-nako3-resizable="true"></div>
 <br>
 長いプログラム
 <div id="editor6"></div>
@@ -86,7 +88,7 @@ try {
 } catch (e) {
     editor7.editorMarkers.addByError(code, e)
 }
-
+navigator.nako3.setupEditor("editor8").editor.setValue(repeat("A=1\nB=2\nA+Bを表示\n", 30), -1)
     </script>
 </body>
 </html>

--- a/demo/ace_editor_tabs.html
+++ b/demo/ace_editor_tabs.html
@@ -46,7 +46,7 @@
     <button id="remove">🗑 ファイルを削除</button>
     <span id="file-list"></span>
 </div>
-<div id="editor" class="nako3_editor"></div>
+<div id="editor" class="nako3_editor" data-nako3-resizable="true"></div>
 <div class="toolbar">
     <button id="run">表示中のファイルを実行</button>
 </div>

--- a/src/wnako3_editor.css
+++ b/src/wnako3_editor.css
@@ -111,11 +111,12 @@
 }
 
 /* 「設定を開く」ボタンのスタイル */
-.settings-button {
+.editor-button {
     color: gray;
     display: inline-block;
     user-select: none;
     white-space: nowrap;
+    margin-left: 10px;
 }
 .nako3_editor.ace-monokai .settings-button {
     color: rgb(218, 218, 218);
@@ -125,10 +126,10 @@
     max-width: 60%;
 }
 
-.settings-button:hover {
+.editor-button:hover {
     color: rgb(90, 90, 255);
 }
-.settings-button:active {
+.editor-button:active {
     color: rgb(24, 24, 192);
 }
 .nako3_editor.ace-monokai .settings-button:hover {
@@ -137,8 +138,17 @@
 .nako3_editor.ace-monokai .settings-button:active {
     color: rgb(182, 182, 255);
 }
-.nako3_editor.readonly .settings-button {
+.nako3_editor.readonly .editor-button {
     display: none; /* readonlyのときは表示しない。 */
+}
+.nako3_editor.fullscreen {
+    position: fixed;
+    resize: none; /* .resizable で指定する resize: vertical を無効化 */
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100% !important; /* !important が無いと、resize: vertical によるリサイズで上書きされてしまう。 */
+    z-index: 1000; /* ace editor のポップアップのz-indexは200000 */
 }
 
 /* 設定メニュー */

--- a/src/wnako3_editor.css
+++ b/src/wnako3_editor.css
@@ -1,6 +1,12 @@
 .nako3_editor {
     height: 300px;
 }
+.nako3_editor.resizable {
+    resize: vertical;
+    overflow: auto;
+    min-height: 42px;
+    max-height: 1080px;
+}
 
 /* シンタックスハイライトの色の調整 */
 .nako3_editor.ace-xcode .ace_name.ace_function {

--- a/src/wnako3_editor.js
+++ b/src/wnako3_editor.js
@@ -1399,11 +1399,31 @@ function setupEditor (id, nako3, ace, defaultFileName = 'main.nako3') {
     slowSpeedMessage.innerHTML = '<span>エディタの|応答速度が|低下したため|シンタックス|ハイライトを|無効化|しました。</span>'.replace(/\|/g, '</span><span>')
     buttonContainer.appendChild(slowSpeedMessage)
 
+    // 「全画面表示」ボタン
+    const exitFullscreen = () => {
+        editor.container.classList.remove('fullscreen')
+        editor.renderer.setScrollMargin(0, 0, 0, 0) // marginを元に戻す
+    }
+    const fullscreenButton = document.createElement('span')
+    fullscreenButton.classList.add('editor-button')
+    fullscreenButton.innerText = '全画面表示'
+    fullscreenButton.addEventListener('click', (e) => {
+        if (editor.container.classList.contains('fullscreen')) {
+            exitFullscreen()
+        } else {
+            editor.container.classList.add('fullscreen')
+            editor.renderer.setScrollMargin(20, 20, 0, 0) // 上下に少し隙間を開ける
+        }
+        e.preventDefault()
+    })
+    buttonContainer.appendChild(fullscreenButton)
+
     // 「設定を開く」ボタン
     const settingsButton = document.createElement('span')
-    settingsButton.classList.add('settings-button')
+    settingsButton.classList.add('editor-button')
     settingsButton.innerText = '設定を開く'
     settingsButton.addEventListener('click', (e) => {
+        exitFullscreen()
         editor.execCommand("showSettingsMenu")
         e.preventDefault()
     })

--- a/src/wnako3_editor.js
+++ b/src/wnako3_editor.js
@@ -1192,6 +1192,7 @@ let editorIdCounter = 0
  * - wnako3_editor.css を読み込む必要がある。
  * - readonly にするには data-nako3-readonly="true" を設定する。
  * - エラー位置の表示を無効化するには data-nako3-disable-marker="true" を設定する。
+ * - 縦方向にリサイズ可能にするには nako3-resizable="true" を設定する。
  * 
  * @param {string} id HTML要素のid
  * @param {NakoCompiler} nako3
@@ -1411,6 +1412,14 @@ function setupEditor (id, nako3, ace, defaultFileName = 'main.nako3') {
     // 複数ファイルの切り替え
     const UndoManager = ace.require('ace/undomanager').UndoManager
     const editorTabs = new EditorTabs(editor, AceRange, UndoManager)
+
+    // リサイズ可能にする
+    const resizable = element.dataset.nako3Resizable
+    if (resizable) {
+        new MutationObserver(() => { editor.resize() }).observe(editor.container, { attributes: true })
+        editor.renderer.setScrollMargin(4, 0, 4, 0)
+        editor.container.classList.add('resizable')
+    }
 
     return { editor, editorMarkers, editorTabs }
 }


### PR DESCRIPTION
エディタのHTMLタグに `data-nako3-resizable="true"` を付けると上下にリサイズ可能になります。
エディタ上の「全画面表示」ボタンを押すと全画面表示になります。requestFullscreenではace editorのポップアップが隠れてしまったため、position: fixed を使用しています。
