### PR TITLE
asyncFn=true周りが連携するよう修正

### DIFF
--- a/core/src/nako_gen.mts
+++ b/core/src/nako_gen.mts
@@ -438,7 +438,7 @@ export class NakoGen {
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         fn: () => {},
         type: 'func',
-        asyncFn: false,
+        asyncFn: t.asyncFn ? true : false,
         isExport: t.isExport
       })
       funcList.push({ name, node: t })
@@ -1467,7 +1467,7 @@ export class NakoGen {
     } else {
       func = this.nakoFuncList.get(funcName)
       // 無名関数の可能性
-      if (func === undefined) { func = { return_none: false } }
+      if (func === undefined) { func = { return_none: false, asyncFn: node.asyncFn ? true : false } }
     }
     // 関数の参照渡しか？
     if (node.type === 'func_pointer') {
@@ -1643,7 +1643,7 @@ export class NakoGen {
             indent(funcBegin, 1) + '\n' +
             indent('try {', 1) + '\n' +
             indent(`let ${varI} = ${funcCall};`, 2) + '\n' +
-            indent(`return ${sorePrefex}${varI}${sorePostfix};`, 2) + '\n' +
+            indent(`return ${varI};`, 2) + '\n' +
             indent('} finally {', 2) + '\n' +
             indent(funcEnd, 1) + '\n' +
             indent('}', 1) + '\n' +
@@ -1651,6 +1651,7 @@ export class NakoGen {
           if (func.asyncFn) {
             code = `await (${code})`
           }
+          code = `${sorePrefex}${code}${sorePostfix}`
         }
       }
       // ...して

--- a/core/src/nako_parser3.mts
+++ b/core/src/nako_parser3.mts
@@ -360,7 +360,10 @@ export class NakoParser extends NakoParserBase {
       throw NakoSyntaxError.fromNode(this.nodeToStr(funcName, { depth: 0, typeName: '関数' }, false) +
         'の定義で以下のエラーがありました。\n' + err.message, def)
     }
-
+    const func = this.funclist.get(funcName.value)
+    if (func && !func.asyncFn && asyncFn) {
+      func.asyncFn = asyncFn
+    }
     return {
       type,
       name: funcName.value,


### PR DESCRIPTION
下記２つにてasyncFnがパーサからジェネレータまでうまく伝達するはずです。
・パーサにて関数のパースでasyncFnが判明した場合はfunclistに反映する。
・ジェネレータにてASTのasynFnの初期値はトークンのasyncFnを反映する。

下記にてローカル変数域を戻した際に設定したはずの「それ」も戻されることがなくなります。
・関数呼び出しの際の「それ」の設定を退避したローカル変数を戻した後に移動する。
