### PR TITLE
取り込み文がプラグインを現在のインスタンスへ取り込むよう修正

### DIFF
--- a/test_browser/test/require_test.js
+++ b/test_browser/test/require_test.js
@@ -38,7 +38,6 @@ describe('require_test', () => {
     })
     it('プラグインの取り込み', async () => {
         const nako = new WebNakoCompiler()
-        navigator.nako3 = nako
         const code =
             `!「${buildURL('js', 0, `navigator.nako3.addPluginObject('PluginRequireTest', { requiretest: { type: 'var', value: 100 } })`)}」を取り込む。\n` +
             'requiretestを表示\n'


### PR DESCRIPTION
navigator.nako3以外のWebNakoCompilerのインスタンスを使う時、事前にコンパイラをnavigator.nako3に入れておく必要があった問題を修正しました。