### PR TITLE
CIのPromiseを使った処理をasync/awaitを使って記述する

### DIFF
--- a/.github/workflows/textlint.yml
+++ b/.github/workflows/textlint.yml
@@ -49,24 +49,19 @@ jobs:
             }
             console.log("call issues.listComments:")
             console.log(issues_listComments_params)
-            github.issues.listComments(issues_listComments_params).then(response =>
-              response.data.filter(
-                comment=>comment.user.id==41898282 && comment.body.startsWith('日本語の')
-              ).map(
-                comment=>comment.id
-              ).forEach(
-                comment_id => {
-                  const issues_deleteComment_params = {
-                    comment_id: comment_id,
-                    owner: context.repo.owner,
-                    repo: context.repo.repo
-                  }
-                  console.log("call issues.deleteComment:")
-                  console.log(issues_deleteComment_params)
-                  github.issues.deleteComment(issues_deleteComment_params)
-                }
-              )
-            )
+            const response = await github.issues.listComments(issues_listComments_params)
+            await Promise.all(response.data.filter(
+              comment=>comment.user.id==41898282 && comment.body.startsWith('日本語の')
+            ).map(async comment => {
+              const issues_deleteComment_params = {
+                comment_id: comment.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo
+              }
+              console.log("call issues.deleteComment:")
+              console.log(issues_deleteComment_params)
+              await github.issues.deleteComment(issues_deleteComment_params)
+            }))
 
             const result = `${{steps.lint.outputs.result}}`
             const issues_createComment_params = {
@@ -77,7 +72,7 @@ jobs:
             }
             console.log("call issues.createComment:")
             console.log(issues_createComment_params)
-            github.issues.createComment(issues_createComment_params)
+            await github.issues.createComment(issues_createComment_params)
       - name: Exit
         if: github.event.pull_request.head.repo.full_name != github.repository && steps.lint.outcome == 'failure'
         run: exit 1
@@ -143,27 +138,28 @@ jobs:
             }
             console.log("call pulls.list:")
             console.log(pulls_list_params)
-            github.pulls.list(pulls_list_params).then(list_res => {
-              if (list_res.data.length === 0) {
-                const pulls_create_params = {
-                  title: "日本語修正 (修正する場合はPRをマージしてください) #${{github.event.pull_request.number}}",
-                  body: "日本語を修正しました。本PRをマージすると #${{github.event.pull_request.number}} に修正が適用されます。",
-                  ...pull_params
-                }
-                console.log("call pulls.create:")
-                console.log(pulls_create_params)
-                github.pulls.create(pulls_create_params).then(create_res => {
-                  const issues_add_assignees_params = {
-                    issue_number: create_res.data.number,
-                    assignees: ["${{github.event.pull_request.user.login}}"],
-                    ...common_params
-                  }
-                  console.log("call issues.addAssignees:")
-                  console.log(issues_add_assignees_params)
-                  github.issues.addAssignees(issues_add_assignees_params)
-                })
-              }
-            })
+            const list_res = await github.pulls.list(pulls_list_params)
+
+            if (0 < list_res.data.length) {
+              return
+            }
+
+            const pulls_create_params = {
+              title: "日本語修正 (修正する場合はPRをマージしてください) #${{github.event.pull_request.number}}",
+              body: "日本語を修正しました。本PRをマージすると #${{github.event.pull_request.number}} に修正が適用されます。",
+              ...pull_params
+            }
+            console.log("call pulls.create:")
+            console.log(pulls_create_params)
+            const create_res = await github.pulls.create(pulls_create_params)
+            const issues_add_assignees_params = {
+              issue_number: create_res.data.number,
+              assignees: ["${{github.event.pull_request.user.login}}"],
+              ...common_params
+            }
+            console.log("call issues.addAssignees:")
+            console.log(issues_add_assignees_params)
+            await github.issues.addAssignees(issues_add_assignees_params)
       # 既にformat修正のPRがある状態で、手動でformatを修正した場合、format修正のPRを閉じる
       - name: Close PullRequest
         uses: actions/github-script@v3
@@ -184,26 +180,24 @@ jobs:
             }
             console.log("call pulls.list:")
             console.log(pulls_list_params)
-            github.pulls.list(pulls_list_params).then(res => {
-              for(const data of res.data){
-                const pulls_update_params = {
-                  pull_number: data.number,
-                  state: "closed",
-                  ...common_params
-                }
-                console.log("call pulls.update:")
-                console.log(pulls_update_params)
-                github.pulls.update(pulls_update_params).then(res2 => {
-                  const git_deleteRef_params = {
-                    ref: "heads/" + head_name,
-                    ...common_params
-                  }
-                  console.log("call git.deleteRef:")
-                  console.log(git_deleteRef_params)
-                  github.git.deleteRef(git_deleteRef_params)
-                })
+            const res = await github.pulls.list(pulls_list_params)
+            await Promise.all(res.data.map(data => {
+              const pulls_update_params = {
+                pull_number: data.number,
+                state: "closed",
+                ...common_params
               }
-            })
+              console.log("call pulls.update:")
+              console.log(pulls_update_params)
+              await github.pulls.update(pulls_update_params)
+              const git_deleteRef_params = {
+                ref: "heads/" + head_name,
+                ...common_params
+              }
+              console.log("call git.deleteRef:")
+              console.log(git_deleteRef_params)
+              await github.git.deleteRef(git_deleteRef_params)
+            }))
       - name: Exit
         if: steps.show_diff.outputs.diff != ''
         run: exit 1

--- a/.github/workflows/textlint.yml
+++ b/.github/workflows/textlint.yml
@@ -48,7 +48,7 @@ jobs:
              repo: context.repo.repo
             }
             console.log("call issues.listComments:", issues_listComments_params)
-            const issue_comments = (await github.issues.listComments(issues_listComments_params)).data.filter(
+            const issue_comments = (await github.paginate(github.issues.listComments, issues_listComments_params)).filter(
               issue_comment => issue_comment.user.id==41898282 && issue_comment.body.startsWith('日本語の')
             )
 
@@ -114,10 +114,27 @@ jobs:
           git add -u
           git commit -m "日本語修正"
           git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git HEAD:refs/heads/fix-text-${{github.event.pull_request.head.ref}}
+      - name: Get PullRequests
+        uses: actions/github-script@v3
+        if: steps.show_diff.outputs.diff != ''
+        id: get_pull_requests
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const pulls_list_params = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: "kujirahand:fix-text-${{github.event.pull_request.head.ref}}",
+              base: "${{github.event.pull_request.head.ref}}",
+              state: "open"
+            }
+            console.log("call pulls.list:", pulls_list_params)
+            const pulls = await github.paginate(github.pulls.list, pulls_list_params)
+            return pulls.length
       # pushしたブランチでPRを作る
       - name: Create PullRequest
         uses: actions/github-script@v3
-        if: steps.show_diff.outputs.diff != ''
+        if: steps.show_diff.outputs.diff != '' && steps.get_pull_requests.outputs.result == 0
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -125,26 +142,12 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo
             }
-            const pull_params = {
+            const pulls_create_params = {
               head: "kujirahand:fix-text-${{github.event.pull_request.head.ref}}",
               base: "${{github.event.pull_request.head.ref}}",
-              ...common_params
-            }
-            const pulls_list_params = {
-              state: "open",
-              ...pull_params
-            }
-            console.log("call pulls.list:", pulls_list_params)
-            const pulls = (await github.pulls.list(pulls_list_params)).data
-
-            if (0 < pulls.length) {
-              return
-            }
-
-            const pulls_create_params = {
               title: "日本語修正 (修正する場合はPRをマージしてください) #${{github.event.pull_request.number}}",
               body: "日本語を修正しました。本PRをマージすると #${{github.event.pull_request.number}} に修正が適用されます。",
-              ...pull_params
+              ...common_params
             }
             console.log("call pulls.create:", pulls_create_params)
             const create_pull_res = (await github.pulls.create(pulls_create_params)).data
@@ -174,7 +177,7 @@ jobs:
               ...common_params
             }
             console.log("call pulls.list:", pulls_list_params)
-            const pulls = (await github.pulls.list(pulls_list_params)).data
+            const pulls = await github.paginate(github.pulls.list,pulls_list_params)
 
             for (const pull of pulls) {
               const pulls_update_params = {

--- a/.github/workflows/textlint.yml
+++ b/.github/workflows/textlint.yml
@@ -47,21 +47,20 @@ jobs:
               owner: context.repo.owner,
              repo: context.repo.repo
             }
-            console.log("call issues.listComments:")
-            console.log(issues_listComments_params)
-            const response = await github.issues.listComments(issues_listComments_params)
-            await Promise.all(response.data.filter(
-              comment=>comment.user.id==41898282 && comment.body.startsWith('日本語の')
-            ).map(async comment => {
+            console.log("call issues.listComments:", issues_listComments_params)
+            const issue_comments = (await github.issues.listComments(issues_listComments_params)).data.filter(
+              issue_comment => issue_comment.user.id==41898282 && issue_comment.body.startsWith('日本語の')
+            )
+
+            for (const issue_comment of issue_comments) {
               const issues_deleteComment_params = {
-                comment_id: comment.id,
+                comment_id: issue_comment.id,
                 owner: context.repo.owner,
                 repo: context.repo.repo
               }
-              console.log("call issues.deleteComment:")
-              console.log(issues_deleteComment_params)
+              console.log("call issues.deleteComment:", issues_deleteComment_params)
               await github.issues.deleteComment(issues_deleteComment_params)
-            }))
+            }
 
             const result = `${{steps.lint.outputs.result}}`
             const issues_createComment_params = {
@@ -70,8 +69,7 @@ jobs:
               repo: context.repo.repo,
               body: "日本語のLint結果\n```\n"+result+"\n```"
             }
-            console.log("call issues.createComment:")
-            console.log(issues_createComment_params)
+            console.log("call issues.createComment:", issues_createComment_params)
             await github.issues.createComment(issues_createComment_params)
       - name: Exit
         if: github.event.pull_request.head.repo.full_name != github.repository && steps.lint.outcome == 'failure'
@@ -136,11 +134,10 @@ jobs:
               state: "open",
               ...pull_params
             }
-            console.log("call pulls.list:")
-            console.log(pulls_list_params)
-            const list_res = await github.pulls.list(pulls_list_params)
+            console.log("call pulls.list:", pulls_list_params)
+            const pulls = (await github.pulls.list(pulls_list_params)).data
 
-            if (0 < list_res.data.length) {
+            if (0 < pulls.length) {
               return
             }
 
@@ -149,16 +146,14 @@ jobs:
               body: "日本語を修正しました。本PRをマージすると #${{github.event.pull_request.number}} に修正が適用されます。",
               ...pull_params
             }
-            console.log("call pulls.create:")
-            console.log(pulls_create_params)
-            const create_res = await github.pulls.create(pulls_create_params)
+            console.log("call pulls.create:", pulls_create_params)
+            const create_pull_res = (await github.pulls.create(pulls_create_params)).data
             const issues_add_assignees_params = {
-              issue_number: create_res.data.number,
+              issue_number: create_pull_res.number,
               assignees: ["${{github.event.pull_request.user.login}}"],
               ...common_params
             }
-            console.log("call issues.addAssignees:")
-            console.log(issues_add_assignees_params)
+            console.log("call issues.addAssignees:", issues_add_assignees_params)
             await github.issues.addAssignees(issues_add_assignees_params)
       # 既にformat修正のPRがある状態で、手動でformatを修正した場合、format修正のPRを閉じる
       - name: Close PullRequest
@@ -178,26 +173,24 @@ jobs:
               state: "open",
               ...common_params
             }
-            console.log("call pulls.list:")
-            console.log(pulls_list_params)
-            const res = await github.pulls.list(pulls_list_params)
-            await Promise.all(res.data.map(async data => {
+            console.log("call pulls.list:", pulls_list_params)
+            const pulls = (await github.pulls.list(pulls_list_params)).data
+
+            for (const pull of pulls) {
               const pulls_update_params = {
-                pull_number: data.number,
+                pull_number: pull.number,
                 state: "closed",
                 ...common_params
               }
-              console.log("call pulls.update:")
-              console.log(pulls_update_params)
+              console.log("call pulls.update:", pulls_update_params)
               await github.pulls.update(pulls_update_params)
               const git_deleteRef_params = {
                 ref: "heads/" + head_name,
                 ...common_params
               }
-              console.log("call git.deleteRef:")
-              console.log(git_deleteRef_params)
+              console.log("call git.deleteRef:", git_deleteRef_params)
               await github.git.deleteRef(git_deleteRef_params)
-            }))
+            }
       - name: Exit
         if: steps.show_diff.outputs.diff != ''
         run: exit 1

--- a/.github/workflows/textlint.yml
+++ b/.github/workflows/textlint.yml
@@ -181,7 +181,7 @@ jobs:
             console.log("call pulls.list:")
             console.log(pulls_list_params)
             const res = await github.pulls.list(pulls_list_params)
-            await Promise.all(res.data.map(data => {
+            await Promise.all(res.data.map(async data => {
               const pulls_update_params = {
                 pull_number: data.number,
                 state: "closed",


### PR DESCRIPTION
CIのPromiseを使った処理をasync/awaitを使って記述することでコードの見通しをよくします。
また、以下の部分も修正しています。
* 早期returnできる箇所を別のstepに分離してstepのifで実行を制御
* `console.log` をまとめる
* GitHub APIのレスポンスを入れる変数の変数名修正
* GitHub API ( `list*` ) のページネーション対応