### PR TITLE
core: useIndentSynax のスペルミスを useIndentSyntax に修正 (#2333)

### DIFF
--- a/core/src/nako_indent_inline.mts
+++ b/core/src/nako_indent_inline.mts
@@ -221,7 +221,7 @@ const INDENT_MODE_KEYWORDS = ['!インデント構文', '!ここまでだるい'
 /** インデント構文 --- インデントを見て"ここまで"を自動挿入 (#596) */
 export function convertIndentSyntax(tokens: Token[]): Token[] {
   // インデント構文の変換が必要か?
-  if (!useIndentSynax(tokens)) { return tokens }
+  if (!useIndentSyntax(tokens)) { return tokens }
   // 『ここまで』があったらエラーを出す
   for (const t of tokens) {
     if (t.type === 'ここまで') {
@@ -321,7 +321,7 @@ export function convertIndentSyntax(tokens: Token[]): Token[] {
   return result
 }
 
-function useIndentSynax(tokens: Token[]) : boolean {
+function useIndentSyntax(tokens: Token[]) : boolean {
   // インデント構文が必要かチェック (最初の100個をチェック)
   for (let i = 0; i < tokens.length; i++) {
     if (i > 100) { break }

--- a/core/test/indent_test.mjs
+++ b/core/test/indent_test.mjs
@@ -292,4 +292,10 @@ describe('indent', async () => {
         '\t\t続ける\n' +
         '\tcを表示\n', '1\n0')
   })
+  it('useIndentSyntaxが正しく動作し、インデント構文が解釈されること (#2333)', async () => {
+    await cmp('!インデント構文\n' +
+        'もし1=1ならば\n' +
+        '　　「OK」と表示。\n', 'OK')
+  })
 })
+


### PR DESCRIPTION
非公開APIである `useIndentSynax` のスペルミスを `useIndentSyntax` に修正しました。また、関連するテストケースを追加しました。

https://github.com/kujirahand/nadesiko3/issues/2359