### PR TITLE
cnakoの「尋」命令をパイプで複数回呼べるように

### DIFF
--- a/src/plugin_node.mjs
+++ b/src/plugin_node.mjs
@@ -709,8 +709,11 @@ export default {
             if (msg !== undefined)
                 process.stdout.write(msg);
             let line = await sys.__linegetter();
+            if (!line) {
+                throw new Error('『尋』命令で標準入力が取得できません。最後の入力が終わった可能性があります');
+            }
             sys.__linereader.pause();
-            if (line & line.match(/^[0-9.]+$/)) {
+            if (line.match(/^[0-9.]+$/)) {
                 line = parseFloat(line);
             }
             return line;
@@ -729,6 +732,9 @@ export default {
             if (msg !== undefined)
                 process.stdout.write(msg);
             let line = await sys.__linegetter();
+            if (!line) {
+                throw new Error('『文字尋』命令で標準入力が取得できません。最後の入力が終わった可能性があります');
+            }
             sys.__linereader.pause();
             return line;
         }

--- a/src/plugin_node.mts
+++ b/src/plugin_node.mts
@@ -658,8 +658,11 @@ export default {
       sys.__linereader.resume()
       if (msg !== undefined) process.stdout.write(msg)
       let line = await sys.__linegetter()
+      if (!line) {
+        throw new Error('『尋』命令で標準入力が取得できません。最後の入力が終わった可能性があります')
+      }
       sys.__linereader.pause()
-      if (line & line.match(/^[0-9.]+$/)) {
+      if (line.match(/^[0-9.]+$/)) {
         line = parseFloat(line)
       }
       return line
@@ -677,6 +680,9 @@ export default {
       sys.__linereader.resume()
       if (msg !== undefined) process.stdout.write(msg)
       let line = await sys.__linegetter()
+      if (!line) {
+        throw new Error('『文字尋』命令で標準入力が取得できません。最後の入力が終わった可能性があります')
+      }
       sys.__linereader.pause()
       return line
     }

--- a/src/plugin_node.mts
+++ b/src/plugin_node.mts
@@ -62,6 +62,25 @@ export default {
       sys.__v0['ナデシコランタイム'] = path.basename(process.argv[0])
       sys.__v0['母艦パス'] = sys.__getBokanPath()
       sys.__v0['AJAX:ONERROR'] = null
+
+
+      // 『尋』『文字尋』『標準入力取得時』『標準入力全取得』のための一時変数
+      // .pause() しないと Ctrl+D するまで永遠に入力待ちになる
+      // .resume() することで標準入力の受け取り待ちになる
+      sys.__linereader = readline.createInterface({ input: process.stdin , output: process.stdout })
+      if (sys.__linereader === null) {
+        sys.__linegetter = null
+      } else {
+        sys.__linegetter = (function () {
+          const getLineGen = (async function* () {
+            for await (const line of sys.__linereader) {
+              yield line
+            }
+          })()
+          return async () => ((await getLineGen.next()).value)
+        })()
+        sys.__linereader.pause()
+      }
     }
   },
   // @ファイル入出力
@@ -617,12 +636,12 @@ export default {
     type: 'func',
     josi: [['を']],
     pure: true,
-    fn: function (callback: any) {
-      const reader = readline.createInterface({
-        input: process.stdin,
-        output: process.stdout
-      })
-      reader.on('line', function (line) {
+    fn: function (callback: any, sys: any) {
+      if (!sys.__linereader) {
+        throw new Error('『標準入力取得時』命令で標準入力が取得できません')
+      }
+      sys.__linereader.resume()
+      sys.__linereader.on('line', function (line :string) {
         callback(line)
       })
     }
@@ -632,22 +651,18 @@ export default {
     josi: [['と', 'を']],
     pure: true,
     asyncFn: true,
-    fn: function (msg: string, sys: any): Promise<string> {
-      return new Promise((resolve, reject) => {
-        // process.stdin.resume()
-        const cli = readline.createInterface(process.stdin, process.stdout)
-        if (!cli) {
-          reject(new Error('『尋』命令で標準入力が取得できません'))
-          return
-        }
-        cli.question(msg, (line: any) => {
-          if (line & line.match(/^[0-9.]+$/)) {
-            line = parseFloat(line)
-          }
-          cli.close()
-          resolve(line)
-        })
-      })
+    fn: async function (msg: string, sys: any) {
+      if (!sys.__linereader) {
+        throw new Error('『尋』命令で標準入力が取得できません')
+      }
+      sys.__linereader.resume()
+      if (msg !== undefined) process.stdout.write(msg)
+      let line = await sys.__linegetter()
+      sys.__linereader.pause()
+      if (line & line.match(/^[0-9.]+$/)) {
+        line = parseFloat(line)
+      }
+      return line
     }
   },
   '文字尋': { // @標準入力を一行取得する。ただし自動で数値に変換しない // @もじたずねる
@@ -655,18 +670,15 @@ export default {
     josi: [['と', 'を']],
     pure: true,
     asyncFn: true,
-    fn: function (msg: string): Promise<any> {
-      return new Promise((resolve, reject) => {
-        const cli = readline.createInterface(process.stdin, process.stdout)
-        if (!cli) {
-          reject(new Error('『尋』命令で標準入力が取得できません'))
-          return
-        }
-        cli.question(msg, (buf: any) => {
-          cli.close()
-          resolve(buf)
-        })
-      })
+    fn: async function (msg: string, sys: any) {
+      if (!sys.__linereader) {
+        throw new Error('『文字尋』命令で標準入力が取得できません')
+      }
+      sys.__linereader.resume()
+      if (msg !== undefined) process.stdout.write(msg)
+      let line = await sys.__linegetter()
+      sys.__linereader.pause()
+      return line
     }
   },
   '標準入力全取得': { // @標準入力を全部取得して返す // @ひょうじゅんにゅうりょくぜんしゅとく
@@ -674,18 +686,18 @@ export default {
     josi: [],
     pure: true,
     asyncFn: true,
-    fn: function (): Promise<string> {
+    fn: function (sys: any): Promise<string> {
       return new Promise((resolve, _reject) => {
         let dataStr = ''
-        const reader = readline.createInterface({
-          input: process.stdin,
-          output: process.stdout
-        })
-        reader.on('line', (line) => {
+        if (!sys.__linereader) {
+          throw new Error('『標準入力全取得』命令で標準入力が取得できません')
+        }
+        sys.__linereader.resume()
+        sys.__linereader.on('line', (line : string) => {
           dataStr += line + '\n'
         })
-        reader.on('close', () => {
-          reader.close()
+        sys.__linereader.on('close', () => {
+          sys.__linereader.close()
           resolve(dataStr)
         })
       })


### PR DESCRIPTION
cnakoの「尋」命令がリダイレクトやパイプを用いたとき、複数回呼べず2行目以降が取得できなかった問題を修正。

方針としては `sys.__linereader` に readline.createInterface を開いておき、pause と resume を切り替える。

標準入力を使用する『尋』『文字尋』『標準入力取得時』『標準入力全取得』命令すべてこの sys を使用するように変更しました。

https://nadesi.com/cgi/kaizen3/?m=thread&threadid=66
