### PR TITLE
ドキュメント内のファイルパスを修正

### DIFF
--- a/doc/files.md
+++ b/doc/files.md
@@ -1,6 +1,6 @@
 # なでしこを構成するファイルたち
 
-## src/nako3.mjs
+## core/src/nako3.mjs
 
 なでしこコンパイラ本体。なでしこのソースコードをJSに変換する。変換処理は、次のように行われる。
 
@@ -9,15 +9,15 @@
 - (3) 構文木(中間表現)
 - (3) JavaScriptソース
 
-## src/nako_prepare.mjs
+## core/src/nako_prepare.mjs
 
 なでしこのソースコードの前置処理を行うもの。主に全角半角の変換処理を行う。
 
-## src/nako_parser3.mjs
+## core/src/nako_parser3.mjs
 
 なでしこ構文から構文木を生成するもの。
 
-## src/nako_gen.mjs
+## core/src/nako_gen.mjs
 
 構文木を元に、JavaScriptのコードを生成するもの。
 

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -207,7 +207,7 @@ const value = sys.__getSysVar('変数名')
 sys.__setSysVar('変数名', value)
 ```
 
-なお、プラグインでは、次のメソッドが使えるようになる。(すべてsrc/plugin_system.jsで定義されている。システム関数の初期化時に、これらの関数が追加される)
+なお、プラグインでは、次のメソッドが使えるようになる。(すべてcore/src/plugin_system.mjsで定義されている。システム関数の初期化時に、これらの関数が追加される)
 
 - sys.__findVar(name)
 - sys.__exec(name, params)


### PR DESCRIPTION
ドキュメント内のファイルパスを実態に合ったものに変更。

`.mjs` のファイルには直接レポジトリに格納されていないものもありますが、ビルドにより生成される上、プラグインは `.mts` と `.mjs` の両方があって面倒なので、`.mjs` に統一しました。
