### PR TITLE
「変更時」のイベントがchangeじゃなくて'click'になっていた件を修正 #1756

### DIFF
--- a/src/plugin_browser_dom_event.mts
+++ b/src/plugin_browser_dom_event.mts
@@ -68,7 +68,7 @@ export default {
     josi: [['で'], ['を', 'の']],
     pure: true,
     fn: function (func: NakoCallback, dom: NakoDom, sys: NakoBrowsesrSystem) {
-      sys.__addEvent(dom, 'click', func, null)
+      sys.__addEvent(dom, 'change', func, null)
     },
     return_none: true
   },


### PR DESCRIPTION
変更時のイベントがチェンジじゃなくて'click'になっているようです
https://github.com/kujirahand/nadesiko3/commit/9b682744854b2d8fe4b7a36db240c60c328db309
と報告があり、修正しました。
