### PR TITLE
fix: 変数名が「秒」で終わると「秒待機」等の命令と誤結合するトークナイザーバグを修正

### DIFF
--- a/core/src/nako_lex_rules.mts
+++ b/core/src/nako_lex_rules.mts
@@ -219,6 +219,11 @@ function cbWordParser(src: string, isTrimOkurigana = true): NakoLexParseResult {
     src = res.charAt(res.length - 1) + src
     res = res.slice(0, -1)
   }
+  // 変数名に「秒」が含まれると「秒待機」等の命令と連結されるバグ修正 (#NE-016)
+  if (/[ぁ-んァ-ヶ\u4E00-\u9FCF]秒$/.test(res)) {
+    src = '秒' + src
+    res = res.slice(0, -1)
+  }
   // 「以上」「以下」「超」「未満」 #918
   const ii = wordHasIjoIka.exec(res)
   if (ii) {

--- a/core/src/nako_lex_rules.mts
+++ b/core/src/nako_lex_rules.mts
@@ -219,10 +219,26 @@ function cbWordParser(src: string, isTrimOkurigana = true): NakoLexParseResult {
     src = res.charAt(res.length - 1) + src
     res = res.slice(0, -1)
   }
-  // 変数名に「秒」が含まれると「秒待機」等の命令と連結されるバグ修正 (#NE-016)
-  if (/[ぁ-んァ-ヶ\u4E00-\u9FCF]秒$/.test(res)) {
-    src = '秒' + src
-    res = res.slice(0, -1)
+  // 変数名末尾の「秒」が「秒待機」等の命令と誤結合するバグ修正 (#NE-016)
+  // 例: 「間隔秒秒待機」→ res=「間隔秒秒待機」の末尾が「秒待機」なら src に戻す
+  // 「間隔秒=5」のような通常の変数名は分割しない
+  {
+    const secondCmdSuffixes = [
+      '秒タイマー開始時', // 長い順に並べて最長一致させる
+      '秒逐次待機',
+      '秒待機',
+      '秒後',
+      '秒毎',
+      '秒差',
+      '秒待',
+    ]
+    for (const suffix of secondCmdSuffixes) {
+      if (res.endsWith(suffix) && res.length > suffix.length) {
+        src = suffix + src
+        res = res.slice(0, -suffix.length)
+        break
+      }
+    }
   }
   // 「以上」「以下」「超」「未満」 #918
   const ii = wordHasIjoIka.exec(res)


### PR DESCRIPTION
## 問題
変数名が「秒」で終わる場合（例：`間隔秒`）、トークナイザーが `秒待機` などの命令と連結してしまいエラーになります。

## 再現コード
```nako3
# ❌ エラーになる
間隔秒 = 5
間隔秒秒待機   # → 「間隔秒秒待機」という未解決トークンになる

# ✅ 回避策（現在）
ポーリング間隔 = 5
(ポーリング間隔)秒待機
```

## 修正
「間」の特殊ルール（#831）と同様のアプローチで、「秒」を末尾に持つ単語をトークン分割します。

## 影響範囲
`core/src/nako_lex_rules.mts` のみ。