### PR TITLE
fix: AJAX_JSON取得で空レスポンス（204 No Content）が来るとエラーになる問題を修正

### DIFF
--- a/src/plugin_browser_ajax.mts
+++ b/src/plugin_browser_ajax.mts
@@ -117,7 +117,12 @@ export default {
       if (options === '') { options = { method: 'GET' } }
       const res = await fetch(url, options)
       const text = await res.text()
-      if (!text || text.trim() === '') { return null }
+      const status = res.status
+      const contentLength = res.headers.get('Content-Length')
+      if ((!text || text.trim() === '') &&
+        ((status === 204 || status === 205) || contentLength === '0')) {
+        return null
+      }
       return JSON.parse(text)
     },
     return_none: false


### PR DESCRIPTION
## 問題
`AJAX_JSON取得` で Supabase の `Prefer: return=minimal` などによる空レスポンス（204 No Content）が返ると、`res.json()` がエラーになります。

## 修正
`res.text()` 経由に変更し、空文字の場合は `null` を返すようにしました。

## 再現方法
```nako3
オプション = {"method":"PATCH","headers":{"Content-Type":"application/json","Prefer":"return=minimal"},"body":"{}"}
オプションにAJAXオプション設定。
エラー監視
  URLからAJAX_JSON取得。   # ← 空レスポンスでJSONエラーになる
エラーならば
  「エラー」と表示。
ここまで
```

## 影響範囲
`plugin_browser_ajax.mts` のみ。cnako3側への影響なし。