### PR TITLE
.nako3ファイルを取り込むとそれ以降の取り込み文が無視されるバグの修正

### DIFF
--- a/src/nako3.js
+++ b/src/nako3.js
@@ -212,7 +212,7 @@ class NakoCompiler {
             return inner(code, item.filePath, '')
           }
           if (content.sync) {
-            return registerFile(content.value)
+            registerFile(content.value)
           } else {
             tasks.push(content.value.then((res) => registerFile(res)))
           }

--- a/test/node/require_nako3_test.js
+++ b/test/node/require_nako3_test.js
@@ -19,4 +19,20 @@ describe('require_nako3_test', () => {
   it('「回」が1回だけ分割されることを確認する', () => {
     cmp('！「' + __dirname + '/kai_test.nako3」を取り込む', '')
   })
+  it('.jsと.nako3を同時に読み込む - .jsが先の場合', () => {
+    const nako = new CNako3()
+    const code =
+      `!「plugin_csv」を取り込む。\n` +
+      `!「${__dirname}/requiretest.nako3」を取り込む。\n`
+    nako.loadDependencies(code, 'main.nako3', '')
+    nako.run(code, 'main.nako3') // エラーが飛ばないことを確認
+  })
+  it('.jsと.nako3を同時に読み込む - .nako3が先の場合', () => {
+    const nako = new CNako3()
+    const code =
+      `!「${__dirname}/requiretest.nako3」を取り込む。\n` +
+      `!「plugin_csv」を取り込む。\n`
+    nako.loadDependencies(code, 'main.nako3', '')
+    nako.run(code, 'main.nako3') // エラーが飛ばないことを確認
+  })
 })


### PR DESCRIPTION
https://github.com/yy0931/nadesiko3-vscode/issues/5 の修正です。for文の中に誤ってreturnを書いていました。
