### PR TITLE
インデント構文のブロックの直後の行が正しくない #2037

### DIFF
--- a/core/src/nako_gen.mts
+++ b/core/src/nako_gen.mts
@@ -1694,7 +1694,10 @@ export class NakoGen {
         }
       }
       // ...して
-      if (node.josi === 'して' || (node.josi === '' && !isExpression)) { code += ';\n' }
+      if (node.josi === 'して' || (node.josi === '' && !isExpression)) {
+        code = this.convLineno(node, false) + code
+        code += ';\n'
+      }
     }
 
     if (res.i === 0 && this.performanceMonitor.systemFunction !== 0) {


### PR DESCRIPTION
インデント構文のブロックの直後の行が正しくない #2037