### PR TITLE
CI textlint 修正

### DIFF
--- a/.github/workflows/textlint.yml
+++ b/.github/workflows/textlint.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Lint files
         id: lint
         run: |
-          result=$(yarn textlint $(find . -type f -name "*.md" -not -name "LICENSE.md" -not -path "./node_modules/*") 2>&1) || true
+          result="$(yarn run textlint 2>&1)" || true
           echo "$result"
           result="${result//'%'/'%25'}"
           result="${result//$'\n'/'%0A'}"
@@ -105,7 +105,7 @@ jobs:
       - name: Format files
         id: format
         run: |
-          yarn textlint --fix $(find . -type f -name "*.md" -not -name "LICENSE.md" -not -path "./node_modules/*")
+          yarn run textlint:fix
         continue-on-error: true
       # 差分があったときは差分を出力する
       - name: Show diff

--- a/doc/docgen.md
+++ b/doc/docgen.md
@@ -18,4 +18,4 @@ npm build:command
 cnako3 batch/jsplugin2text.nako3 /plugin/path/nadesiko3-xxx
 ```
 
-生成したテキストは、konawiki3 形式となっている。
+生成したテキストは、konawiki3形式となっている。

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "analyze": "webpack-bundle-analyzer release/stats.json",
     "release": "npm run build && npm run test:all && npm publish",
     "textlint": "textlint *.md && textlint doc/*.md && textlint batch/*.md && textlint tools/*.md",
+    "textlint:fix": "textlint --fix *.md && textlint --fix doc/*.md && textlint --fix batch/*.md && textlint --fix tools/*.md",
     "extlib:clean": "rm -f -r demo/extlib/*",
     "extlib:install": "node src/cnako3.js batch/download-extlib.nako3"
   },


### PR DESCRIPTION
https://github.com/kujirahand/nadesiko3/commit/a6947ad3ba09c28b8f0f6d9de3dfe37705e75fb9 でscriptとして `yarn run textlint` が追加されたことが原因でCI `textlint` が正常に動作しなくなっているため修正します。