### PR TITLE
デバッグ記法でなでしこ風関数呼び出しを実行可能にする #2033

### DIFF
--- a/core/src/nako_parser3.mts
+++ b/core/src/nako_parser3.mts
@@ -715,7 +715,7 @@ export class NakoParser extends NakoParserBase {
     if (!t || t.value !== '??') {
       throw NakoSyntaxError.fromNode('『??』で指定してください。', map)
     }
-    const arg: Ast|null = this.yGetArg()
+    const arg: Ast|null = this.yCalc()
     if (!arg) {
       throw NakoSyntaxError.fromNode('『??(計算式)』で指定してください。', map)
     }


### PR DESCRIPTION
下記が正しく実行されるように修正しました。

```
?? 「●が多いと失敗を避けられない」の「●」を「言葉」に置換  
# → 「●が多いと失敗を避けられない」…あれれ？？？
```