### PR TITLE
WebWorkerのワーカー側のエラーをブラウザ側のloggerに通知するよう修正。

### DIFF
--- a/src/plugin_webworker.js
+++ b/src/plugin_webworker.js
@@ -21,10 +21,18 @@ const PluginWebWorker = {
                   work.ondata.apply(sys, [value, event])
                 }
                 break;
+              case 'error':
+                sys.logger.error(value.noColor)
+                break;
             }
           }
           work.onerror = (event) => {
-            throw new Error(event.message)
+            const e = new Error(typeof event.message !== 'undefined' ? event.message : 'no message')
+            sys.logger.error(e)
+          }
+          work.onerrormessage = (event) => {
+            const e = new Error(typeof event.message !== 'undefined' ? event.message : 'no message')
+            sys.logger.error(e)
           }
         },
         inWorker: () => {
@@ -299,6 +307,8 @@ const PluginWebWorker = {
               func: Object.assign({}, sys.compiler.funclist[data], { fn: null })
             }
           })
+        } else {
+          throw new Error('指定した名前のユーザ関数もしくはグローバル変数がありません:' + data)
         }
       })
       if (obj.length > 0) {

--- a/src/wnako3.js
+++ b/src/wnako3.js
@@ -149,7 +149,7 @@ if (typeof (navigator) === 'object' && !navigator.exportWNako3) {
     if (isAutoRun) {nako3.runNakoScript()}
   }, false)
   window.addEventListener('beforeunload', (e) => {
-    if (mocha){mocha.dispose()}
+    if (typeof mocha !== 'undefined'){mocha.dispose()}
   })
 } else
   {module.exports = WebNakoCompiler}

--- a/src/wnako3webworker.js
+++ b/src/wnako3webworker.js
@@ -26,6 +26,13 @@ if (typeof (navigator) === 'object' && self && self instanceof WorkerGlobalScope
   nako3Compiler.addPluginObject('PluginBrowserInWorker', PluginBrowserInWorker)
   nako3Compiler.addPluginObject('PluginWorker', PluginWorker)
 
+  nako3Compiler.logger.addListener("error", function(obj) {
+    self.postMessage({
+      type: 'error',
+      data: obj
+    })
+  }, false)
+
   self.onmessage = (event) => {
     const data = event.data || { type: '', data: '' }
     const type = data.type || ''


### PR DESCRIPTION
WebWorkerのワーカー側のエラーをブラウザ側のloggerに通知するよう修正。
NAKOワーカー転送で存在しない名前が含まれていたらエラーにするよう修正。
(fix #919)
