### PR TITLE
「先月」の説明を改善

### DIFF
--- a/core/src/plugin_system.mts
+++ b/core/src/plugin_system.mts
@@ -2659,7 +2659,7 @@ export default {
       return (new Date()).getMonth() + 2
     }
   },
-  '先月': { // @先月が何月かをかえす // @せんげつ
+  '先月': { // @先月が何月かを返す // @せんげつ
     type: 'func',
     josi: [],
     pure: true,


### PR DESCRIPTION
「かえす」を「返す」に変更。

「今日」「明日」「昨日」「今年」「来年」「去年」「今月」「来月」で使われている表現に統一。