### PR TITLE
代入文で関数に代入した時のエラーを親切に #1981

### DIFF
--- a/core/src/nako3.mts
+++ b/core/src/nako3.mts
@@ -9,7 +9,7 @@ import { Ast, AstBlocks } from './nako_ast.mjs'
 // parser / lexer
 import { NakoParser } from './nako_parser3.mjs'
 import { NakoLexer } from './nako_lexer.mjs'
-import { NakoPrepare, ConvertResult } from './nako_prepare.mjs'
+import { NakoPrepare } from './nako_prepare.mjs'
 import { NakoGen, generateJS, NakoGenOptions, NakoGenResult } from './nako_gen.mjs'
 import { convertInlineIndent, convertIndentSyntax } from './nako_indent_inline.mjs'
 import { convertDNCL } from './nako_from_dncl.mjs'

--- a/core/src/nako_parser3.mts
+++ b/core/src/nako_parser3.mts
@@ -1221,6 +1221,9 @@ export class NakoParser extends NakoParserBase {
     if (!word || (word.type !== 'word' && word.type !== 'func' && word.type !== 'ref_array')) {
       throw NakoSyntaxError.fromNode('代入文で代入先の変数が見当たりません。『(変数名)に(値)を代入』のように使います。', dainyu)
     }
+    if (word.type === 'func') {
+      throw NakoSyntaxError.fromNode('関数『' + word.name + '』に代入できません。『(変数名)に(値)を代入』のように使います。', dainyu)
+    }
     // 配列への代入
     if (word.type === 'ref_array') {
       const indexArray = word.index || []


### PR DESCRIPTION
以下のようなケースでエラーが分かりやすく

```
1を符号に代入。
```