### PR TITLE
「NAKOワーカーリセット」命令のよみがなを変更

### DIFF
--- a/src/plugin_webworker.mjs
+++ b/src/plugin_webworker.mjs
@@ -227,7 +227,7 @@ const PluginWebWorker = {
     },
     return_none: true
   },
-  'NAKOワーカーリセット': { // @WORKERに固有の形式でプログラムの転送と実行行う。 // @わーかーりせっと
+  'NAKOワーカーリセット': { // @WORKERに固有の形式でプログラムの転送と実行行う。 // @NAKOわーかーりせっと
     type: 'func',
     josi: [['を']],
     pure: true,


### PR DESCRIPTION
「NAKOワーカーリセット」命令のよみがなを、他の「NAKOワーカー～」シリーズの命令と同様に最初に「NAKO」がつくものに変更。
