### PR TITLE
ビデオ機能を追加 #2012

### DIFF
--- a/src/plugin_browser.mts
+++ b/src/plugin_browser.mts
@@ -22,6 +22,7 @@ import PartBrowserAudio from './plugin_browser_audio.mjs'
 import PartBrowserHotkey from './plugin_browser_hotkey.mjs'
 import PartBrowserChart from './plugin_browser_chart.mjs'
 import PartBrowserCrypto from './plugin_browser_crypto.mjs'
+import PartBrowserCamera from './plugin_browser_camera.mjs'
 
 const BrowserParts = [
   PartBrowserColor,
@@ -41,7 +42,8 @@ const BrowserParts = [
   PartBrowserAudio,
   PartBrowserHotkey,
   PartBrowserChart,
-  PartBrowserCrypto
+  PartBrowserCrypto,
+  PartBrowserCamera
 ]
 
 const PluginBrowser = {

--- a/src/plugin_browser_camera.mts
+++ b/src/plugin_browser_camera.mts
@@ -1,0 +1,101 @@
+// @ts-nocheck
+import { NakoSystem } from '../core/src/plugin_api.mjs'
+
+export default {
+  // @カメラ
+  'カメラオプション': { type: 'const', value: { video: true, audio: false } }, // @かめらおぷしょん
+  'カメラ起動': { // @カメラを起動する // @かめらきどう
+    type: 'func',
+    josi: [['の', 'に', 'へ', 'で']],
+    pure: true,
+    asyncFn: true,
+    fn: async function (v: any, sys: NakoSystem) {
+      const options = sys.__getSysVar('カメラオプション')
+      const stream = await navigator.mediaDevices.getUserMedia(options)
+      v.srcObject = stream
+      const settings = sys.__exec('カメラ設定取得', [v, sys])
+      if (settings.width && settings.height) {
+        v.width = settings.width
+        v.height = settings.height
+      }
+      v.onloadedmetadata = function () {
+        v.play()
+      }
+    },
+    return_none: true
+  },
+  'カメラ終了': { // @カメラを終了 // @かめらしゅうりょう
+    type: 'func',
+    josi: [['の']],
+    pure: true,
+    fn: function (v: any, sys: NakoSystem) {
+      sys.__exec('メディアストリーム停止', [v, sys])
+      v.srcObject = null
+    },
+    return_none: true
+  },
+  'カメラ映像再生': { // @カメラ映像を再生する // @かめらえいぞうさいせい
+    type: 'func',
+    josi: [['の']],
+    pure: true,
+    fn: function (v: any, sys: NakoSystem) {
+      if (v && v.play) {
+        v.play()
+      }
+    },
+    return_none: true
+  },
+  'カメラ映像一時停止': { // @カメラ映像の再生を一時停止する // @かめらえいぞういちじていし
+    type: 'func',
+    josi: [['の']],
+    pure: true,
+    fn: function (v: any, sys: NakoSystem) {
+      if (v && v.pause) {
+        v.pause()
+      }
+    },
+    return_none: true
+  },
+  'カメラ設定取得': { // @カメラ設定を取得して返す // @かめらせっていしゅとく
+    type: 'func',
+    josi: [['の']],
+    pure: true,
+    fn: function (v: any, sys: NakoSystem) {
+      if (v && v.srcObject && v.srcObject.getVideoTracks) {
+        const tracks = v.srcObject.getVideoTracks()
+        if (tracks.length > 0) {
+          const settings = tracks[0].getSettings()
+          return settings
+        }
+        return {}
+      }
+      return {}
+    },
+    return_none: false
+  },
+  'メディアストリーム取得': { // @メディアストリームを取得して返す(カメラオプションを参照) // @めでぃあすとりーむしゅとく
+    type: 'func',
+    josi: [],
+    pure: true,
+    asyncFn: true,
+    fn: async function (sys: NakoSystem) {
+      const options = sys.__getSysVar('カメラオプション')
+      return await navigator.mediaDevices.getUserMedia(options)
+    },
+    return_none: false
+  },
+  'メディアストリーム停止': { // @メディアストリームを停止する // @めでぃあすとりーむていし
+    type: 'func',
+    josi: [['の']],
+    pure: true,
+    fn: function (v:any, sys: NakoSystem) {
+      if (v && v.srcObject && v.srcObject.getVideoTracks) {
+        const tracks = v.srcObject.getVideoTracks()
+        for (const track of tracks) {
+          track.stop()
+        }
+      }
+    },
+    return_none: false
+  }
+}

--- a/src/plugin_browser_dom_parts.mts
+++ b/src/plugin_browser_dom_parts.mts
@@ -611,5 +611,14 @@ export default {
       await win.mermaid.run()
       return div
     }
+  },
+  'ビデオ作成': { // @ ビデオ部品を作成して返す // @ びでおさくせいい
+    type: 'func',
+    josi: [],
+    pure: true,
+    fn: function (sys: any) {
+      const video = sys.__exec('DOM部品作成', ['video', sys])
+      return video
+    }
   }
 }


### PR DESCRIPTION
```
V=ビデオ作成
改行作成。
Vでカメラ起動。
C=Vのカメラ設定取得
CをJSONエンコードして表示
描画中キャンバス$幅=C$width
描画中キャンバス$高さ=C$height
B=「停止」のボタン作成
Bのクリックした時には：
　　Vのカメラ終了。
B2=「再開」のボタン作成
B2のクリックした時には：
　　Vのカメラ起動。
B3=「撮影」のボタン作成。
B3のクリックした時には：
　　[0,0]にVを画像描画
```
