### PR TITLE
Node v18のサポート切るために、coreをシンプルにしたらコンパイルに失敗する問題を修正 #2285

### DIFF
--- a/batch/copy_core.nako3
+++ b/batch/copy_core.nako3
@@ -11,7 +11,9 @@ NAKO3CORE_DIR=REPOS_DIR&「/nadesiko3core」
 「{NAKO3_DIR}/core/src/*.mts」を「{NAKO3CORE_DIR}/src」へ列挙コピー。
 「{NAKO3_DIR}/core/*.mts」を「{NAKO3CORE_DIR}」へ列挙コピー。
 「{NAKO3_DIR}/core/test/*」を「{NAKO3CORE_DIR}/test」へ列挙コピー。
-「{NAKO3_DIR}/core/package.json」を「{NAKO3CORE_DIR}/package.json」へファイル上書きコピー。
+「{NAKO3_DIR}/core/batch/*」を「{NAKO3CORE_DIR}/batch」へ列挙コピー。
+「{NAKO3_DIR}/core/package.json」を「{NAKO3CORE_DIR}/package.json」へファイル上書コピー。
+「{NAKO3_DIR}/core/tsconfig.json」を「{NAKO3CORE_DIR}/tsconfig.json」へファイル上書コピー。
 「[OK] COPY」と表示。
 ＃＃＃
 MSG="auto commit ver{ナデシコバージョン}"

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -32,7 +32,7 @@
     },
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     "typeRoots": ["src/@types","node_modules/@types",],  /* Specify multiple folders that act like `./node_modules/@types`. */
-    "types": ["node"],                          /* Specify type package names to be included without being referenced in a source file. */
+    "types": ["node"],                                   /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "resolveJsonModule": true,                        /* Enable importing .json files */
     // "noResolve": true,                                /* Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project. */


### PR DESCRIPTION
Node v18のサポート切るために、coreをシンプルにしたらコンパイルに失敗する問題を修正 #2285