### PR TITLE
reactのエディタのコードの短縮

### DIFF
--- a/demo/css/common.css
+++ b/demo/css/common.css
@@ -126,6 +126,7 @@ button {
 
 .info {
   background-color: #f0fff0;
+  margin-top: 0;
 }
 
 .err {

--- a/demo/index.html
+++ b/demo/index.html
@@ -36,7 +36,6 @@
 
   <!-- editor -->
   <div id="editor" class="edit_div">
-    <p class="edit_head">エディタ:</p>
     <div class="editor-component">
       <script type="application/json">
         {

--- a/demo/turtle.html
+++ b/demo/turtle.html
@@ -20,7 +20,6 @@
 <body>
 <h1><a name="src_box_head">なでしこ3/タートルグラフィックス</a></h1>
 <div id="editor" class="edit_div">
-  <p class="edit_head">簡易エディタ:</p>
   <textarea id="src_box" rows="4" title="簡易エディタ">
 カメ作成。
 [10,10]にカメ起点移動。

--- a/editor/edit_main.jsx
+++ b/editor/edit_main.jsx
@@ -1,57 +1,35 @@
 // edit_main.js
 import React from 'react'
 import ReactDOM from 'react-dom'
-import 'mocha-css'
 import dayjs from 'dayjs'
+
 /** @type {Record<string, Record<string, string[][]>>} */
 const commandListJSON = require('../release/command.json')
-
-/** @returns {import('../src/wnako3')} */
-const getNako3 = () => navigator.nako3
-
-/** @param {string} id @returns {HTMLElement} */
-const mustGetElementById = (id) => {
-  const element = document.getElementById(id)
-  if (element === null) {
-    throw new Error(`idが${id}の要素は存在しません。`)
+const commandList = /** @type {{ name: String, group: { type: string, name: String, args: string, value: string }[] }[]} */([])
+for (const fname of ['plugin_browser', 'plugin_turtle', 'plugin_system']) {
+  const groups = commandListJSON[fname]
+  if (!groups) {
+    console.log('command.jsonの[' + fname + ']が読み込めません。')
+    continue // 読み込みに失敗した場合
   }
-  return element
+  for (const [groupName, group] of Object.entries(groups)) {
+    commandList.push({
+      name: groupName,
+      group: group.map(([type, name, args]) => ({ type, name, args, value: (type === '関数') ? ((args + '/').split('/')[0] + name + '。') : name })),
+    })
+  }
 }
 
-/**
- * コマンドのリストを表示する。コマンドをクリックするとその値を引数に与えてonClickを呼ぶ。
- * @type {React.FC<{ onClick?: (value: string) => void }>}
- */
-const CommandList = (props) => {
-  const list = /** @type {{ name: String, group: string[][] }[]} */([])
-  for (const fname of ['plugin_browser', 'plugin_turtle', 'plugin_system']) {
-    const groups = commandListJSON[fname]
-    if (!groups) {
-      console.log('command.jsonの[' + fname + ']が読み込めません。')
-      continue // 読み込みに失敗した場合
-    }
-    for (const name in groups) {
-      list.push({ name, group: groups[name] })
-    }
-  }
+// @ts-ignore
+const getNako3 = () => /** @type {import('../src/wnako3')} */(navigator.nako3)
 
-  return <ul>{
-    list.map(({ group, name }) => <li key={name}>
-      <div style={{ color: '#55c' }}>{name}</div>
-      <div style={{ marginLeft: '12px' }}>{
-        group.map(([type, name, args], i) => {
-          const value = (type === '関数') ? ((args + '/').split('/')[0] + name + '。') : name
-          return <span key={i} style={{ marginRight: '12px', cursor: 'pointer' }} onClick={() => props.onClick?.(value)}>[{name}]</span>
-        })
-      }</div>
-    </li>)
-  }</ul>
-}
+/** @type {React.FC<{ onClick: () => void, text: string }>} */
+const Button = (props) => <button className="default_button" onClick={props.onClick}>{props.text}</button>
 
-/**
- * エディタ本体
- * @type {React.FC<{ code: string, editorId: number }>}
- */
+/** @type {React.FC<{ title: string }>} */
+const Section = (props) => <section><h5 className="edit_head">{props.title}</h5>{props.children}</section>
+
+/** @type {React.FC<{ code: string, editorId: number }>} */
 const Editor = ({ code, editorId }) => {
   const preCode = `\
 # 自動実行されるコード (編集不可)
@@ -62,95 +40,69 @@ const Editor = ({ code, editorId }) => {
 
   // エディタの状態
   const [usedFuncs, setUsedFuncs] = React.useState(/** @type {Set<string>} */(new Set()))
-  const [showCommandList, setShowCommandList] = React.useState(false)
+  const [showCommandList, toggleCommandList] = React.useReducer((x) => !x, false)
 
-  /** @type {React.MutableRefObject<ReturnType<import('../src/wnako3')['setupEditor']> | null>} */
-  const editor = React.useRef(null)
-
-  // 各ボタンが押された時の動作
-  const run = React.useCallback(async () => {
-    await editor.current?.run({ preCode, outputContainer: mustGetElementById(`nako3_editor_info_${editorId}`) }).promise
-    setUsedFuncs(getNako3().usedFuncs)
-  }, [])
-  const test = React.useCallback(() => { editor.current?.run({ preCode, outputContainer: mustGetElementById(`nako3_editor_info_${editorId}`), method: 'test' }) }, [])
-  const clear = React.useCallback(() => { mustGetElementById(`nako3_editor_info_${editorId}`).innerHTML = '' }, [])
-  const download = React.useCallback(async () => {
-    const js = await editor.current?.run({ preCode, outputContainer: mustGetElementById(`nako3_editor_info_${editorId}`), method: 'compile' }).promise
-    const link = document.createElement('a')
-    if (typeof js !== 'string') { return }  // コンパイルエラーなど
-    link.href = window.URL.createObjectURL(new Blob([js]))
-    link.download = 'nako3_' + dayjs().format('YYYYMMDDHHmmss') + '.js'
-    link.click()
-  }, [])
-
-  // コマンドのリスト
-  const toggleCommandList = React.useCallback(() => { setShowCommandList(!showCommandList) }, [showCommandList])
-  const insertCommand = React.useCallback((/** @type {string} */value) => {
-    // カーソル位置に命令を挿入する。
-    const aceEditor = editor.current?.editor
-    if (!aceEditor) { return }
-    aceEditor.session.insert(aceEditor.getCursorPosition(), value)
-  }, [])
-
-  // ace editor のマウント
-  React.useEffect(() => {
-    getNako3().setupEditor(`nako3_editor_precode_${editorId}`)
-    editor.current = getNako3().setupEditor(`nako3_editor_code_${editorId}`)
-  }, [])
+  // ace editor の初期化
+  const preCodeEditorRef = /** @type {React.MutableRefObject<HTMLDivElement>} */(React.useRef())
+  const editorRef = /** @type {React.MutableRefObject<HTMLDivElement>} */(React.useRef())
+  const editor = /** @type {React.MutableRefObject<ReturnType<import('../src/wnako3')['setupEditor']>>} */(React.useRef())
+  React.useEffect(() => { getNako3().setupEditor(preCodeEditorRef.current) }, [])
+  React.useEffect(() => { editor.current = getNako3().setupEditor(editorRef.current) }, [])
+  const editorOptions = () => ({ preCode, outputContainer: /** @type {HTMLDivElement} */(document.getElementById(`nako3_editor_info_${editorId}`)) })
 
   return <div>
-    {/* プログラムの直前に自動挿入されるコードをreadonlyなエディタで表示する。 */}
-    {React.useMemo(() => <div id={`nako3_editor_precode_${editorId}`} data-nako3-readonly style={{ height: '100px', borderBottom: 'gray 1px solid' }}>{preCode}</div>, [])}
-
-    {/* 実行したいプログラムを書くエディタ */}
-    {React.useMemo(() => <div id={`nako3_editor_code_${editorId}`}>{code}</div>, [])}
-
-    {/* 実行ボタンなど */}
-    <div className="buttons">
-      <button className="default_button" onClick={run}>実行</button>
-      <button className="default_button" onClick={test}>テスト</button>
-      <button className="default_button" onClick={clear}>クリア</button>
-      <button onClick={download}>↓</button>
-    </div>
-
-    {/* 実行結果の表示用のdivと、ユーザープログラムから操作できるdivとキャンバス */}
-    <div>
-      <div className="edit_head">実行結果:</div>
+    <Section title="エディタ">
+      <div ref={preCodeEditorRef} data-nako3-readonly style={{ height: '100px', borderBottom: 'gray 1px solid' }}>{preCode}</div>
+      <div ref={editorRef}>{code}</div>
+      <div className="buttons">
+        <Button text="実行" onClick={async () => {
+          await editor.current.run({ ...editorOptions() }).promise
+          setUsedFuncs(getNako3().usedFuncs)
+        }} />
+        <Button text="テスト" onClick={() => editor.current.run({ ...editorOptions(), method: 'test' })} />
+        <Button text="クリア" onClick={() => editorOptions().outputContainer.innerHTML = ''} />
+        <Button text="↓" onClick={async () => {
+          const js = await editor.current.run({ ...editorOptions(), method: 'compile' }).promise
+          if (typeof js === 'string') {
+            // ファイルのダウンロード
+            const link = document.createElement('a')
+            link.href = window.URL.createObjectURL(new Blob([js])) // ファイルの中身
+            link.download = 'nako3_' + dayjs().format('YYYYMMDDHHmmss') + '.js' // ファイル名
+            link.click()
+          }
+        }} />
+      </div>
+    </Section>
+    <Section title="実行結果">
       <div id={`nako3_editor_info_${editorId}`} className="info"></div>
       <div id={`nako3_div_${editorId}`}></div>
       <canvas id={`nako3_canvas_${editorId}`} width="310" height="150"/>
-    </div>
-
-    {/* 使用した命令のリストを表示する。 */}
-    <div>
-      <div className="edit_head">使用した命令:</div>
-      <p className="info">{Array.from(usedFuncs.values()).sort().join(', ')}</p>
-    </div>
-
-    {/* テストの結果を表示する。 */}
-    <div>
-      <p className="edit_head">テスト結果:</p>
-      <div id="mocha"/>
-    </div>
-
-    {/* 命令の一覧を表示する。命令をクリックするとエディタのカーソル位置にその文字列が挿入される。 */}
-    <div>
+    </Section>
+    <Section title="使用した命令"><p className="info">{Array.from(usedFuncs.values()).sort().join(', ')}</p></Section>
+    <Section title="命令の一覧">
       <div style={{paddingTop: '8px'}}>
-        <button onClick={toggleCommandList} className="default_button">
-          <span>{showCommandList ? '命令の一覧を隠す' : '命令の一覧を表示する'}</span>
-        </button>
+        <Button text={showCommandList ? '命令の一覧を隠す' : '命令の一覧を表示する'} onClick={toggleCommandList} />
       </div>
-      {showCommandList ? <CommandList onClick={insertCommand} /> : null}
-    </div>
+      {showCommandList && <ul>{
+        commandList.map(({ group, name }) => <li key={name}>
+          <div style={{ color: '#55c' }}>{name}</div>
+          <div style={{ marginLeft: '12px' }}>{group.map(({ value, name }, i) =>
+            <span key={i} style={{ marginRight: '12px', cursor: 'pointer' }} onClick={() => {
+              // カーソル位置に命令を挿入する。
+              editor.current.editor.session.insert(editor.current.editor.getCursorPosition(), value)
+            }}>[{name}]</span>)
+          }</div>
+        </li>)
+      }</ul>}
+    </Section>
   </div>
 }
 
 try {
   for (const [i, e] of Array.from(Array.from(document.getElementsByClassName('editor-component')).entries())) {
     const data = JSON.parse(e.getElementsByTagName('script')[0].text)
-    const autoLoad = data['autoLoad']
     let code = data['code']
-    if (autoLoad && window.localStorage['nako3/editor/code']) {
+    if (data['autoLoad'] && window.localStorage['nako3/editor/code']) {
       code = window.localStorage['nako3/editor/code']
     }
     ReactDOM.render(<Editor code={code} editorId={i} />, e)

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -9,7 +9,7 @@
     // "lib": [],                                   /* Specify library files to be included in the compilation. */
     // "allowJs": true,                             /* Allow javascript files to be compiled. */
     "checkJs": true,                             /* Report errors in .js files. */
-    // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
+    "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
     // "declaration": true,                         /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                           /* Generates corresponding '.map' file. */

--- a/src/wnako3.js
+++ b/src/wnako3.js
@@ -130,11 +130,11 @@ class WebNakoCompiler extends NakoCompiler {
 
   /**
    * 指定したidのHTML要素をなでしこ言語のエディタにする。
-   * @param {string} id div要素のid
+ * @param {string | Element} idOrElement HTML要素
    * @see {setupEditor}
    */
-  setupEditor(id) {
-    return setupEditor(id, this, /** @type {any} */(window).ace)
+  setupEditor(idOrElement) {
+    return setupEditor(idOrElement, this, /** @type {any} */(window).ace)
   }
 }
 

--- a/src/wnako3_editor.js
+++ b/src/wnako3_editor.js
@@ -1265,16 +1265,16 @@ let editorIdCounter = 0
  * - 縦方向にリサイズ可能にするには nako3-resizable="true" を設定する。
  * - デバイスが遅いときにシンタックスハイライトを無効化する機能を切るには nako3-force-syntax-highlighting="true" を設定する。
  * 
- * @param {string} id HTML要素のid
+ * @param {string | Element} idOrElement HTML要素
  * @param {import('./wnako3')} nako3
  * @param {any} ace
  */
-function setupEditor (id, nako3, ace) {
+function setupEditor (idOrElement, nako3, ace) {
     /** @type {AceEditor} */
-    const editor = ace.edit(id)
-    const element = document.getElementById(id)
+    const editor = ace.edit(idOrElement)
+    const element = typeof idOrElement === 'string' ? document.getElementById(idOrElement) : idOrElement
     if (element === null) {
-        throw new Error(`idが ${id} のHTML要素は存在しません。`)
+        throw new Error(`idが ${idOrElement} のHTML要素は存在しません。`)
     }
 
     /** @type {TypeofAceRange} */
@@ -1289,7 +1289,7 @@ function setupEditor (id, nako3, ace) {
     if (element.classList.contains('nako3_ace_mounted')) {
         // 同じエディタを誤って複数回初期化すると、ace editor の挙動を書き換えているせいで
         // 意図しない動作をしたため、すでにエディタとして使われていないことを確認する。
-        throw new Error(`idが ${id} のHTML要素をなでしこ言語エディタとして2回初期化しました。`)
+        throw new Error(`なでしこ言語のエディタの初期化処理を同一のHTML要素に対して複数回適用しました。`)
     }
     // 以前のバージョンではnako3_editorをhtmlに直接付けていたため、互換性のためnako3_editorとは別のクラス名を使用する。
     element.classList.add('nako3_ace_mounted')
@@ -1324,6 +1324,7 @@ function setupEditor (id, nako3, ace) {
             initialValue: true
         },
         underlineJosi: {
+            /** @type {(this: AceEditor, value: boolean) => void} */
             set: function(value) {
                 this.session.bgTokenizer.underlineJosi = value
                 resetEditorTokens(this.session)

--- a/test_bundled/test/bundled_test.js
+++ b/test_bundled/test/bundled_test.js
@@ -44,7 +44,7 @@ describe('bundled test', () => {
         return new Promise((resolve, reject) => {
           setTimeout(() => {
             try {
-              const rsltHead = Array.from(el.querySelectorAll('.edit_head')).find(e => e.textContent === '実行結果:')
+              const rsltHead = Array.from(el.querySelectorAll('.edit_head')).find(e => e.textContent === '実行結果')
               if (rsltHead) {
                 rslt = rsltHead.parentNode.querySelector('.info')
                 if (rslt) {

--- a/test_bundled/test/html/custom_context.html
+++ b/test_bundled/test/html/custom_context.html
@@ -18,7 +18,6 @@ Reloaded before every execution run.
 <body>
   <!-- editor -->
   <div id="editor" class="edit_div">
-    <p class="edit_head">エディタ:</p>
     <div class="editor-component">
       <script type="application/json">
         {

--- a/test_bundled/test/html/custom_debug.html
+++ b/test_bundled/test/html/custom_debug.html
@@ -20,7 +20,6 @@ just for immediate execution, without reporting to Karma server.
 <body>
   <!-- editor -->
   <div id="editor" class="edit_div">
-    <p class="edit_head">エディタ:</p>
     <div class="editor-component">
       <script type="application/json">
         {


### PR DESCRIPTION
冗長な記述を消してedit_main.jsxを161行から[112行に](https://github.com/yy0931/nadesiko3/blob/ff059844619a4ee13bdd8fe08b7171f682a0b8c7/editor/edit_main.jsx)短縮しました。
ボタンやヘッダー（セクション）の共通化、`エディタ:` の文字列をhtmlではなくreact側で表示、HTML要素にidでアクセスしていた部分をrefに変更、の変更を含んでいます。