### PR TITLE
wnakoのナデシコバージョンがcoreのバージョンを返す問題を修正

### DIFF
--- a/src/wnako3mod.mts
+++ b/src/wnako3mod.mts
@@ -12,10 +12,12 @@ import PluginBrowser from './plugin_browser.mjs'
 const NAKO_SCRIPT_RE = /^(なでしこ|nako|nadesiko)3?$/
 
 export class WebNakoCompiler extends NakoCompiler {
+  version: string
   wnakoVersion: NakoVersion
   localFiles: Record<string, string>
   constructor () {
     super({ useBasicPlugin: true })
+    this.version = nakoVersion.version
     this.wnakoVersion = nakoVersion
     this.localFiles = {}
     // プラグインを追加


### PR DESCRIPTION
wnakoのナデシコバージョンがcoreのバージョンを返す問題を修正
・バージョン類(coreも)はnako_genのスタートアップコードでcoreのバージョンで初期化される。
・cnakoではコンストラクタでthis.versionにnakoVersion.versionを設定している
・wnakoではthis.versionは設定せずナデシコバージョンをbeforeRunで設定しているだけ
・plugin_systemの初期化でナデシコバージョンをsys.versionから設定している
・beforeRunとpluginの初期化では後者の方が後から実行される（上書きされる）

とりあえずcnakoを真似てwnakoでもコンストラクタでthis.versionにnakoVersion.versionを設定するよう修正