### PR TITLE
継承の型エラーの修正

### DIFF
--- a/src/cnako3.js
+++ b/src/cnako3.js
@@ -244,7 +244,7 @@ class CNako3 extends NakoCompiler {
     /** @type {string[]} */
     const log = []
     // 同期的に読み込む
-    const tasks = super.loadDependencies(code, filename, preCode, {
+    const tasks = super._loadDependencies(code, filename, preCode, {
       resolvePath: (name, token) => {
         if (/\.js(\.txt)?$/.test(name) || /^[^\.]*$/.test(name)) {
           return { filePath: path.resolve(CNako3.findPluginFile(name, this.filename, __dirname, log)), type: 'js' }

--- a/src/nako3.js
+++ b/src/nako3.js
@@ -165,8 +165,9 @@ class NakoCompiler {
    *     readJs: (filePath: string, token: TokenWithSourceMap) => { sync: true, value: () => object } | { sync: false, value: Promise<() => object> }
    * }} tools
    * @returns {Promise<unknown> | void}
+   * @protected
    */
-  loadDependencies(code, filename, preCode, tools) {
+  _loadDependencies(code, filename, preCode, tools) {
     /** @type {NakoCompiler['dependencies']} */
     const dependencies = {}
     const compiler = new NakoCompiler()

--- a/src/wnako3.js
+++ b/src/wnako3.js
@@ -40,7 +40,7 @@ class WebNakoCompiler extends NakoCompiler {
    * @returns {Promise<unknown>}
    */
   async loadDependencies(code, filename, preCode = '', localFiles = {}) {
-    return super.loadDependencies(code, filename, preCode, {
+    return this._loadDependencies(code, filename, preCode, {
       readJs: (filePath, token) => {
         if (localFiles.hasOwnProperty(filePath)) {
           return { sync: true, value: () => {


### PR DESCRIPTION
`Property 'loadDependencies' in type 'WebNakoCompiler' is not assignable to the same property in base type 'NakoCompiler'.` の警告を解消しました。