### PR TITLE
pluin_system分割で発覚した問題の修正 #2355

### DIFF
--- a/core/src/plugin_system_datetime.mts
+++ b/core/src/plugin_system_datetime.mts
@@ -355,7 +355,7 @@ export default {
     josi: [],
     pure: true,
     fn: function() {
-      if (performance && performance.now) {
+      if (typeof performance !== 'undefined' && performance.now) {
         return performance.now()
       } else if (Date.now) {
         return Date.now()

--- a/core/src/plugin_system_debug.mts
+++ b/core/src/plugin_system_debug.mts
@@ -60,6 +60,8 @@ export default {
       // nameが文字列ならevalして関数を得る
       if (typeof f === 'string') { f = sys.__findFunc(f, 'AWAIT実行') }
       if (!(f instanceof Function)) { throw new Error('『AWAIT実行』の第一引数はなでしこ関数名かFunction型で指定してください。') }
+      // argsがArrayでなければArrayに変換する
+      if (!(args instanceof Array)) { args = [args] }
       // 実行
       return await f(...args)
     }
@@ -153,7 +155,7 @@ export default {
     fn: function(f: any, sys: any) {
       if (typeof f === 'string') { f = sys.__findFunc(f, '実行時間計測') }
       //
-      if (performance && performance.now) {
+      if (typeof performance !== 'undefined' && performance.now) {
         const t1 = performance.now()
         f(sys)
         const t2 = performance.now()

--- a/core/src/plugin_system_string.mts
+++ b/core/src/plugin_system_string.mts
@@ -49,8 +49,11 @@ export default {
       // 配列のとき
       const res: string[] = []
       for (const s of v) {
-        if (!String.fromCodePoint) { res.push(String.fromCharCode(s)) }
-        res.push(String.fromCodePoint(s))
+        if (!String.fromCodePoint) {
+          res.push(String.fromCharCode(s))
+        } else {
+          res.push(String.fromCodePoint(s))
+        }
       }
       return res
     }
@@ -66,8 +69,11 @@ export default {
       }
       const res: number[] = []
       for (const s of v) {
-        if (!String.prototype.codePointAt) { res.push(String(s).charCodeAt(0)) }
-        res.push(String(s).codePointAt(0) || 0)
+        if (!String.prototype.codePointAt) {
+          res.push(String(s).charCodeAt(0))
+        } else {
+          res.push(String(s).codePointAt(0) || 0)
+        }
       }
       return res
     }

--- a/core/src/plugin_system_url.mts
+++ b/core/src/plugin_system_url.mts
@@ -39,10 +39,20 @@ export default {
       }
       const params = p[1].split('&')
       for (const line of params) {
-        const line2 = line + '='
-        const kv = line2.split('=')
-        const k = sys.__exec('URLデコード', [kv[0]])
-        res[k] = sys.__exec('URLデコード', [kv[1]])
+        if (line === '') { continue }
+        const eqIdx = line.indexOf('=')
+        let k: string
+        let v: string
+        if (eqIdx < 0) {
+          k = line
+          v = ''
+        } else {
+          k = line.substring(0, eqIdx)
+          v = line.substring(eqIdx + 1)
+        }
+        const decodedKey = sys.__exec('URLデコード', [k])
+        const decodedVal = sys.__exec('URLデコード', [v])
+        res[decodedKey] = decodedVal
       }
       return res
     }

--- a/core/test/plugin_system_debug_test.mjs
+++ b/core/test/plugin_system_debug_test.mjs
@@ -65,6 +65,13 @@ describe('plugin_system_debug_test', async () => {
     await new Promise((resolve) => setTimeout(resolve, 10))
     assert.strictEqual(g.log, '42')
   })
+  it('特殊命令 - AWAIT実行（配列以外の引数）', async () => {
+    const nako = new NakoCompiler()
+    const code = 'F=「a=>a*2」をJS実行\nFを21でAWAIT実行して表示'
+    const g = await nako.runAsync(code, 'main.nako3')
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    assert.strictEqual(g.log, '42')
+  })
   it('特殊命令 - ナデシコ', async () => {
     await cmp('『「なでしこ」を表示』をナデシコ', 'なでしこ')
   })

--- a/core/test/plugin_system_test.mjs
+++ b/core/test/plugin_system_test.mjs
@@ -477,6 +477,8 @@ describe('plugin_system_test', async () => {
   it('URLパラメータ解析', async () => {
     await cmp('「http://hoge.com/」のURLパラメータ解析してJSONエンコードして表示', '{}')
     await cmp('「https://nadesi.com/?a=3&b=5」のURLパラメータ解析;それ["a"]を表示;それ["b"]を表示。', '3\n5')
+    await cmp('「https://nadesi.com/?a=3=3&b=5」のURLパラメータ解析;それ["a"]を表示;それ["b"]を表示。', '3=3\n5')
+    await cmp('「https://nadesi.com/?a&b=5」のURLパラメータ解析;それ["a"]を表示;それ["b"]を表示。', '\n5')
   })
   it('助詞省略形のコマンド', async () => {
     await cmp('3が1以上。もし、そうなら「OK」と表示。', 'OK')


### PR DESCRIPTION
#2355 に対する修正です。

### 修正内容

1. **`URLパラメータ解析`の問題の修正**
   * 最初に見つかる `=` でキーと値を正しく分割する方式に変更し、値に `=` が含まれる場合や `=` のないパラメータでも正しく動作するようにしました。
   * テストケースを追加しました。

2. **`CHR` の問題の修正（`ASC` も含む）**
   * 配列処理において `String.fromCodePoint`（`ASC` の場合は `codePointAt`）が存在しない環境で例外が発生する問題、および存在する環境で値が重複して `push` される不具合を `if-else` 分岐で修正しました。

3. **`AWAIT実行`の問題の修正**
   * 第二引数 `args` が配列以外の場合でも、正しく `[args]` として配列に正規化してから関数を呼び出すようにガード処理を追加しました。
   * テストケースを追加しました。

4. **`実行時間計測`の問題の修正**
   * `performance` が未定義の環境で `ReferenceError` になるのを防ぐため、`typeof performance !== 'undefined'` でガードするように修正しました。

5. **`時間ミリ秒取得`の問題の修正**
   * `performance` が未定義の環境で `ReferenceError` になるのを防ぐため、`typeof performance !== 'undefined'` でガードするように修正しました。
