### PR TITLE
cnakoで、リダイレクトで「尋ねる」をしたとき、入力がエコーされるのを無効に

### DIFF
--- a/src/plugin_node.mjs
+++ b/src/plugin_node.mjs
@@ -685,12 +685,16 @@ export default {
         asyncFn: true,
         fn: function (msg) {
             return new Promise((resolve, reject) => {
-                const rl = readline.createInterface(process.stdin, process.stdout);
+                const rl = readline.createInterface({
+                    input: process.stdin,
+                    output: process.stdout,
+                    terminal: false
+                });
                 if (!rl) {
                     reject(new Error('『尋』命令で標準入力が取得できません'));
                     return;
                 }
-                rl.question(msg, (buf) => {
+                rl.question((msg === undefined ? "" : msg), (buf) => {
                     rl.close();
                     if (buf && buf.match(/^[0-9.]+$/)) {
                         buf = parseFloat(buf);

--- a/src/plugin_node.mts
+++ b/src/plugin_node.mts
@@ -634,12 +634,16 @@ export default {
     asyncFn: true,
     fn: function (msg: string): Promise<any> {
       return new Promise((resolve, reject) => {
-        const rl = readline.createInterface(process.stdin, process.stdout)
+        const rl = readline.createInterface({
+          input: process.stdin,
+          output: process.stdout,
+          terminal: false
+        })
         if (!rl) {
           reject(new Error('『尋』命令で標準入力が取得できません'))
           return
         }
-        rl.question(msg, (buf: any) => {
+        rl.question((msg === undefined ? "" : msg), (buf: any) => {
           rl.close()
           if (buf && buf.match(/^[0-9.]+$/)) { buf = parseFloat(buf) }
           resolve(buf)


### PR DESCRIPTION
以下のコードを cnako で実行したとき、
```
(『』と尋ねる)*2 を表示
```
`echo "123" | ./bin/cnako3 tazuneru.nako3` と実行すると、入力がエコーされて以下のように標準出力されます。
```
123
246
```
しかし、（恐らく一般に）標準入力をそのまま標準出力にエコーされる挙動は、コマンドラインプログラムとして歓迎されません。（もしもエコーしたいならコード側でエコーの記述を書くことで実現できますが、逆の場合、抑制したくても処理系システム上不可能になってしまうからです）

関連する話題として、国内外の有数の競技プログラミングサービス AtCoder にて、2023年の言語アップデートにより、なでしこ3 を追加する方針がポジティブに進んでおり、仮・新ジャッジに実際に導入されています。
https://docs.google.com/spreadsheets/d/1HXyOXt5bKwhKWXruzUvfMFHQtBxfZQ0047W7VVObnXI/edit#gid=0
https://atcoder.jp/contests/language-test-202301/rules
現在この新ジャッジは仮状態であり、残念なことに cnako が正しくインストールされていないために提出するとエラーになってしまいますが、今後数回予定されているアップデート作業により修正される見込みです。

なでしこで競技プログラミングを行えるようになることは非常に歓迎されるべきことだと思いますが、残念ながら「尋ねる」命令を使って入力を得ようとしたとき、入力がエコーされる仕様によって正しく問題を解くことができません。
代わりに `「/dev/stdin」から開く` を使うことで回避はできますが、入門者にとっても、なでしこ熟練者にとってもこの命令を使って無理やり解くのは快適とは程遠いでしょう。
そのため、「尋ねる」命令を使って快適にプログラミングに取り組めるように、この変更を提案します。


AtCoder は近年、情報オリンピック（JOI）の予選・本選にも使用されており、AtCoder でなでしこが使用できるようになることは JOI でもなでしこが利用できるようになることを意味します。また近年、学校の授業として JOI 1次予選にクラスで参加する中高・専門学校も増えてきています。
https://www.ioi-jp.org/joi/2022/2023-yo1-yo2-joigho-rule.html


なお、この変更はリダイレクトを行った際の挙動修正であり、cnako3 をそのまま実行したときの挙動には変更を加えません。
以下は `123` を対話形式で手動で入力したときの様子です。
```
$ ./bin/cnako3 tazuneru.nako3
123
246
```

なお、ソースコード修正に含まれている
```
msg === undefined ? "" : msg)
```
は、
```
(尋ねる)*2 を表示
```
というなでしこプログラムを実行した時に、修正前はエラー無く実行できるものの、`terminal: false` により undefined を渡したときの question の挙動が変わり、undefined を渡すとエラーになってしまう問題に対処するものです。






