### PR TITLE
Nakoワーカーを名前空間と文字列定数プールへの対応。

### DIFF
--- a/src/wnako3webworker.mjs
+++ b/src/wnako3webworker.mjs
@@ -54,6 +54,23 @@ if (typeof (navigator) === 'object' && self && self instanceof WorkerGlobalScope
             nako3Compiler.__varslist[1][o.name] = () => {}
           } else if (o.type === 'val') {
             nako3Compiler.__varslist[2][o.name] = o.content
+          } else if (o.type === 'env') {
+            if (o.name === 'modlist') {
+              for (const modInfo of o.content) {
+                if (nako3Compiler.lexer.modList.indexOf(modInfo.name) < 0) {
+                  nako3Compiler.lexer.modList.push(modInfo.name)
+                }
+                if (modInfo.export != null && !nako3Compiler.moduleExport.hasOwnProperty(modInfo.name)) {
+                  nako3Compiler.moduleExport[modInfo.name] = modInfo.export
+                }
+              }
+            } else if (o.name === 'constPools') {
+              nako3Compiler.constPools = o.content
+            } else if (o.name === 'constPoolsTemplate') {
+              nako3Compiler.constPoolsTemplate = o.content
+            } else if (o.name === 'chk') {
+              nako3Compiler.chk = o.content
+            }
           }
         })
         break


### PR DESCRIPTION
Nakoワーカーを名前空間に対応。
Nakoワーカーを文字列定数プールに暫定対応。

文字列定数プールはmainのものをそのまま転送しているので
ワーカー側でユーザ関数を定義すると関係性がずれてしまう
制約がある。
完全対応にするには以下のいずれか
・配列内容と添字を転送時に再採番する。
・転送時に文字列定数プールを展開して埋め込みなおす。