### PR TITLE
mochaのtimeoutの変更

### DIFF
--- a/test/plugin_node_test.js
+++ b/test/plugin_node_test.js
@@ -58,7 +58,7 @@ describe('plugin_node_test', () => {
       'S1=「{TMP}/plugin_node_test.js」を読む。\n' +
       'S2=FINを読む。\n' +
       'もし(S1＝S2)ならば、"OK"と表示。\n', 'OK')
-  }).timeout(3000)
+  })
   it('ファイルサイズ取得', () => {
     cmp('「' + testFileMe + '」のファイルサイズ取得;もし、それが2000以上ならば;「OK」と表示。違えば「NG」と表示。', 'OK')
   })


### PR DESCRIPTION
#856 のテストが落ちたためタイムアウトを伸ばしました。
mochaのtimeoutのデフォルト値を15秒に設定してあるため、.timeout(3000) を除くと制限時間が長くなります。

https://github.com/kujirahand/nadesiko3/blob/master/package.json#L12
