### PR TITLE
「DOM和スタイル」からCSSに無い値を削除 (「DOM属性設定」でreadonly属性を設定できるように)

### DIFF
--- a/src/plugin_browser_dom_basic.mts
+++ b/src/plugin_browser_dom_basic.mts
@@ -276,10 +276,7 @@ export default {
       'ブロック': 'block',
       '表示位置': 'float',
       '重なり': 'z-index',
-      '重': 'z-index',
-      '読取専用': 'readOnly',
-      '読み取り専用': 'readOnly',
-      'readonly': 'readOnly'
+      '重': 'z-index'
     }
   },
   'DOMプロパティ情報': { // 'const' // @DOMぷろぱてぃじょうほう


### PR DESCRIPTION
「[DOM和スタイル](https://nadesi.com/v3/doc/index.php?plugin_browser%2FDOM%E5%92%8C%E3%82%B9%E3%82%BF%E3%82%A4%E3%83%AB&show)」の定義から、CSSでは (キーワードとしては) 使われない値 `readOnly` の定義を削除します。
少なくとも、[CSS Snapshot 2026](https://www.w3.org/TR/css-2026/) 2. Classification of CSS Specifications からリンクされている定義において、`readOnly` は使われていないようでした。

これにより、「[DOM属性設定](https://nadesi.com/v3/doc/index.php?plugin_browser%2FDOM%E5%B1%9E%E6%80%A7%E8%A8%AD%E5%AE%9A&show)」で [readonly 属性](https://developer.mozilla.org/ja/docs/Web/HTML/Reference/Attributes/readonly)を設定できない問題を解消します。

テストコード：

```
空のエディタ作成。
その「readonly」にオンをDOM属性設定。
「(e) => window.editor = e」を[それ]でJS関数実行。
```

「エディタ作成」では、「DOM部品作成」により要素を作っています。

https://github.com/kujirahand/nadesiko3/blob/84d75e0e7f62fcc217c075d24952c3932c34c781/src/plugin_browser_dom_parts.mts#L83-L93

「DOM部品作成」では、作成した要素を `sys.__addPropMethod` に渡しています。

https://github.com/kujirahand/nadesiko3/blob/84d75e0e7f62fcc217c075d24952c3932c34c781/src/plugin_browser_dom_parts.mts#L46

[`sys.__addPropMethod` ](https://github.com/kujirahand/nadesiko3/blob/84d75e0e7f62fcc217c075d24952c3932c34c781/src/plugin_browser.mts#L225) では、「DOM和スタイル」のキーを含むキー群について、設定時に「DOM設定変更」を呼び出す**プロパティを定義**しています。
現状では、`readonly` もこの定義対象に含まれます。

「[DOM設定変更](https://github.com/kujirahand/nadesiko3/blob/84d75e0e7f62fcc217c075d24952c3932c34c781/src/plugin_browser_dom_basic.mts#L408)」で `readonly` を設定しようとすると、

* 配列ではない
* 「DOMプロパティ情報」には含まれていない
* 単位つきスタイルではない
* 「DOM和属性」には含まれていない
* 「DOM和スタイル」には含まれている

ため、以下の部分により、(おそらく意味はない) `style.readOnly` が設定されるだけになってしまいます。

https://github.com/kujirahand/nadesiko3/blob/84d75e0e7f62fcc217c075d24952c3932c34c781/src/plugin_browser_dom_basic.mts#L473-L478

そして、「DOM属性設定」では、設定しようとする属性の名前がプロパティとして定義されていれば、かわりにプロパティを設定する仕様になっています。

https://github.com/kujirahand/nadesiko3/blob/84d75e0e7f62fcc217c075d24952c3932c34c781/src/plugin_browser_dom_basic.mts#L194-L199

そのため、「DOM属性設定」で `readonly` 属性を設定しようとしても、`sys.__addPropMethod` によって追加される `readonly` プロパティに妨害され、設定に失敗してしまいます。
今回の変更では、「DOM和スタイル」から `readonly` の定義を削除することで、

* `readonly` プロパティを定義させない
* 「DOM設定変更」で `style` のメンバを設定するだけにさせない

ことになり、「DOM属性設定」で `readonly` 属性を設定する (要素を読み取り専用にする) ことができるようにします。
