### PR TITLE
「線色設定」「塗色設定」のヨミガナを変更

### DIFF
--- a/src/plugin_browser_canvas.mts
+++ b/src/plugin_browser_canvas.mts
@@ -42,7 +42,7 @@ export default {
     },
     return_none: true
   },
-  '線色設定': { // @Canvasの線の描画色(lineStyle)を指定する   // @ せんいろしてい
+  '線色設定': { // @Canvasの線の描画色(lineStyle)を指定する   // @ せんいろせってい
     type: 'func',
     josi: [['に', 'へ']],
     pure: true,
@@ -55,7 +55,7 @@ export default {
     },
     return_none: true
   },
-  '塗色設定': { // @Canvasへの描画色(fillStyle)を指定する   // @ ぬりいろしてい
+  '塗色設定': { // @Canvasへの描画色(fillStyle)を指定する   // @ ぬりいろせってい
     type: 'func',
     josi: [['に', 'へ']],
     pure: true,


### PR DESCRIPTION
「線色設定」「塗色設定」命令のヨミガナをより直感に則したものに変更。

> [!NOTE]
> 説明や解説では「指定」が使用されているため、命令は「設定」だがヨミガナは「してい」で正しい可能性も考えられる。
