### PR TITLE
「尋ねる」を2万行分実行すると入力が壊れる問題を修正 #2055

### DIFF
--- a/batch/pickup_command.nako3
+++ b/batch/pickup_command.nako3
@@ -14,7 +14,7 @@ CORE="core/src"
 コアプラグイン一覧は[
     ["plugin_system.mts", 'wnako,cnako,phpnako'],
     ["plugin_csv.mts", 'wnako,cnako'],
-    ['plugin_toml.mjs', 'wnako,cnako'],
+    ["plugin_toml.mts", 'wnako,cnako'],
     ["plugin_math.mts", 'wnako,cnako'],
     ["plugin_promise.mts", 'wnako,cnako']
 ]


### PR DESCRIPTION
This pull request introduces significant improvements to the handling of standard input (stdin) in the Node.js plugin, streamlining the way input lines are read and distributed to handlers. It also includes a minor fix for a core plugin file extension and a small update to file upload handling. The most important changes are grouped below:

**Standard Input Handling Improvements:**

* Refactored the stdin reading logic in `src/plugin_node.mts` to use a single listener and shared queues/handlers, allowing for more robust and flexible line reading and distribution to both persistent and one-time handlers. This resolves issues with process termination and improves compatibility with asynchronous operations.
* Enhanced the implementation of the "read all from stdin" command to use the new shared stdin state, supporting immediate resolution if stdin has ended and ensuring all input is captured reliably.

**Bug Fixes and Minor Improvements:**

* Fixed a typo in the core plugin list by changing the TOML plugin file extension from `.mjs` to `.mts` in `batch/pickup_command.nako3`.
* Updated file upload handling in `src/plugin_node.mts` to wrap file data in a `Uint8Array` before creating a `Blob`, ensuring compatibility and correctness when uploading files.