### PR TITLE
cnako で尋ねたとき、数値判定を正しく

### DIFF
--- a/src/plugin_node.mjs
+++ b/src/plugin_node.mjs
@@ -708,15 +708,18 @@ export default {
             sys.__linereader.resume();
             if (msg !== undefined)
                 process.stdout.write(msg);
-            let line = await sys.__linegetter();
+            const line = await sys.__linegetter();
             if (!line) {
                 throw new Error('『尋』命令で標準入力が取得できません。最後の入力が終わった可能性があります');
             }
             sys.__linereader.pause();
-            if (line.match(/^[0-9.]+$/)) {
-                line = parseFloat(line);
+            const line_as_number = Number(line);
+            if (isNaN(line_as_number)) {
+                return line;
             }
-            return line;
+            else {
+                return line_as_number;
+            }
         }
     },
     '文字尋': {

--- a/src/plugin_node.mts
+++ b/src/plugin_node.mts
@@ -656,15 +656,17 @@ export default {
       }
       sys.__linereader.resume()
       if (msg !== undefined) process.stdout.write(msg)
-      let line = await sys.__linegetter()
+      const line = await sys.__linegetter()
       if (!line) {
         throw new Error('『尋』命令で標準入力が取得できません。最後の入力が終わった可能性があります')
       }
       sys.__linereader.pause()
-      if (line.match(/^[0-9.]+$/)) {
-        line = parseFloat(line)
+      const line_as_number = Number(line)
+      if (isNaN(line_as_number)) {
+        return line
+      } else {
+        return line_as_number
       }
-      return line
     }
   },
   '文字尋': { // @標準入力を一行取得する。ただし自動で数値に変換しない // @もじたずねる


### PR DESCRIPTION
cnako で「尋」命令を使うと数値のときは勝手に数値変換してくれるが、正規表現が雑で、
「.」
等を入力すると NaN になってしまうので、`Number()` 関数で変換したとき、正しい数値じゃなかったときは NaN になる事を利用して判定するように変更