### PR TITLE
非同期関数でローカル変数が壊れる問題を修正 #1758

### DIFF
--- a/core/src/plugin_system.mts
+++ b/core/src/plugin_system.mts
@@ -2377,7 +2377,7 @@ export default {
       // 文字列で指定された関数をオブジェクトに変換
       if (typeof f === 'string') { f = sys.__findFunc(f, '秒後') }
       // 1回限りのタイマーをセット
-      const timerId = setTimeout(async () => {
+      const timerId = setTimeout(() => {
         // 使用中リストに追加したIDを削除
         const i = sys.__timeout.indexOf(timerId)
         if (i >= 0) { sys.__timeout.splice(i, 1) }

--- a/core/src/plugin_system.mts
+++ b/core/src/plugin_system.mts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { NakoRuntimeError } from './nako_errors.mjs'
 import { NakoSystem } from './plugin_api.mjs'
 
@@ -167,6 +168,7 @@ export default {
         }
       }
       // eval function #1733 - 互換性を優先するため、direct evalを使うことに
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       sys.__evalJS = (src: string, sys?: NakoSystem) => {
         try {
           return eval(src)
@@ -1853,6 +1855,7 @@ export default {
     type: 'func',
     josi: [['から', 'の'], ['を']],
     pure: true,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     fn: function (a: any, i: any, sys: any) {
       // 文字列のとき
       if (typeof a === 'string') {
@@ -2374,7 +2377,7 @@ export default {
       // 文字列で指定された関数をオブジェクトに変換
       if (typeof f === 'string') { f = sys.__findFunc(f, '秒後') }
       // 1回限りのタイマーをセット
-      const timerId = setTimeout(() => {
+      const timerId = setTimeout(async () => {
         // 使用中リストに追加したIDを削除
         const i = sys.__timeout.indexOf(timerId)
         if (i >= 0) { sys.__timeout.splice(i, 1) }
@@ -2925,7 +2928,7 @@ export default {
     type: 'func',
     josi: [],
     pure: true,
-    asyncFn: true,
+    asyncFn: false,
     fn: function (sys: NakoSystem) {
       return sys.josiList
     }
@@ -2934,7 +2937,7 @@ export default {
     type: 'func',
     josi: [],
     pure: true,
-    asyncFn: true,
+    asyncFn: false,
     fn: function (sys: NakoSystem) {
       return sys.reservedWords
     }

--- a/core/test/calc_test.mjs
+++ b/core/test/calc_test.mjs
@@ -5,12 +5,12 @@ import { NakoCompiler } from '../src/nako3.mjs'
 describe('calc_test.js', async () => {
   const cmp = async (/** @type {string} */ code, /** @type {string} */ res) => {
     const nako = new NakoCompiler()
-    assert.strictEqual((await nako.runAsync(code)).log, res)
+    assert.strictEqual((await nako.runAsync(code, 'main.nako3')).log, res)
   }
   const errorTest = async (/** @type {string} */ code, /** @type {string} */ errorType, /** @type {string} */ partOfErrorStr) => {
     const nako = new NakoCompiler()
     try {
-      await nako.runAsync(code)
+      await nako.runAsync(code, 'main.nako3')
     } catch (err) {
       assert.strictEqual(errorType, err.type)
       assert.strictEqual(err.msg.indexOf(partOfErrorStr) >= 0, true)
@@ -236,4 +236,5 @@ describe('calc_test.js', async () => {
     await cmp('1234567890123456789n<<60nを表示', '1423359869420436337641010675071320064')
     await cmp('123456789012345678901234567890123456789n>>60nを表示', '107081695084215790682')
   })
+
 })

--- a/core/test/func_call.mjs
+++ b/core/test/func_call.mjs
@@ -1,3 +1,4 @@
+/* eslint-disable no-irregular-whitespace */
 /* eslint-disable no-undef */
 import assert from 'assert'
 import { NakoCompiler } from '../src/nako3.mjs'
@@ -5,7 +6,7 @@ import { NakoCompiler } from '../src/nako3.mjs'
 describe('関数呼び出しテスト', async () => {
   const cmp = async (/** @type {string} */ code, /** @type {string} */ res) => {
     const nako = new NakoCompiler()
-    nako.logger.debug('code=' + code)
+    nako.getLogger().debug('code=' + code)
     const g = await nako.runAsync(code, 'main.nako3')
     if (code.indexOf('秒待') >= 0) {
       await forceWait(200)
@@ -14,7 +15,7 @@ describe('関数呼び出しテスト', async () => {
   }
   // 強制的にミリ秒待機
   function forceWait(/** @type {number} */ms) {
-    return /** @type {Promise<void>} */(new Promise((resolve, reject) => {
+    return /** @type {Promise<void>} */(new Promise((resolve) => {
       setTimeout(() => { resolve() }, ms);
     }));
   }
@@ -189,5 +190,41 @@ describe('関数呼び出しテスト', async () => {
 それを表示
     `
     await cmp(code, 'CCCBBBCCCAAA')
+  })
+  
+  it('後方で宣言した関数がasyncFnだったときその関数が正しく実行できない(1) #1758', async () => {
+    const code = `
+●test1():
+　xとは変数= 1
+　0.05秒待つ
+　xを表示
+●test2():
+　xとは変数= 2
+　0.05秒待つ
+　xを表示
+
+0.01秒後には:
+　test1
+0.05秒後には:
+　test2`
+    await cmp(code, '1\n2')
+  })
+  it('後方で宣言した関数がasyncFnだったときその関数が正しく実行できない(2) #1758', async () => {
+    const code = `
+0.1秒後には:
+　Aとは変数 = 「A」
+　関数A
+　Aを表示　//→undefined
+
+●関数Aとは:
+　Bとは変数 = 「B」
+　関数B
+　Bを表示　//→undefined
+
+●関数Bとは:
+　もし0ならば:
+　　0.01秒待つ　//（待たない）
+    `
+    await cmp(code, 'B\nA')
   })
 })


### PR DESCRIPTION
非同期関数を呼び出す時に、ローカル変数が壊れるのを防ぐために、try { ... } finally { ... } で囲って、ローカル変数が壊れないように待避するように修正しました。
