### PR TITLE
「$」「.」の動作ロジックの変更

### DIFF
--- a/core/src/plugin_api.mts
+++ b/core/src/plugin_api.mts
@@ -37,6 +37,8 @@ export interface NakoSystem {
   __parseFloatOrBigint(v: NakoValue): number | bigint;
   __evalJS(code: string, sys?: NakoSystem): NakoValue;
   __evalSafe(code: string): NakoValue;
+  __registPropAccessor(f: Function, getProp: (prop: string|string[], sys: NakoSystem) => any, setProp: (prop: string|string[], value: object, sys: NakoSystem) => any):void;
+  __checkPropAccessor(mode: 'get'|'set', obj: any):void;
   josiList: string[];
   reservedWords: string[];
   // 実際には存在するが利用が非推奨なメソッドやプロパティ

--- a/core/src/plugin_system.mts
+++ b/core/src/plugin_system.mts
@@ -177,6 +177,34 @@ export default {
           return null
         }
       }
+      // Propアクセス支援
+      sys.__registPropAccessor = (f: Function, getProp: (prop: string|string[], sys: NakoSystem) => any, setProp: (prop: string|string[], value: object, sys: NakoSystem) => any, sys?: NakoSystem) => {
+        system.__propAccessor.push(
+          {
+            target: f,
+            getProp,
+            setProp
+          }
+        )
+      }
+      sys.__checkPropAccessor = (mode: 'get'|'set', obj: any):void => {
+        if ((mode === 'get' && obj.__getProp === undefined) || (mode === 'set' && obj.__setProp === undefined)) {
+          for (let i = 0; i < system.__propAccessor.length; i++) {
+            const accs = system.__propAccessor[i]
+            if (accs.target[Symbol.hasInstance](obj)) {
+              if (accs.getProp) {
+                obj.__getProp = accs.getProp
+              } else { obj.__getProp = null }
+              if (accs.setProp) {
+                obj.__setProp = accs.setProp
+              } else { obj.__setProp = null }
+              return
+            }
+          }
+          obj.__getProp = obj.__setProp = null
+        }
+      }
+
     }
   },
   '!クリア': {

--- a/src/plugin_browser.mts
+++ b/src/plugin_browser.mts
@@ -1,7 +1,7 @@
 /**
  * @fileOverview ブラウザプラグイン
  */
-import { NakoValue, NakoCallback, NakoCallbackEvent } from '../core/src/plugin_api.mjs'
+import { NakoValue, NakoCallback, NakoCallbackEvent, NakoSystem } from '../core/src/plugin_api.mjs'
 import { NakoBrowsesrSystem, IBrowserDocument, IBrowserWindow, IBrowserLocation } from './plugin_browser_api.mjs'
 
 import PartBrowserColor from './plugin_browser_color.mjs'
@@ -213,6 +213,17 @@ const PluginBrowser = {
             return sys.__exec('DOM設定取得', [obj, prop, sys])
           }
         }
+      }
+      // Elementのクラスに対してDOMに動的プロパティの取得と設定を適用するよう登録する
+      if (sys.__registPropAccessor && globalThis.Element) {
+        sys.__registPropAccessor(Element,
+          function (prop: string|string[], sys: NakoSystem):any { // @ts-ignore
+            return sys.__exec('DOM設定取得', [this as Element, prop, sys as NakoBrowsesrSystem])
+          },
+          function (prop: string|string[], value: object, sys: NakoSystem):any { // @ts-ignore
+            sys.__exec('DOM設定変更', [this as Element, prop, value, sys as NakoBrowsesrSystem])
+          }
+        )
       }
       // DOM取得のために使う
       sys.__query = (dom: object|string, commandName: string, isGetFunc: boolean) => {

--- a/test/node/plugin_node_stdin_test.mjs
+++ b/test/node/plugin_node_stdin_test.mjs
@@ -3,6 +3,7 @@ import assert from 'assert'
 import path from 'path'
 import fs from 'fs'
 import { execSync, spawnSync } from 'child_process'
+import os from 'node:os'
 
 // __dirname のために
 import url from 'url'
@@ -11,6 +12,8 @@ const debug = false
 const __filename = url.fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
+const execOption = os.platform() === 'win32' ? { shell: 'powershell.exe' } : undefined
+
 // PATH
 const cnako3 = path.join(__dirname, '../../src/cnako3.mjs')
 
@@ -18,7 +21,7 @@ const cnako3 = path.join(__dirname, '../../src/cnako3.mjs')
 describe('plugin_node_stdin_test(cnako)', () => {
   const cmp = (code, exRes, stdinStr) => {
     const cmd = `echo "${stdinStr}" | node ${cnako3} -e "${code}"`
-    const result = execSync(cmd).toString().trimEnd()
+    const result = execSync(cmd, execOption).toString().trimEnd()
     if (debug) {
       console.log('code=' + code)
       console.log('result=' + result)


### PR DESCRIPTION
「$」「.」の仕組みの変更です。改善/修正というよりもメリット・デメリットのある変更案です。
従来
・対象のobj毎に特定のメソッドをsetter/getterとして定義する。
・生成コードはメソッドの有無のチェックとある場合/ない場合のそれぞれおのコードが生成され単純アクセスより少し増える。
変更
・事前にクラス(コンストラクタ)に対してsetterとgetterを登録する。
・対象objにsetter/getterがある場合は従来と同じ動き。
・対象objにsetter/getterがundefinedの場合、登録したクラスのインスタンスならsetter/getterをobjに定義してそれに従う。
　登録したクラスにない場合はsetter/getterにnullを設定して再チェックを抑止する。
・対象objのsetter/getterがnulの場合、登録したクラスのチェックを省略してメソッドがない場合の動作をする。
・生成コードは共通部分をNakoSystemに追い出したうえで更に増える。
・クラスのインスタンスチェックは登録した暮らすかどうかをループでチェックすることになるので登録数が増えると重くなる。
とりあえず、plugin_browserからはwindow.Elementに対して登録しています。

本題とは関係ないんですが、Windows(のcmd.exe)でtestが失敗するを修正してます。他環境での動作は不明。
※cmd.exeのechoが""とかも含めて常にそのまま全て出力するのでテストに失敗する。