### PR TITLE
node-fetch依存を削除 #2328

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
     "html": "^1.0.0",
     "iconv-lite": "^0.7.2",
     "marked": "^18.0.5",
-    "node-fetch": "^3.3.2",
     "opener": "^1.5.2",
     "shell-quote": "^1.8.4",
     "smol-toml": "1.6.1"

--- a/src/cnako3mod.mts
+++ b/src/cnako3mod.mts
@@ -11,7 +11,6 @@ import path from 'node:path'
 import url from 'node:url'
 import fse from 'fs-extra'
 
-import fetch from 'node-fetch'
 import { NakoCompiler, LoaderTool, newCompilerOptions } from '../core/src/nako3.mjs'
 import { NakoImportError } from '../core/src/nako_errors.mjs'
 
@@ -278,7 +277,7 @@ export class CNako3 extends NakoCompiler {
     // or 以下のコピーだと依存ファイルがコピーされない package.jsonを見てコピーする必要がある
     const orgModule = path.join(__dirname, '..', 'node_modules')
     const dirNodeModules = path.join(path.dirname(opt.output), 'node_modules')
-    const modlist = ['fs-extra', 'iconv-lite', 'opener', 'node-fetch', 'shell-quote']
+    const modlist = ['fs-extra', 'iconv-lite', 'opener', 'shell-quote']
     const copied: { [key: string]: boolean } = {}
     // 再帰的に必要なモジュールをコピーする
     const copyModule = (mod: string) => {

--- a/src/plugin_node.mts
+++ b/src/plugin_node.mts
@@ -14,7 +14,6 @@ import url from 'node:url'
 import opener from 'opener'
 import iconv from 'iconv-lite'
 import shellQuote from 'shell-quote'
-import fetch, { FormData, Blob } from 'node-fetch'
 import fse from 'fs-extra'
 import { NakoSystem } from '../core/src/plugin_api.mjs'
 

--- a/test/node/package_json_test.mjs
+++ b/test/node/package_json_test.mjs
@@ -1,0 +1,17 @@
+import fs from 'node:fs'
+import assert from 'node:assert'
+import { test } from 'node:test'
+
+test('package.json に node-fetch の依存がない', () => {
+  const pkgUrl = new URL('../../package.json', import.meta.url)
+  const pkg = JSON.parse(fs.readFileSync(pkgUrl, 'utf-8'))
+  const dependencySections = [
+    'dependencies',
+    'devDependencies',
+    'optionalDependencies',
+    'peerDependencies'
+  ]
+  for (const section of dependencySections) {
+    assert.equal(pkg[section]?.['node-fetch'], undefined, `${section} に node-fetch が含まれています`)
+  }
+})


### PR DESCRIPTION
## 概要
- package.json から node-fetch の依存を削除
- Node 実装の node-fetch import を削除し、グローバル fetch / FormData / Blob を利用
- 単体実行出力時のコピー対象モジュールから node-fetch を削除
- package.json に node-fetch が戻らないことを確認するテストを追加

## テスト
- npm run build:tsc
- npm run test:node

Closes #2328