### PR TITLE
「LN」命令の説明を変更

### DIFF
--- a/core/src/plugin_math.mts
+++ b/core/src/plugin_math.mts
@@ -176,7 +176,7 @@ export default {
       return Math.hypot(a, b)
     }
   },
-  'LN': { // @実数式 A の自然対数（Ln(A) = 1）を返す // @LN
+  'LN': { // @実数式 A の自然対数（Ln(e) = 1）を返す // @LN
     type: 'func',
     josi: [['の']],
     pure: true,


### PR DESCRIPTION
> 実数式 A の自然対数（Ln(A) = 1）を返す 

という説明において、`LN(A)` の値は `A` の値によって変化し、`Ln(A) = 1` の意味がよくわからないので、自然対数の底を渡したときの返り値が1になることを表す `Ln(e) = 1` に変更。

kujirahand/nadesiko3doc#47 に合わせる。

