### PR TITLE
v3.7.8

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nadesiko3core",
-  "version": "3.7.7",
+  "version": "3.7.8",
   "description": "Japanese Programming Language Nadesiko v3 core",
   "main": "index.mjs",
   "type": "module",

--- a/core/src/nako_core_version.mts
+++ b/core/src/nako_core_version.mts
@@ -11,9 +11,9 @@ export interface NakoCoreVersion {
 }
 // 実際のバージョン定義 (自動生成されるので以下を編集しない)
 const coreVersion: NakoCoreVersion = {
-  version: '3.7.7',
+  version: '3.7.8',
   major: 3,
   minor: 7,
-  patch: 7
+  patch: 8
 }
 export default coreVersion

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nadesiko3",
-  "version": "3.7.7",
+  "version": "3.7.8",
   "description": "Japanese Programming Language",
   "type": "module",
   "main": "src/index.mjs",

--- a/src/nako_version.mts
+++ b/src/nako_version.mts
@@ -11,9 +11,9 @@ export interface NakoVersion {
 }
 // 実際のバージョン定義 (自動生成されるので以下を編集しない)
 const nakoVersion: NakoVersion = {
-  version: '3.7.7',
+  version: '3.7.8',
   major: 3,
   minor: 7,
-  patch: 7
+  patch: 8
 }
 export default nakoVersion


### PR DESCRIPTION
This pull request updates the version number of both the main `nadesiko3` package and its core library from 3.7.7 to 3.7.8. The change ensures consistency across the project by updating all relevant version references.

Version updates:

* Updated the `version` field in `package.json` from 3.7.7 to 3.7.8 for the main package.
* Updated the `version` field in `core/package.json` from 3.7.7 to 3.7.8 for the core library.

Internal version constants:

* Updated the `version`, `patch`, and related fields in `src/nako_version.mts` to reflect 3.7.8.
* Updated the `version`, `patch`, and related fields in `core/src/nako_core_version.mts` to reflect 3.7.8.