### PR TITLE
非同期モードでのcallstack/変数stackを必要に応じて分離(#1110)

### DIFF
--- a/src/plugin_browser.js
+++ b/src/plugin_browser.js
@@ -89,6 +89,7 @@ const PluginBrowser = {
           sys.__v0['対象イベント'] = e
           // 追加データが得られる場合
           if (setHandler) { setHandler(e, sys) }
+          if (sys.__genMode === '非同期モード') { sys.newenv = true }
           return func(e, sys)
         }
         // add

--- a/src/plugin_browser_ajax.js
+++ b/src/plugin_browser_ajax.js
@@ -13,7 +13,8 @@ module.exports = {
         return res.text()
       }).then(text => {
         sys.__v0['対象'] = text
-        callback(text)
+        if (sys.__genMode === '非同期モード') { sys.newenv = true }
+        callback(text, sys)
       }).catch(err => {
         console.log('[fetch.error]', err)
         sys.__v0['AJAX:ONERROR'](err)
@@ -29,7 +30,7 @@ module.exports = {
       if (sys.__genMode !== '非同期モード') {
         throw new Error('『AJAX受信』を使うには、プログラムの冒頭で「!非同期モード」と宣言してください。')
       }
-      sys.async = true
+      const sysenv = sys.setAsync(sys)
       let options = sys.__v0['AJAXオプション']
       if (options === '') { options = { method: 'GET' } }
       // fetch 実行
@@ -41,7 +42,7 @@ module.exports = {
         }
       }).then(text => {
         sys.__v0['対象'] = text
-        sys.nextAsync(sys)
+        sys.compAsync(sys, sysenv)
       }).catch(err => {
         console.error('[AJAX受信のエラー]', err)
         sys.__errorAsync(err, sys)

--- a/src/plugin_node.js
+++ b/src/plugin_node.js
@@ -882,7 +882,7 @@ const PluginNode = {
       if (sys.__genMode !== '非同期モード') {
         throw new Error('『AJAX受信』を使うには、プログラムの冒頭で「!非同期モード」と宣言してください。')
       }
-      sys.async = true
+      const sysenv = sys.setAsync(sys)
       let options = sys.__v0['AJAXオプション']
       if (options === '') { options = { method: 'GET' } }
       // fetch 実行
@@ -894,7 +894,7 @@ const PluginNode = {
         }
       }).then(text => {
         sys.__v0['対象'] = text
-        sys.nextAsync(sys)
+        sys.compAsync(sys, sysenv)
       }).catch(err => {
         console.error('[AJAX受信のエラー]', err)
         sys.__errorAsync(err, sys)

--- a/src/plugin_system.js
+++ b/src/plugin_system.js
@@ -1809,9 +1809,9 @@ const PluginSystem = {
     pure: false,
     fn: function (n, sys) {
       if (sys.__genMode === '非同期モード') {
-        sys.async = true
+        const sysenv = sys.setAsync(sys)
         setTimeout(() => {
-          sys.nextAsync(sys)
+          sys.compAsync(sys, sysenv)
         }, n * 1000)
       } else {
         if (sys.resolve === undefined) { throw new Error('『秒待機』命令は『!非同期モード』で使ってください。') }
@@ -1850,6 +1850,7 @@ const PluginSystem = {
         // 使用中リストに追加したIDを削除
         const i = sys.__timeout.indexOf(timerId)
         if (i >= 0) { sys.__timeout.splice(i, 1) }
+        if (sys.__genMode === '非同期モード') { sys.newenv = true }
         try {
           f(timerId, sys)
         } catch (e) {
@@ -1874,6 +1875,7 @@ const PluginSystem = {
       if (typeof f === 'string') { f = sys.__findFunc(f, '秒毎') }
       // タイマーをセット
       const timerId = setInterval(() => {
+        if (sys.__genMode === '非同期モード') { sys.newenv = true }
         f(timerId, sys)
       }, parseFloat(n) * 1000)
       // タイマーIDを追加


### PR DESCRIPTION
貯蔵庫で非同期モードがハングアップするので参考が出せませんが・・・
```
!非同期モード
カウンタ = ０
描画中キャンバスをクリックした時には
　カウンタ = カウンタ＋１
　ローカルカウンタ = カウンタ
　「S:{ローカルカウンタ}」を表示
　１秒待機
　「E:{ローカルカウンタ}」を表示
ここまで
```
のようなプログラムを実行して、連続で３回クリックした時、
誤　S1,S2,S3,E3,E2,E1 or S1,S3,S3,E3,E3,E3
のようになっていたような記憶があります。
正　S1,S2,S3,E1,E2,E3
です。
以下の修正をしています。
・イベントからのcallbackと秒後について、発火毎にcallstack/変数スタックが別々に作成(sysenv)されます。コールバック前にsys.newenv = trueと目印を置いているので、命令毎に対応が必要です(※)
・秒待機の際に戻るべきsysenvを記憶し復帰時にsysenvを明示的に渡すことで元のcallstack/変数スタックに戻れるようにしています。そのため、命令側に以前と互換性のない修正が必要です（sysenvの保持と復帰時に渡す）
※または全てのユーザ関数はcallstackに積まれず独立した変数スタックを持つ(常にsysenvを作成する)ことにするか。

なお、上記の例の通り再入自体は禁止していません。自動的な再入禁止を突き詰めて考えると非同期モード自体が不要という状態に近いのと、発火されてしまっているイベントを勝手に破棄するのと開発者に混乱をきたしそうであるためです。
