### PR TITLE
真(=1)、偽(=0)を、真(true)、偽(false)に差し替える #1936

### DIFF
--- a/core/src/plugin_system.mts
+++ b/core/src/plugin_system.mts
@@ -223,13 +223,13 @@ export default {
   'ナデシコ言語バージョン': { type: 'const', value: '?' }, // @なでしこげんごばーじょん
   'ナデシコエンジン': { type: 'const', value: 'nadesi.com/v3' }, // @なでしこえんじん
   'ナデシコ種類': { type: 'const', value: '?' }, // @なでしこしゅるい
-  'はい': { type: 'const', value: 1 }, // @はい
-  'いいえ': { type: 'const', value: 0 }, // @いいえ
-  '真': { type: 'const', value: 1 }, // @しん
-  '偽': { type: 'const', value: 0 }, // @ぎ
-  '永遠': { type: 'const', value: 1 }, // @えいえん
-  'オン': { type: 'const', value: 1 }, // @おん
-  'オフ': { type: 'const', value: 0 }, // @おふ
+  'はい': { type: 'const', value: true }, // @はい
+  'いいえ': { type: 'const', value: false }, // @いいえ
+  '真': { type: 'const', value: true }, // @しん
+  '偽': { type: 'const', value: false }, // @ぎ
+  '永遠': { type: 'const', value: true }, // @えいえん
+  'オン': { type: 'const', value: true }, // @おん
+  'オフ': { type: 'const', value: false }, // @おふ
   '改行': { type: 'const', value: '\n' }, // @かいぎょう
   'タブ': { type: 'const', value: '\t' }, // @たぶ
   'カッコ': { type: 'const', value: '「' }, // @かっこ
@@ -288,6 +288,14 @@ export default {
     pure: false,
     fn: function (sys: NakoSystem): any {
       return sys.__exec('空ハッシュ', [sys])
+    }
+  },
+  '真偽判定': { // @引数bが真(true)ならば「真」を偽(false)ならば「偽」を返す // @しんぎはんてい
+    type: 'func',
+    josi: [['の', 'を']],
+    pure: true,
+    fn: function (b: any): string {
+      return b ? '真' : '偽'
     }
   },
 

--- a/core/test/lex_test.mjs
+++ b/core/test/lex_test.mjs
@@ -41,8 +41,8 @@ describe('lex_test', async () => {
     await cmp('手説明＝["グー","チョキ","パー"];「自分は{手説明@1}、相手は{手説明@0}」と表示', '自分はチョキ、相手はグー')
   })
   it('はい/いいえ', async () => {
-    await cmp('はいを表示', '1')
-    await cmp('いいえを表示', '0')
+    await cmp('はいを表示', 'true')
+    await cmp('いいえを表示', 'false')
   })
   it('A = 8の書き方', async () => {
     await cmp('A = 8;Aを表示', '8')

--- a/core/test/plugin_system_test.mjs
+++ b/core/test/plugin_system_test.mjs
@@ -407,10 +407,27 @@ describe('plugin_system_test', async () => {
     await cmp('XOR(0,1)を表示', '1')
     await cmp('NOT(0xFF)を表示', '-256')
   })
-  it('論理演算', async () => {
-    await cmp('論理OR(TRUE,FALSE)を表示', 'true')
-    await cmp('論理AND(TRUE,FALSE)を表示', 'false')
-    await cmp('論理NOT(TRUE)を表示', 'false')
+  it('真偽判定', async () => { // #1936
+    await cmp('1の真偽判定を表示', '真')
+    await cmp('trueの真偽判定を表示', '真')
+    await cmp('"a"の真偽判定を表示', '真')
+    await cmp('「」の真偽判定を表示', '偽')
+    await cmp('0の真偽判定を表示', '偽')
+  })
+  it('論理演算', async () => { // #1936
+    // OR
+    await cmp('論理OR(真,真)の真偽判定を表示', '真')
+    await cmp('論理OR(真,偽)の真偽判定を表示', '真')
+    await cmp('論理OR(偽,偽)の真偽判定を表示', '偽')
+    // AND
+    await cmp('論理AND(真,偽)の真偽判定を表示', '偽')
+    await cmp('論理AND(偽,真)の真偽判定を表示', '偽')
+    await cmp('論理AND(真,真)の真偽判定を表示', '真')
+    // NOT
+    await cmp('論理NOT(真)の真偽判定を表示', '偽')
+    await cmp('論理NOT(0)の真偽判定を表示', '真')
+    await cmp('論理NOT("")の真偽判定を表示', '真')
+    await cmp('論理NOT("a")の真偽判定を表示', '偽')
   })
   it('英数記号全角半角変換', async () => {
     await cmp('「＃！」を英数記号半角変換して表示', '#!')


### PR DESCRIPTION
真偽値の定義を変更します。
真(=1)、偽(=0)を、真(true)、偽(false)に差し替えます。

