### PR TITLE
構文エラーのクラス名の変更

### DIFF
--- a/src/nako_errors.js
+++ b/src/nako_errors.js
@@ -32,7 +32,8 @@ class NakoIndentError extends NakoError {
   }
 }
 
-class LexError extends NakoError {
+// コンパイラの内部でのみ使うエラー。投げられたらtryでキャッチしてLexerErrorへ変更する。
+class InternalLexerError extends NakoError {
   /**
    * @param {string} msg
    * @param {number} preprocessedCodeStartOffset
@@ -41,7 +42,7 @@ class LexError extends NakoError {
    * @param {string | undefined} [file]
    */
   constructor(msg, preprocessedCodeStartOffset, preprocessedCodeEndOffset, line, file) {
-    super('字句解析エラー', msg, file, line)
+    super(`字句解析エラー（内部エラー）`, msg, file, line)
     this.preprocessedCodeStartOffset = preprocessedCodeStartOffset
     this.preprocessedCodeEndOffset = preprocessedCodeEndOffset
     this.line = line
@@ -49,11 +50,9 @@ class LexError extends NakoError {
   }
 }
 
-class LexErrorWithSourceMap extends LexError {
+class NakoLexerError extends NakoError {
   /**
    * @param {string} msg
-   * @param {number} preprocessedCodeStartOffset
-   * @param {number} preprocessedCodeEndOffset
    * @param {number | null} startOffset
    * @param {number | null} endOffset,
    * @param {number | undefined} line
@@ -61,16 +60,16 @@ class LexErrorWithSourceMap extends LexError {
    */
   constructor(
     msg,
-    preprocessedCodeStartOffset,
-    preprocessedCodeEndOffset,
     startOffset,
     endOffset,
     line,
     file,
   ) {
-    super(msg, preprocessedCodeStartOffset, preprocessedCodeEndOffset, line, file)
+    super('字句解析エラー', msg, file, line)
     this.startOffset = startOffset
     this.endOffset = endOffset
+    this.line = line
+    this.file = file
   }
 }
 
@@ -169,8 +168,8 @@ class NakoImportError extends NakoError {
 module.exports = {
   NakoError,
   NakoIndentError,
-  LexError,
-  LexErrorWithSourceMap,
+  NakoLexerError,
+  InternalLexerError,
   NakoSyntaxError,
   NakoRuntimeError,
   NakoImportError,

--- a/src/nako_lexer.js
+++ b/src/nako_lexer.js
@@ -14,7 +14,7 @@ const josiRE = josi.josiRE
 const lexRules = require('./nako_lex_rules')
 const rules = lexRules.rules
 
-const {LexError} = require('./nako_errors')
+const {NakoLexerError, InternalLexerError} = require('./nako_errors')
 
 /**
  * @typedef {import('./nako3').TokenWithSourceMap} TokenWithSourceMap
@@ -327,7 +327,6 @@ class NakoLexer {
    * @param {number} line
    * @param {string} filename
    * @returns {Token[]}
-   * @throws {LexError}
    */
   tokenize (src, line, filename) {
     const srcLength = src.length
@@ -367,7 +366,7 @@ class NakoLexer {
             // 展開あり文字列 → aaa{x}bbb{x}cccc
             const list = this.splitStringEx(rp.res)
             if (list === null) {
-              throw new LexError(
+              throw new InternalLexerError(
                 '展開あり文字列で値の埋め込み{...}が対応していません。',
                 srcLength - src.length,
                 srcLength - rp.src.length,
@@ -471,7 +470,7 @@ class NakoLexer {
         break
       }
       if (!ok) {
-        throw new LexError('未知の語句: ' + src.substr(0, 3) + '...',
+        throw new InternalLexerError('未知の語句: ' + src.substr(0, 3) + '...',
           srcLength - src.length,
           srcLength - srcLength + 3,
           line,

--- a/src/wnako3_editor.js
+++ b/src/wnako3_editor.js
@@ -1,7 +1,7 @@
 /** なでしこのtokenのtypeをscope（CSSのクラス名）に変換する。 */
 
 const { OffsetToLineColumn } = require('./nako_source_mapping')
-const { LexError, NakoIndentError } = require('./nako_errors')
+const { NakoError } = require('./nako_errors')
 const { getBlockStructure, getIndent, countIndent, isIndentSyntaxEnabled } = require('./nako_indent')
 const NakoPrepare = require('./nako_prepare')
 
@@ -641,7 +641,7 @@ class BackgroundTokenizer {
                         this.cache = { code, lines: JSON.stringify(lines.editorTokens) }
                         ok = true
                     } catch (e) {
-                        if (!(e instanceof NakoIndentError || e instanceof LexError)) {
+                        if (!(e instanceof NakoError)) {
                             console.error(e)
                         }
                     }
@@ -938,7 +938,7 @@ class LanguageFeatures {
             tokens = nako3.lex(line, 'completion.nako3', undefined, true).tokens
                 .filter((t) => t.type !== 'eol' && t.type !== 'eof')
         } catch (e) {
-            if (!(e instanceof NakoIndentError || e instanceof LexError)) {
+            if (!(e instanceof NakoError)) {
                 console.error(e)
             }
         }

--- a/test/error_message_test.js
+++ b/test/error_message_test.js
@@ -2,7 +2,7 @@ const assert = require('assert')
 const path = require('path')
 const CNako3 = require('../src/cnako3')
 const NakoCompiler = require('../src/nako3')
-const { NakoSyntaxError, NakoRuntimeError, NakoIndentError, LexErrorWithSourceMap } = require('../src/nako_errors')
+const { NakoSyntaxError, NakoRuntimeError, NakoIndentError, NakoLexerError } = require('../src/nako_errors')
 
 describe('error_message', () => {
   const nako = new NakoCompiler()
@@ -31,7 +31,7 @@ describe('error_message', () => {
       cmp(`\n「こんに{ちは」と表示する`, [
         '2行目',
         'main.nako3',
-      ], LexErrorWithSourceMap)
+      ], NakoLexerError)
     })
   })
 

--- a/test_browser/karma.config.js
+++ b/test_browser/karma.config.js
@@ -174,7 +174,8 @@ module.exports = function(config) {
     reporters: ['mocha', 'coverage'],
     // reporter options
     mochaReporter: {
-      showDiff: true
+      showDiff: true,
+      timeout: 10000  // 10秒間
     },
     coverageReporter: {
       dir: '../coverage/ct',

--- a/test_browser/test/compare_util.js
+++ b/test_browser/test/compare_util.js
@@ -28,4 +28,23 @@ const waitTimer = (second) => {
   })
 }
 
-export { CompareUtil, waitTimer, assert }
+/**
+ * 5秒たつかfがエラーを投げなくなるまで繰り返す。呼び出すときは必ずawaitすること。
+ * @type {<T>(f: () => Promise<T>) => Promise<T>}
+ */
+const retry = async (f) => {
+  const startTime = Date.now()
+  while (true) {
+    try {
+      return await f()
+    } catch (err) {
+      if (Date.now() - startTime < 5000) {
+        await waitTimer(0.1)
+        continue
+      }
+      throw err
+    }
+  }
+}
+
+export { CompareUtil, waitTimer, assert, retry }

--- a/test_browser/test/plugin_browser_test_ajax.js
+++ b/test_browser/test/plugin_browser_test_ajax.js
@@ -1,5 +1,5 @@
 import * as td from 'testdouble'
-import { CompareUtil, waitTimer } from './compare_util'
+import { CompareUtil, waitTimer, retry } from './compare_util'
 
 export default (nako) => {
   const cu = new CompareUtil(nako)
@@ -32,9 +32,7 @@ AJAXオプションをJSONエンコードして表示する。
       nako.logger.debug('code=' + code)
       nako.runReset(code)
 
-      await waitTimer(1.0)
-
-      td.verify(windowalert('"OK"'), { times: 1 })
+      await retry(() => td.verify(windowalert('"OK"'), { times: 1 }))
       td.reset()
     })
 
@@ -51,9 +49,7 @@ AJAXオプションをJSONエンコードして表示する。
       nako.logger.debug('code=' + code)
       nako.runReset(code)
 
-      await waitTimer(1.0)
-
-      td.verify(windowalert('"param1=data1%5E&param2=data2%5E%5E"'), { times: 1 })
+      await retry(() => td.verify(windowalert('"param1=data1%5E&param2=data2%5E%5E"'), { times: 1 }))
       td.reset()
     })
 
@@ -70,9 +66,7 @@ AJAXオプションをJSONエンコードして表示する。
       nako.logger.debug('code=' + code)
       nako.runReset(code)
 
-      await waitTimer(1.0)
-
-      td.verify(windowalert('{"param1":"data1^","param2":"data2^^"}'), { times: 1 })
+      await retry(() => td.verify(windowalert('{"param1":"data1^","param2":"data2^^"}'), { times: 1 }))
       td.reset()
     })
 
@@ -87,9 +81,7 @@ AJAXオプションをJSONエンコードして表示する。
       nako.logger.debug('code=' + code)
       nako.runReset(code)
 
-      await waitTimer(1.0)
-
-      td.verify(windowalert('"OK"'), { times: 1 })
+      await retry(() => td.verify(windowalert('"OK"'), { times: 1 }))
       td.reset()
     })
 
@@ -106,10 +98,7 @@ AJAXオプションをJSONエンコードして表示する。
 `
       nako.logger.debug('code=' + code)
       nako.runReset(code)
-
-      await waitTimer(1.0)
-
-      td.verify(windowalert('"param1=data1%5E&param2=data2%5E%5E"'), { times: 1 })
+      await retry(() => td.verify(windowalert('"param1=data1%5E&param2=data2%5E%5E"'), { times: 1 }))
       td.reset()
     })
 
@@ -127,9 +116,7 @@ AJAXオプションをJSONエンコードして表示する。
       nako.logger.debug('code=' + code)
       nako.runReset(code)
 
-      await waitTimer(1.0)
-
-      td.verify(windowalert('{"param1":"data1^","param2":"data2^^"}'), { times: 1 })
+      await retry(() => td.verify(windowalert('{"param1":"data1^","param2":"data2^^"}'), { times: 1 }))
       td.reset()
     })
   })


### PR DESCRIPTION
- 2つの構文エラーのクラス間の継承関係をなくして、コードを分かりやすくしました。
- ライブラリ外へ投げられる方の構文エラーの名前をNakoLexerErrorに変更しました。
