### PR TITLE
「ランダム配列生成」の説明を改善

### DIFF
--- a/src/plugin_browser_crypto.mts
+++ b/src/plugin_browser_crypto.mts
@@ -43,7 +43,7 @@ export default {
       return window.crypto.randomUUID()
     },
   },
-  'ランダム配列生成': { // @暗号強度の強い乱数のバイト配列(Uint8Array)を指定個数返す // @ らんだむはいれつせいせい
+  'ランダム配列生成': { // @暗号強度の強い乱数のバイト配列(Uint8Array)を指定の長さで返す // @ らんだむはいれつせいせい
     type: 'func',
     josi: [['の']],
     pure: true,


### PR DESCRIPTION
「指定個数返す」では配列を (指定に応じて) 複数返すような印象があるので、表現を変更。
