### PR TITLE
明示的に取り込んだプラグインの関数がシンタックスハイライトされない問題の修正

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://json.schemastore.org/mocharc",
+    "exit": true,
+    "timeout": 15000,
+    "require": "module-alias/register",
+    "spec": "./test/+(common|node)/*.js"
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "nako3edit": "tools/nako3edit/run.js"
   },
   "scripts": {
-    "test": "cross-env TZ=Asia/Tokyo mocha --exit --timeout 15000 --require module-alias/register \"./test/+(common|node)/*.js\"",
+    "test": "cross-env TZ=Asia/Tokyo mocha",
     "test:common": "cross-env TZ=Asia/Tokyo NODE_ENV=development karma start --single-run --browsers FirefoxCustomHeadless --reporters=mocha test/karma.config.js",
     "test:browser": "cross-env TZ=Asia/Tokyo NODE_ENV=development karma start --single-run --browsers FirefoxCustomHeadless --reporters=mocha test/browser/karma.config.js",
     "test:bundled": "cross-env TZ=Asia/Tokyo NODE_ENV=development karma start --single-run --browsers FirefoxCustomHeadless test/bundled/karma.config.js",

--- a/src/wnako3_editor.js
+++ b/src/wnako3_editor.js
@@ -548,6 +548,9 @@ class BackgroundTokenizer {
 
         this.deleted = false
 
+        /** @public */
+        this.enabled = true
+
         const update = () => {
             if (this.deleted) {
                 return
@@ -574,10 +577,10 @@ class BackgroundTokenizer {
                 setTimeout(update, 100)
             }
         }
-        update()
 
-        /** @public */
-        this.enabled = true
+        // コンストラクタが返る前にコールバックを呼ぶのはバグの元になるため一瞬待つ。
+        // たとえば `const a = new BackgroundTokenizer(..., () => { /* aを使った処理 */ }, ...)` がReferenceErrorになる。
+        setTimeout(() => { update() }, 0)
     }
 
     dispose() {

--- a/src/wnako3_editor.js
+++ b/src/wnako3_editor.js
@@ -286,7 +286,7 @@ function tokenize(lines, nako3, underlineJosi) {
     lexerOutput.tokens = lexerOutput.tokens.filter((t) => t.file === 'main.nako3')
 
     // 外部ファイルで定義された関数名に一致するトークンのtypeをfuncに変更する。
-    // 取り込んでいないファイルも参照される問題や、関数名の重複がある場合に正しくない情報を表示する問題がある。可能なら修正する。
+    // 取り込んでいないファイルも参照される問題や、関数名の重複がある場合に正しくない情報を表示する問題がある。
     {
         /** @type {Record<string, object>} */
         for (const [file, { funclist }] of Object.entries(nako3.dependencies)) {

--- a/src/wnako3_editor.js
+++ b/src/wnako3_editor.js
@@ -789,7 +789,7 @@ class LanguageFeatures {
     /**
      * checkOutdentがtrueを返したときに呼ばれる。
      * @param {string} state
-     * @param {{ doc: AceDocument }} session
+     * @param {Session} session
      * @param {number} row
      * @returns {void}
      */

--- a/test/common/basic_test.js
+++ b/test/common/basic_test.js
@@ -1,16 +1,17 @@
 const assert = require('assert')
 const NakoCompiler = require('../../src/nako3')
+const { expect } = require('chai')
 
 describe('basic', () => {
   const nako = new NakoCompiler()
   // nako.logger.addListener('trace', ({ browserConsole }) => { console.log(...browserConsole) })
-  const cmp = (code, res) => {
+  const cmp = (/** @type {string} */code, /** @type {string} */res) => {
     nako.logger.debug('code=' + code)
-    assert.strictEqual(nako.run(code).log, res)
+    assert.strictEqual(nako.run(code, '').log, res)
   }
-  const cmpNakoFuncs = (code, res) => {
+  const cmpNakoFuncs = (/** @type {string} */code, /** @type {Set<string>} */res) => {
     nako.logger.debug('code=' + code)
-    nako.run(code)
+    nako.run(code, '')
     assert.deepStrictEqual(nako.usedFuncs, res)
   }
   // --- test ---
@@ -129,17 +130,17 @@ describe('basic', () => {
     )
   })
   it('独立した助詞『ならば』の位置の取得', () => {
-    const out = nako.lex('もし存在するならば\nここまで')
+    const out = nako.lex('もし存在するならば\nここまで', '')
     const sonzai = out.tokens.find((t) => t.value === '存在')
     const naraba = out.tokens.find((t) => t.type === 'ならば')
 
     // 「存在する」
-    assert.strictEqual(sonzai.startOffset, 2)
-    assert.strictEqual(sonzai.endOffset, 6)
+    expect(sonzai).to.have.property("startOffset").and.to.equal(2)
+    expect(sonzai).to.have.property("endOffset").and.to.equal(6)
 
     // ならば
-    assert.strictEqual(naraba.startOffset, 6)
-    assert.strictEqual(naraba.endOffset, 9)
+    expect(naraba).to.have.property("startOffset").and.to.equal(6)
+    expect(naraba).to.have.property("endOffset").and.to.equal(9)
   })
   it('preCodeを考慮したソースマップ', () => {
     const preCode = '1を表示\n2を表示\n3を'
@@ -185,7 +186,7 @@ describe('basic', () => {
   it('return_none: true のaddFuncで定義した関数が「それ」に値を代入しないことを確認する', () => {
     const nako = new NakoCompiler()
     nako.addFunc('hoge', [], () => {}, true)
-    assert.strictEqual(nako.run('1と2を足す\nhoge\nそれを表示').log, '3')
+    assert.strictEqual(nako.run('1と2を足す\nhoge\nそれを表示', '').log, '3')
   })
   it('制御構文で一語関数を使う', () => {
     cmp('●一とは\n1を戻す\nここまで\nもし一ならば\n1を表示\nここまで', '1') // if
@@ -225,7 +226,7 @@ describe('basic', () => {
     if (typeof process === 'undefined' || process.env.NODE_ENV === 'test') {return this.skip()}
     const code = nako.compileStandalone('1+2を表示', 'main.nako3', false)    
     Function('const console = { log: this.callback };\n' + code).apply({
-      callback: (text) => {
+      callback: (/** @type {any} */text) => {
         assert.strictEqual(text, '3')
         done()
       },
@@ -243,7 +244,18 @@ describe('basic', () => {
 0.0001秒後には
     「A」のJSオブジェクト取得して表示
 ここまで。
-`)
+`, '')
     nako.reset()
+    console.log(nako.compile(`\
+●テスト:足すとは
+    1と2を足す
+    それと3がASSERT等しい
+ここまで
+
+●テスト:引くとは
+    1と2を足す
+    それと3がASSERT等しい
+ここまで
+`, 'main.nako3', true))
   })
 })

--- a/test/node/side_effects_test.js
+++ b/test/node/side_effects_test.js
@@ -70,7 +70,8 @@ describe('side_effects_test', () => {
         assert.throws(() => nako.run(code2, 'main.nako3'), NakoSyntaxError)
     })
     it('「初期化」と「!クリア」を呼ぶ', () => {
-        let log = []
+        /** @type {any[]} */
+        const log = []
         const nako = new NakoCompiler()
 
         let count = 0
@@ -94,8 +95,8 @@ describe('side_effects_test', () => {
             },
         })
 
-        const process1 = nako.run('a=1')
-        const process2 = nako.run('a=1')
+        const process1 = nako.run('a=1', '')
+        const process2 = nako.run('a=1', '')
 
         process1.destroy()
         process2.destroy()

--- a/test/node/wnako3_editor_test.js
+++ b/test/node/wnako3_editor_test.js
@@ -133,6 +133,15 @@ describe('wnako3_editor_test', () => {
                 fs.unlinkSync(largeFile)
             }
         })
+        it('明示的に取り込んだプラグインの関数', async () => {
+            const compiler = new CNako3()
+            const code = `!「plugin_csv」を取り込む\n「1」のCSV取得`
+            compiler.loadDependencies(code, '', '')
+            const token = tokenize(code.split('\n'), compiler, false).editorTokens[1][1]
+            expect(token.type).to.include('function')
+            expect(token.docHTML).to.include('CSV取得')
+            expect(token.value).to.equal('CSV取得')
+        })
     })
     describe('ドキュメントのホバー', () => {
         it('プラグイン関数の助詞のドキュメントを表示する', () => {

--- a/test/node/wnako3_editor_test.js
+++ b/test/node/wnako3_editor_test.js
@@ -1,31 +1,39 @@
 const assert = require('assert')
 const NakoCompiler = require('../../src/nako3')
-const { tokenize, LanguageFeatures } = require('../../src/wnako3_editor')
+const { tokenize, LanguageFeatures, AceDocument: IAceDocument, Session: ISession } = require('../../src/wnako3_editor')
 const CNako3 = require('../../src/cnako3')
 const path = require('path')
 const fs = require('fs')
+const {expect} = require('chai')
 
 describe('wnako3_editor_test', () => {
     class AceRange {
-        constructor(startLine, startColumn, endLine, endColumn) {
+        constructor(/** @type {number} */startLine, /** @type {number} */startColumn, /** @type {number} */endLine, /** @type {number} */endColumn) {
             this.startLine = startLine
             this.startColumn = startColumn
             this.endLine = endLine
             this.endColumn = endColumn
         }
     }
+    /** @implements {IAceDocument} */
     class AceDocument {
-        constructor(text) {
+        constructor(/** @type {string} */text) {
             this.lines = text.split('\n')
+            /** @type {any[]} */
             this.log = []
         }
-        getLine(row) { return this.lines[row] }
+        getLine(/** @type {number} */row) { return this.lines[row] }
+        getLength() { return this.lines.length }
         getAllLines() { return [...this.lines] }
-        insertInLine(position, text) { this.log.push(['insertInLine', position, text]) }
-        removeInLine(row, columnStart, columnEnd) { this.log.push(['removeInLine', row, columnStart, columnEnd]) }
-        replace(range, text) { this.log.push(['replace', range, text]) }
+        insertInLine(/** @type {{ row: number, column: number }} */position, /** @type {string} */text) { this.log.push(['insertInLine', position, text]) }
+        removeInLine(/** @type {number} */row, /** @type {number} */columnStart, /** @type {number} */columnEnd) { this.log.push(['removeInLine', row, columnStart, columnEnd]) }
+        replace(/** @type {AceRange} */range, /** @type {string} */text) { this.log.push(['replace', range, text]) }
+        /** @returns {ISession} */
+        asSession() { // テスト用
+            // @ts-ignore
+            return { doc: this }
+        }
     }
-    
     describe('シンタックスハイライト', () => {
         it('コードを分割する', () => {
             const tokens = tokenize('A=1\nA+1を表示'.split('\n'), new NakoCompiler(), false).editorTokens
@@ -73,13 +81,12 @@ describe('wnako3_editor_test', () => {
             const nako3 = new CNako3()
             const code = '!「./requiretest_indirect.nako3」を取り込む\n1と2の痕跡演算'
             const file = path.join(__dirname, 'main.nako3')
-            nako3.loadDependencies(code, file)
+            nako3.loadDependencies(code, file, "")
             const tokens = tokenize(code.split('\n'), nako3, true)
 
             // 「痕跡演算」が関数として認識されていることを確認する。
             const token = tokens.editorTokens[1].find((token) => token.value === '痕跡演算')
-            assert.notStrictEqual(token, undefined)
-            assert(token.type.includes('function'))
+            expect(token).to.have.property("type").and.to.include("function")
         })
         it('シンタックスハイライトにかかる時間が依存ファイルの行数に依存しないことを確認', () => {
             // 一時的に大きいファイルを作成
@@ -93,7 +100,7 @@ describe('wnako3_editor_test', () => {
 
                 const nako3 = new CNako3()
                 console.time('loadDependencies')
-                nako3.loadDependencies(code, file)  // この行は遅いが、取り込み文に変更が合った時しか呼ばれない
+                nako3.loadDependencies(code, file, "")  // この行は遅いが、取り込み文に変更が合った時しか呼ばれない
                 console.timeEnd('loadDependencies')
 
                 const startTime = process.hrtime.bigint()
@@ -108,8 +115,7 @@ describe('wnako3_editor_test', () => {
 
                 // 取り込みが行われたことを確認する
                 const token = tokens.editorTokens[1].find((token) => token.value === 'large_file')
-                assert.notStrictEqual(token, undefined)
-                assert(token.type.includes('function'))
+                expect(token).to.have.property('type').and.to.include('function')
             } finally {
                 fs.unlinkSync(largeFile)
             }
@@ -129,14 +135,14 @@ describe('wnako3_editor_test', () => {
             const token = tokenize('XをYにプラグイン関数テスト'.split('\n'), nako3, false)
                 .editorTokens[0]
                 .find((t) => t.value === 'プラグイン関数テスト')
-            assert(token.docHTML.includes('（Aを|Aと、Bに|Bは）'))
-            assert(token.docHTML.includes('PluginEditorTest'))
+            expect(token).to.have.property('docHTML').and.to.include('（Aを|Aと、Bに|Bは）')
+            expect(token).to.have.property('docHTML').and.to.include('PluginEditorTest')
         })
         it('ユーザー定義関数の助詞のドキュメントを表示する', () => {
             const token = tokenize('●（Aを）Fとは\nここまで\n1をF'.split('\n'), new NakoCompiler(), false)
                 .editorTokens[2]
                 .find((t) => t.value === 'F')
-            assert(token.docHTML.includes('（Aを）'))
+            expect(token).to.have.property('docHTML').and.to.include('（Aを）')
         })
         it('前回の実行結果の影響を受けない', () => {
             const nako3 = new NakoCompiler()
@@ -144,13 +150,13 @@ describe('wnako3_editor_test', () => {
             const token = tokenize('1をF'.split('\n'), nako3, false)
                 .editorTokens[0]
                 .find((t) => t.value === 'F')
-            assert.strictEqual(token.docHTML, null)
+            expect(token).to.have.property("docHTML").and.is.null
         })
     })
     describe('行コメントのトグル', () => {
         it('コメントアウト', () => {
             const doc = new AceDocument('abc\n')
-            LanguageFeatures.toggleCommentLines('', { doc }, 0, 1)
+            LanguageFeatures.toggleCommentLines('', doc.asSession(), 0, 1)
             assert.deepStrictEqual(doc.log, [
                 [ 'insertInLine', { row: 0, column: 0 }, '// ' ],
                 [ 'insertInLine', { row: 1, column: 0 }, '// ' ],
@@ -158,7 +164,7 @@ describe('wnako3_editor_test', () => {
         })
         it('アンコメント', () => {
             const doc = new AceDocument('// abc\n\n※def')
-            LanguageFeatures.toggleCommentLines('', { doc }, 0, 2)
+            LanguageFeatures.toggleCommentLines('', doc.asSession(), 0, 2)
             assert.deepStrictEqual(doc.log, [
                 [ 'removeInLine', 0, 0, 3 ], // '// ' を削除
                 [ 'removeInLine', 2, 0, 1 ], // '※' を削除
@@ -166,7 +172,7 @@ describe('wnako3_editor_test', () => {
         })
         it('中黒のある場合', () => {
             const doc = new AceDocument('・・abc')
-            LanguageFeatures.toggleCommentLines('', { doc }, 0, 0)
+            LanguageFeatures.toggleCommentLines('', doc.asSession(), 0, 0)
             assert.deepStrictEqual(doc.log, [
                 [ 'insertInLine', { row: 0, column: 2 }, '// ' ], // 'abc' の直前に挿入
             ])
@@ -185,14 +191,14 @@ describe('wnako3_editor_test', () => {
         it('1つ前の行がブロックの開始行なら、その行に合わせる', () => {
             const doc = new AceDocument('    もしはいならば\n        ここまで')
             // 2行目にauto outdentを実行
-            new LanguageFeatures(AceRange, new NakoCompiler()).autoOutdent('start', { doc }, 1)
+            new LanguageFeatures(AceRange, new NakoCompiler()).autoOutdent('start', doc.asSession(), 1)
             // 2行目の0-8文字目が '    ' で置換される
             assert.deepStrictEqual(doc.log, [[ 'replace', new AceRange(1, 0, 1, 8), '    ']])
         })
         it('1つ前の行がブロックの開始行でなければ、1段階インデントを下げる', () => {
             const doc = new AceDocument('もしはいならば\n    もしはいならば\n        1を表示\n        ここまで')
             // 4行目にauto outdentを実行
-            new LanguageFeatures(AceRange, new NakoCompiler()).autoOutdent('start', { doc }, 3)
+            new LanguageFeatures(AceRange, new NakoCompiler()).autoOutdent('start', doc.asSession(), 3)
             // 2行目の0-8文字目が '    ' で置換される
             assert.deepStrictEqual(doc.log, [[ 'replace', new AceRange(3, 0, 3, 8), '    ']])
         })
@@ -227,7 +233,7 @@ describe('wnako3_editor_test', () => {
             '●（AとBを）足すとは\n' +
             'ここまで\n' +
             '●テスト:引くとは\n' +
-            'ここまで\n'
+            'ここまで\n',
         ))
         assert.deepStrictEqual(out, [
             { start: { row: 0 }, command: { title: 'テストを実行', id: 'runTest', arguments: ['足す'] } },


### PR DESCRIPTION
- 2つ目のコミットでmochaの引数を.mocharc.jsonに移動させています。`npx mocha -g 'シンタックスハイライト'` のようにテストを実行できるようになります。
- 3つ目のコミットでオートコンプリートのテストを追加しました。
- 4つ目のコミットで、取り込み文で.jsファイルを取り込んだときに、そのプラグインに関数が関数としてシンタックスハイライトされず、オートコンプリートにも出ない問題を修正しました。初回実行時にthis.dependencies[].funclistに関数のリストを保存して、エディタ側からそれを利用します。

例えば 雪乃☆雫 さんの コード ( https://nadesi.com/v3/storage/id.php?465 ) の `アクセスデバイス` が、関数として認識されるべきところ、変数として扱われていました。
```
!「https://snowdrops89.github.io/nako3_plugin/Plugin_UserInfo.js」を取り込む。
アクセスデバイスを表示。
```
