### PR TITLE
CI textlint で使用するNode.jsのバージョンを16系にする

### DIFF
--- a/.github/workflows/textlint.yml
+++ b/.github/workflows/textlint.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [ 16.x ]
 
     steps:
       - uses: actions/checkout@v2
@@ -88,7 +88,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [ 16.x ]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
CI `textlint` ではNode.js 12系が使われていますが、もうじき16系がACTIVEになるので、16系に変更します。

Node.jsのリリース情報: https://nodejs.org/ja/about/releases/