### PR TITLE
#2300 ファイルコピー/移動のデフォルト動作に上書きモードを追加

### DIFF
--- a/src/plugin_node.mts
+++ b/src/plugin_node.mts
@@ -683,18 +683,19 @@ export default {
       return fse.mkdirpSync(path)
     }
   },
-  'ファイルコピー': { // @パスAをパスBへファイルコピーする(コピー先が存在するなら失敗) // @ふぁいるこぴー
+  'ファイルコピーデフォルト動作': { type: 'var', value: '上書禁止' }, // @ふぁいるこぴーでふぉるとどうさ
+  'ファイルコピー': { // @パスAをパスBへファイルコピーする(『ファイルコピーデフォルト動作』が「上書」「上書き」「overwrite」なら上書きコピー、それ以外はコピー先が存在するなら失敗) // @ふぁいるこぴー
     type: 'func',
     josi: [['から', 'を'], ['に', 'へ']],
     pure: true,
     asyncFn: true,
     fn: async function(a: string, b: string, sys: NakoSystem) {
-      // コピー先が既に存在する場合はエラー
-      if (await fse.pathExists(b)) {
+      const mode: string = sys.__getSysVar('ファイルコピーデフォルト動作')
+      const overwrite = (mode === '上書き' || mode === '上書' || mode === 'overwrite')
+      if (!overwrite && await fse.pathExists(b)) {
         throw new Error(`ファイルコピー先に同名のファイルまたはフォルダが存在します: ${b}`)
       }
-      // 進捗コールバック付きでコピーを実行（overwrite: false で衝突時はエラー）
-      await copyMergeWithProgress(a, b, false, sys)
+      await copyMergeWithProgress(a, b, overwrite, sys)
     },
     return_none: true
   },
@@ -721,18 +722,18 @@ export default {
     },
     return_none: false
   },
-  'ファイル移動': { // @パスAをパスBへ移動する(移動先が存在するなら失敗) // @ふぁいるいどう
+  'ファイル移動': { // @パスAをパスBへ移動する(『ファイルコピーデフォルト動作』が「上書」「上書き」「overwrite」なら上書き移動、それ以外は移動先が存在するなら失敗) // @ふぁいるいどう
     type: 'func',
     josi: [['から', 'を'], ['に', 'へ']],
     pure: true,
     asyncFn: true,
     fn: async function(a: string, b: string, sys: NakoSystem) {
-      // 移動先が既に存在する場合はエラー
-      if (await fse.pathExists(b)) {
+      const mode: string = sys.__getSysVar('ファイルコピーデフォルト動作')
+      const overwrite = (mode === '上書き' || mode === '上書' || mode === 'overwrite')
+      if (!overwrite && await fse.pathExists(b)) {
         throw new Error(`ファイル移動先に同名のファイルまたはフォルダが存在します: ${b}`)
       }
-      // 進捗コールバック付きでコピーを実行し、その後ソースを削除（overwrite: false で衝突時はエラー）
-      await copyMergeWithProgress(a, b, false, sys)
+      await copyMergeWithProgress(a, b, overwrite, sys)
       if (!sys.tags.__fileProcessStop) {
         await fse.remove(a)
       }

--- a/test/node/plugin_node_test.mjs
+++ b/test/node/plugin_node_test.mjs
@@ -286,6 +286,18 @@ describe('plugin_node_test', () => {
       fs.rmSync(tmp, { recursive: true })
     }
   })
+  it('ファイルコピー - デフォルト動作をoverwriteにすると上書き成功', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'nako3-cp-overwrite-'))
+    try {
+      const src = path.join(tmp, 'src.txt')
+      const dest = path.join(tmp, 'dest.txt')
+      fs.writeFileSync(src, 'new-data')
+      fs.writeFileSync(dest, 'old-data')
+      await cmp(`ファイルコピーデフォルト動作="overwrite"。「${src}」を「${dest}」へファイルコピー。「${dest}」を読む。トリムして表示。`, 'new-data', 200)
+    } finally {
+      fs.rmSync(tmp, { recursive: true })
+    }
+  })
   it('ファイル上書コピー - ディレクトリのマージコピー', async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'nako3-merge-cp-'))
     try {
@@ -331,6 +343,19 @@ describe('plugin_node_test', () => {
       assert.strictEqual(g.numFailures > 0, true, '移動先が存在する場合はエラーになるべき')
     } finally {
       fs.rmSync(tmp, { recursive: true })
+    }
+  })
+  it('ファイル移動 - デフォルト動作を上書きにすると上書き成功', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'nako3-mv-overwrite-'))
+    try {
+      const src = path.join(tmp, 'src.txt')
+      const dest = path.join(tmp, 'dest.txt')
+      fs.writeFileSync(src, 'moved-data')
+      fs.writeFileSync(dest, 'old-data')
+      await cmp(`ファイルコピーデフォルト動作="上書き"。「${src}」を「${dest}」へファイル移動。「${dest}」を読む。トリムして表示。`, 'moved-data', 200)
+      assert.strictEqual(fs.existsSync(src), false, '上書き移動後はソースファイルが消えるべき')
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
     }
   })
   it('ファイル上書移動 - ディレクトリのマージ移動', async () => {


### PR DESCRIPTION
## 概要
- 「ファイルコピーデフォルト動作」変数を追加し、「ファイルコピー」「ファイル移動」で参照するようにしました。
- 値が「上書」「上書き」「overwrite」のときは上書きモードで動作し、それ以外は従来どおり存在時エラーになります。

## 変更点
- src/plugin_node.mts
  - 「ファイルコピーデフォルト動作」を追加（初期値: 「上書禁止」）
  - 「ファイルコピー」と「ファイル移動」の overwrite 判定を導入
- test/node/plugin_node_test.mjs
  - overwrite指定時に既存ファイルへコピー/移動できることを確認するテストを追加

## テスト
- node --test --test-concurrency=1 --test-timeout=15000 --test-force-exit --test-reporter=spec --import ./test/node-test-globals.mjs test/node/plugin_node_test.mjs

Closes #2300
