### PR TITLE
インデント構文のブロックの直後の行が正しくない #2037

### DIFF
--- a/core/src/nako_indent_inline.mts
+++ b/core/src/nako_indent_inline.mts
@@ -262,7 +262,14 @@ export function convertIndentSyntax (tokens: Token[]): Token[] {
     for (let i = lines.length - 1; i >= 0; i--) {
       const line = lines[i]
       if (line.length > 0) {
-        t = line[line.length - 1]
+        // テンプレートとなるトークンを行の後方から順に探す
+        for (let j = 0; j < line.length; j++) {
+          const tt = line[line.length - j - 1]
+          if (tt.line > 0) {
+            t = tt
+            break
+          }
+        }
         break
       }
     }

--- a/core/test/debug_test.mjs
+++ b/core/test/debug_test.mjs
@@ -3,15 +3,22 @@ import assert from 'assert'
 import { NakoCompiler } from '../src/nako3.mjs'
 
 describe('debug', () => {
-  const nako = new NakoCompiler()
   // nako.logger.addListener('trace', ({ browserConsole }) => { console.log(...browserConsole) })
   const cmp = async (/** @type {string} */ code, /** @type {string} */ res) => {
+    const nako = new NakoCompiler()
     nako.logger.debug('code=' + code)
     assert.strictEqual((await nako.runAsync(code)).log, res)
   }
   // --- test ---
   it('print simple', async () => {
     await cmp('/* aaa */\n3を表示\n2*3を表示', '3\n6')
-    // cmp("/* a\n */\n3を表示\n「テスト」でエラー発生。", "3\n6");
+  })
+  it('インデント構文のブロックの直後の行が正しくない #2037', async () => {
+    await cmp(
+      '1回:\n' +
+      '　　// test\n' +
+      '333をデバッグ表示;' +
+      '',
+      'main.nako3(3): 333')
   })
 })


### PR DESCRIPTION
```
 1回:
　　// tes
333をデバッグ表示
```
