### PR TITLE
NakoCompilerから依存ファイル読み込みとプラグイン管理を分離 (#2360)

### DIFF
--- a/core/src/nako3.mts
+++ b/core/src/nako3.mts
@@ -17,9 +17,12 @@ import { convertInlineIndent, convertIndentSyntax } from './nako_indent_inline.m
 import { convertDNCL } from './nako_from_dncl.mjs'
 import { convertDNCL2 } from './nako_from_dncl2.mjs'
 import { SourceMappingOfTokenization, SourceMappingOfIndentSyntax, OffsetToLineColumn, subtractSourceMapByPreCodeLength } from './nako_source_mapping.mjs'
-import { NakoLexerError, NakoImportError, NakoSyntaxError, InternalLexerError } from './nako_errors.mjs'
+import { NakoLexerError, NakoSyntaxError, InternalLexerError } from './nako_errors.mjs'
 import { NakoLogger } from './nako_logger.mjs'
 import { NakoGlobal } from './nako_global.mjs'
+// 取り込み文(require)の処理 / プラグイン管理 (#2360)
+import { Dependencies, LoaderTool, listRequireStatements, NakoRequireHost, NakoRequireLoader, NakoRequireScanner } from './nako_require.mjs'
+import { NakoPluginHost, NakoPluginManager } from './nako_plugin_manager.mjs'
 // version info
 import coreVersion from './nako_core_version.mjs'
 // basic plugins
@@ -30,32 +33,13 @@ import PluginPromise from './plugin_promise.mjs'
 import PluginTOML from './plugin_toml.mjs'
 import PluginTest from './plugin_test.mjs'
 
-const cloneAsJSON = (x: any): any => JSON.parse(JSON.stringify(x))
-const PLUGIN_MIN_VERSION_INT = 600 // = minor * 100 + patch
-
 export interface NakoCompilerOption {
   useBasicPlugin: boolean;
 }
 
-/** インタプリタに「取り込み」文を追加するために用意するオブジェクト */
-export interface LoaderToolTask<T> {
-  task: Promise<T>;
-}
-export interface LoaderTool {
-  // type: 'nako3' | 'js' | 'invalid' | 'mjs'
-  resolvePath: (name: string, token: Token, fromFile: string) => { type: string, filePath: string };
-  readNako3: (filePath: string, token: Token) => LoaderToolTask<string>;
-  readJs: (filePath: string, token: Token) => LoaderToolTask<any>;
-}
-
-interface DependenciesItem {
-  tokens: Token[];
-  alias: Set<string>;
-  addPluginFile: () => void;
-  funclist: any;
-  moduleExport: any;
-}
-type Dependencies = { [key:string]:DependenciesItem }
+// 取り込み文に関する型は nako_require.mts へ移動したが、
+// 外部から `nako3.mjs` 経由で参照されているため再エクスポートする (#2360)
+export type { LoaderTool, LoaderToolTask, Dependencies, DependenciesItem } from './nako_require.mjs'
 
 interface LexResult {
   commentTokens: Token[];
@@ -85,13 +69,13 @@ export class NakoCompiler {
   private nakoFuncList: FuncList
   private funclist: FuncList
   private moduleExport: ExportMap
-  private pluginFunclist: Record<string, FuncListItem>
-  private pluginfiles: Record<string, any>
-  private commandlist: Set<string>
   private prepare: NakoPrepare
   private parser: NakoParser
   private lexer: NakoLexer
-  private dependencies: Dependencies
+  /** プラグイン管理 (#2360) */
+  private pluginManager: NakoPluginManager
+  /** 取り込み文の処理 (#2360) */
+  private requireLoader: NakoRequireLoader
   private usedFuncs: Set<string>
   private codeGenerateor: {[key: string]: any}
   protected logger: NakoLogger
@@ -133,12 +117,8 @@ export class NakoCompiler {
     this.coreVersion = coreVersion.version
     this.__globals = [] // 生成した NakoGlobal のインスタンスを保持
     this.__globalObj = null
-    this.__module = {} // requireなどで取り込んだモジュールの一覧
-    this.pluginFunclist = {} // プラグインで定義された関数
     this.funclist = this.newVaiables() // プラグインで定義された関数 + ユーザーが定義した関数
     this.moduleExport = this.newVaiables()
-    this.pluginfiles = {} // 取り込んだファイル一覧
-    this.commandlist = new Set() // プラグインで定義された定数・変数・関数の名前
     this.nakoFuncList = this.newVaiables() // __v1に配置するJavaScriptのコードで定義された関数
     this.eventList = [] // 実行前に環境を変更するためのイベント
     this.codeGenerateor = {} // コードジェネレータ
@@ -147,13 +127,27 @@ export class NakoCompiler {
     this.logger = new NakoLogger()
     this.filename = 'main.nako3'
 
-    /**
-     * 取り込み文を置換するためのオブジェクト。
-     * 正規化されたファイル名がキーになり、取り込み文の引数に指定された正規化されていないファイル名はaliasに入れられる。
-     * JavaScriptファイルによるプラグインの場合、contentは空文字列。
-     * funclistはシンタックスハイライトの高速化のために事前に取り出した、ファイルが定義する関数名のリスト。
-     */
-    this.dependencies = {}
+    // プラグイン管理を生成する (#2360)
+    const pluginHost: NakoPluginHost = {
+      getFuncList: () => this.funclist, // reset() で差し替わるため、その都度参照する
+      getSysVars: () => this.__varslist[0],
+      getLogger: () => this.logger
+    }
+    this.pluginManager = new NakoPluginManager(pluginHost)
+    // requireなどで取り込んだモジュールの一覧(プラグイン管理と同じオブジェクトを共有する)
+    this.__module = this.pluginManager.modules
+
+    // 取り込み文の処理を生成する (#2360)
+    const requireHost: NakoRequireHost = {
+      rawtokenize: (code, line, filename, preCode) => this.rawtokenize(code, line, filename, preCode),
+      addPluginFromFile: (fpath, po, persistent) => this.addPluginFromFile(fpath, po, persistent),
+      getLogger: () => this.logger,
+      // 名前空間(modList)を汚さないように、取り込み文の検出には別のコンパイラを使う
+      createScanner: (): NakoRequireScanner => new NakoCompiler({ useBasicPlugin: true }),
+      countFailure: () => { this.numFailures++ }
+    }
+    this.requireLoader = new NakoRequireLoader(requireHost)
+
     this.usedFuncs = new Set()
     this.numFailures = 0
 
@@ -189,7 +183,18 @@ export class NakoCompiler {
   }
 
   getPluginfiles(): Record<string, any> {
-    return this.pluginfiles
+    return this.pluginManager.pluginfiles
+  }
+
+  /**
+   * 取り込み文を置換するためのオブジェクト。
+   * 正規化されたファイル名がキーになり、取り込み文の引数に指定された正規化されていないファイル名はaliasに入れられる。
+   * JavaScriptファイルによるプラグインの場合、contentは空文字列。
+   * funclistはシンタックスハイライトの高速化のために事前に取り出した、ファイルが定義する関数名のリスト。
+   * (エディタのシンタックスハイライトから参照される)
+   */
+  get dependencies (): Dependencies {
+    return this.requireLoader.dependencies
   }
 
   /**
@@ -214,171 +219,26 @@ export class NakoCompiler {
 
   /**
    * ファイル内のrequire文の位置を列挙する。出力の配列はstartでソートされている。
+   * (実体は nako_require.mts の listRequireStatements)
    * @param {Token[]} tokens rawtokenizeの出力
    */
-  static listRequireStatements(tokens: Token[]): Token[] {
-    const requireStatements: Token[] = []
-    for (let i = 0; i + 2 < tokens.length; i++) {
-      // not (string|string_ex) '取り込み'
-      if (!(tokens[i].type === 'not' &&
-        (tokens[i + 1].type === 'string' || tokens[i + 1].type === 'string_ex') &&
-        tokens[i + 2].value === '取込')) {
-        continue
-      }
-      // 取り込むライブラリ
-      let filename = String(tokens[i + 1].value) + ''
-      // 全角コロン「：」を半角コロン「:」に正規化する（「貯蔵庫：」「拡張プラグイン：」の記法に対応 #2282）
-      filename = filename.replace(/^(貯蔵庫|拡張プラグイン)：/, '$1:')
-      // 『取り込む』文で「拡張プラグイン:」機構を追加する #139
-      // (ex) !『貯蔵庫:ojyo-sama.nako3』を取り込む → https://n3s.nadesi.com/plain/ojyo-sama.nako3
-      if (filename.startsWith('貯蔵庫:') || filename.startsWith('貯蔵庫：')) {
-        filename = `https://n3s.nadesi.com/plain/${filename.substring(4)}`
-      }
-      // (ex) !『拡張プラグイン:music.js@1.0.2』を取り込む → https://cdn.jsdelivr.net/npm/nadesiko3-music@1.0.2/nadesiko3-music.js
-      if (filename.startsWith('拡張プラグイン:') || filename.startsWith('拡張プラグイン：')) {
-        const name = filename.substring('拡張プラグイン:'.length)
-        const m = name.match(/^([a-zA-Z0-9_-]+)\.(js|mjs|nako3)(@[0-9.]+)?$/)
-        if (m) {
-          let basename = m[1]
-          const ext = m[2]
-          const version = m[3] || '@latest'
-          if (ext === 'js' || ext === 'mjs') {
-            // JSプラグイン
-            if (!basename.startsWith('nadesiko3-')) {
-              basename = `nadesiko3-${basename}`
-            }
-            filename = `https://cdn.jsdelivr.net/npm/${basename}${version}/${basename}.${ext}`
-          } else {
-            // なでしこ3プラグイン
-            filename = `https://n3s.nadesi.com/plain/${basename}.${ext}`
-          }
-        } else {
-          throw new NakoImportError('『取込』の指定エラー。『拡張プラグイン:(ファイル名).(js|nako3)(@ver)』の書式で指定してください。', tokens[i].file, tokens[i].line)
-        }
-      }
-      // push
-      requireStatements.push({
-        ...tokens[i],
-        start: i,
-        end: i + 3,
-        value: filename,
-        firstToken: tokens[i],
-        lastToken: tokens[i + 2]
-      })
-      i += 2
-    }
-    return requireStatements
+  static listRequireStatements (tokens: Token[]): Token[] {
+    return listRequireStatements(tokens)
   }
 
   /**
    * プログラムが依存するファイルを再帰的に取得する。
-   * - 依存するファイルがJavaScriptファイルの場合、そのファイルを実行して評価結果をthis.addPluginFileに渡す。
-   * - 依存するファイルがなでしこ言語の場合、ファイルの中身を取得して変数に保存し、再帰する。
+   * (実体は nako_require.mts の NakoRequireLoader.load)
    *
    * @param {string} code
    * @param {string} filename
    * @param {string} preCode
    * @param {LoaderTool} tools 実行環境 (ブラウザ or Node.js) によって外部ファイルの取得・実行方法は異なるため、引数でそれらを行う関数を受け取る。
-   *  - resolvePath は指定した名前をもつファイルを検索し、正規化されたファイル名を返す関数。返されたファイル名はreadNako3かreadJsの引数になる。
-   *  - readNako3は指定されたファイルの中身を返す関数。
-   *  - readJsは指定したファイルをJavaScriptのプログラムとして実行し、`export default` でエクスポートされた値を返す関数。
    * @returns {Promise<unknown> | void}
    * @protected
    */
-  _loadDependencies(code: string, filename: string, preCode: string, tools: LoaderTool) {
-    const dependencies: Dependencies = {}
-    const compiler = new NakoCompiler({ useBasicPlugin: true })
-    /**
-     * @param {any} item
-     * @param {any} tasks
-     */
-    const loadJS = (item: any, tasks: any) => {
-      // jsならプラグインとして読み込む。(ESMでは必ず動的に読む)
-      const obj = tools.readJs(item.filePath, item.firstToken)
-      tasks.push(obj.task.then((res: any) => {
-        const pluginFuncs = res()
-        this.addPluginFromFile(item.filePath, pluginFuncs)
-        dependencies[item.filePath].funclist = pluginFuncs
-        dependencies[item.filePath].moduleExport = {}
-        dependencies[item.filePath].addPluginFile = () => { this.addPluginFromFile(item.filePath, pluginFuncs) }
-      }))
-    }
-    const loadNako3 = (item: any, tasks: any) => {
-      // nako3ならファイルを読んでdependenciesに保存する。
-      const content = tools.readNako3(item.filePath, item.firstToken)
-      const registerFile = (code: string) => {
-        // シンタックスハイライトの高速化のために、事前にファイルが定義する関数名のリストを取り出しておく。
-        // preDefineFuncはトークン列に変更を加えるため、事前にクローンしておく。
-        // 「プラグイン名設定」を行う (#956)
-        const modName = NakoLexer.filenameToModName(item.filePath)
-        code = `『${modName}』に名前空間設定;『${modName}』にプラグイン名設定;` + code + ';名前空間ポップ;'
-        const tokens = this.rawtokenize(code, 0, item.filePath)
-        dependencies[item.filePath].tokens = tokens
-        const funclist = new Map()
-        const moduleexport = new Map()
-        NakoLexer.preDefineFunc(cloneAsJSON(tokens), this.logger, funclist, moduleexport)
-        dependencies[item.filePath].funclist = funclist
-        dependencies[item.filePath].moduleExport = moduleexport
-        // 再帰
-        return loadRec(code, item.filePath, '')
-      }
-      // 取り込み構文における問題を減らすため、必ず非同期でプログラムを読み込む仕様とした #1219
-      tasks.push(content.task.then((res) => registerFile(res)))
-    }
-    const loadRec = (code: string, filename: string, preCode: string): Promise<unknown>|void => {
-      const tasks: Promise<unknown>[] = []
-      // 取り込みが必要な情報一覧を調べる(トークン分割して、取り込みタグを得る)
-      const tags = NakoCompiler.listRequireStatements(compiler.rawtokenize(code, 0, filename, preCode))
-      // パスを解決する
-      const tagsResolvePath = tags.map((v) => ({ ...v, ...tools.resolvePath(v.value, v.firstToken as Token, filename) }))
-      // 取り込み開始
-      for (const item of tagsResolvePath) {
-        // 2回目以降の読み込み
-        // eslint-disable-next-line no-prototype-builtins
-        if (dependencies.hasOwnProperty(item.filePath)) {
-          dependencies[item.filePath].alias.add(item.value)
-          continue
-        }
-
-        // 初回の読み込み
-         
-        dependencies[item.filePath] = { tokens: [], alias: new Set([item.value]), addPluginFile: ():void => {}, funclist: {}, moduleExport: {} }
-        if (item.type === 'js' || item.type === 'mjs') {
-          loadJS(item, tasks)
-        } else if (item.type === 'nako3') {
-          loadNako3(item, tasks)
-        } else {
-          throw new NakoImportError(`ファイル『${String(item.value)}』を読み込めません。ファイルが存在しないか未対応の拡張子です。`,
-            (item.firstToken as Token).file, (item.firstToken as Token).line)
-        }
-      }
-      if (tasks.length > 0) {
-        return Promise.all(tasks)
-      }
-      return undefined
-    }
-
-    try {
-      const result = loadRec(code, filename, preCode)
-
-      // 非同期な場合のエラーハンドリング
-      if (result !== undefined) {
-        result.catch((err) => {
-          // 読み込みに失敗したら処理を中断する
-          this.logger.error(err.msg)
-          this.numFailures++
-        })
-      }
-
-      // すべてが終わってからthis.dependenciesに代入する。そうしないと、「実行」ボタンを連打した場合など、
-      // loadDependencies() が並列実行されるときに正しく動作しない。
-      this.dependencies = dependencies
-      return result
-    } catch (err) {
-      // 同期処理では素直に例外を投げる
-      this.logger.error(String(err))
-      throw err
-    }
+  _loadDependencies (code: string, filename: string, preCode: string, tools: LoaderTool): Promise<unknown>|void {
+    return this.requireLoader.load(code, filename, preCode, tools)
   }
 
   /**
@@ -494,14 +354,7 @@ export class NakoCompiler {
     this.__locals = this.newVaiables()
 
     // プラグイン命令以外を削除する。
-    this.funclist = new Map()
-    for (const name of this.__v0.keys()) {
-      const original = this.pluginFunclist[name] // record
-      if (!original) {
-        continue
-      }
-      this.funclist.set(name, JSON.parse(JSON.stringify(original)))
-    }
+    this.funclist = this.pluginManager.createFuncListFromPlugins(this.__v0)
 
     this.lexer.setFuncList(this.funclist)
 
@@ -553,55 +406,23 @@ export class NakoCompiler {
   /**
    * 再帰的にrequire文を置換する。
    * .jsであれば削除し、.nako3であればそのファイルのトークン列で置換する。
-   * @param {TokenWithSourceMap[]} tokens
+   * (実体は nako_require.mts の NakoRequireLoader.replaceRequireStatements)
+   * @param {Token[]} tokens
    * @param {Set<string>} [includeGuard]
    * @returns {Token[]} 削除された取り込み文のトークン
    */
-  replaceRequireStatements(tokens: Token[], includeGuard:Set<string> = new Set()): Token[] {
-    /** @type {TokenWithSourceMap[]} */
-    const deletedTokens = []
-    for (const r of NakoCompiler.listRequireStatements(tokens).reverse()) {
-      // C言語のinclude guardと同じ仕組みで無限ループを防ぐ。
-      if (includeGuard.has(r.value)) {
-        deletedTokens.push(...tokens.splice((r.start || 0), (r.end || 0) - (r.start || 0)))
-        continue
-      }
-      const filePath = Object.keys(this.dependencies).find((key) => this.dependencies[key].alias.has(r.value))
-      if (filePath === undefined) {
-        if (!r.firstToken) { throw new Error(`ファイル『${String(r.value)}』が読み込まれていません。`) }
-        throw new NakoLexerError(`ファイル『${String(r.value)}』が読み込まれていません。`,
-          (r.firstToken).startOffset || 0,
-          (r.firstToken).endOffset || 0,
-          (r.firstToken).line, (r.firstToken).file)
-      }
-      this.dependencies[filePath].addPluginFile()
-      const children = cloneAsJSON(this.dependencies[filePath].tokens)
-      includeGuard.add(r.value)
-      deletedTokens.push(...this.replaceRequireStatements(children, includeGuard))
-      deletedTokens.push(...tokens.splice(r.start || 0, (r.end || 0) - (r.start || 0), ...children))
-    }
-    return deletedTokens
+  replaceRequireStatements (tokens: Token[], includeGuard: Set<string> = new Set()): Token[] {
+    return this.requireLoader.replaceRequireStatements(tokens, includeGuard)
   }
 
   /**
    * replaceRequireStatementsのシンタックスハイライト用の実装。
-   * @param {TokenWithSourceMap[]} tokens
-   * @returns {TokenWithSourceMap[]} 削除された取り込み文のトークン
+   * (実体は nako_require.mts の NakoRequireLoader.removeRequireStatements)
+   * @param {Token[]} tokens
+   * @returns {Token[]} 削除された取り込み文のトークン
    */
-  removeRequireStatements(tokens: Token[]): Token[] {
-    /** @type {TokenWithSourceMap[]} */
-    const deletedTokens = []
-    for (const r of NakoCompiler.listRequireStatements(tokens).reverse()) {
-      // プラグイン命令のシンタックスハイライトのために、addPluginFileを呼んで関数のリストをthis.dependencies[filePath].funclistに保存させる。
-      const filePath = Object.keys(this.dependencies).find((key) => this.dependencies[key].alias.has(r.value))
-      if (filePath !== undefined) {
-        this.dependencies[filePath].addPluginFile()
-      }
-
-      // 全ての取り込み文を削除する。そうしないとトークン化に時間がかかりすぎる。
-      deletedTokens.push(...tokens.splice(r.start || 0, (r.end || 0) - (r.start || 0)))
-    }
-    return deletedTokens
+  removeRequireStatements (tokens: Token[]): Token[] {
+    return this.requireLoader.removeRequireStatements(tokens)
   }
 
   /** 字句解析を行う */
@@ -698,7 +519,7 @@ export class NakoCompiler {
 
   deleteUnNakoFuncs(): Set<string> {
     for (const func of this.usedFuncs) {
-      if (!this.commandlist.has(func)) {
+      if (!this.pluginManager.hasCommand(func)) {
         this.usedFuncs.delete(func)
       }
     }
@@ -934,102 +755,13 @@ export class NakoCompiler {
 
   /**
    * プラグイン・オブジェクトを追加
+   * (実体は nako_plugin_manager.mts の NakoPluginManager.addPlugin)
    * @param po プラグイン・オブジェクト
    * @param persistent falseのとき、次以降の実行では使えない
    * @param fpath ファイルパス
    */
-  addPlugin(po: {[key: string]: any}, persistent = true, fpath = ''): void {
-    // __v0を取得
-    const __v0 = this.__varslist[0]
-    // プラグインのメタ情報をチェック (#1034) (#1647)
-    let __pluginInfo = __v0.get('__pluginInfo')
-    if (!__pluginInfo) {
-      __pluginInfo = {}
-      __v0.set('__pluginInfo', __pluginInfo)
-    }
-    // バージョンチェック
-    let intVersion = 0
-    let pluginName = 'unknown'
-    let metaValue = { pluginName: 'unknown', nakoVersionResult: true, nakoVersion: '0.0.0', path: '' }
-    if (po.meta) {
-      if (po.meta.value && typeof (po.meta) === 'object') {
-        const meta = po.meta
-        metaValue = meta.value || { pluginName: 'unknown', nakoVersion: '0.0.0' }
-        pluginName = metaValue.pluginName || 'unknown'
-        // version check
-        const nakoVersion = (metaValue.nakoVersion || '0.0.0') + '.0.0'
-        const versions = nakoVersion.split('.').map((v) => parseInt(v))
-        intVersion = versions[1] * 100 + versions[2]
-        // fpath
-        metaValue.path = fpath
-      }
-    }
-    // unknown の場合は、関数名からプラグイン名を自動生成する
-    if (pluginName === 'unknown') {
-      pluginName = Object.keys(po).join('-')
-    }
-    // プラグイン名の重複を確認
-    if (__pluginInfo[pluginName] !== undefined) {
-      // プラグイン名が重複した場合はプラグインとして登録しない
-      return
-    }
-    // Windowsのパスやファイル名に使えない文字列があると、JSファイル書き出しでエラーになるので置換
-    const removeInvalidFilenameChars = (str: string): string => {
-      return str.replace(/[^a-zA-z0-9\-_\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF\u3400-\u4DBF\uF900-\uFAFF]/g, '_')
-    }
-    pluginName = removeInvalidFilenameChars(pluginName)
-    // プラグイン情報を記録
-    __pluginInfo[pluginName] = metaValue
-    // バージョンチェック
-    if (PLUGIN_MIN_VERSION_INT > intVersion) {
-      const keyStr: string = Object.keys(po).join(',')
-      if (pluginName === 'unknown') {
-        pluginName = keyStr.substring(0, 30) + '...'
-      }
-      if (pluginName !== '') {
-        const errMsg = `なでしこプラグイン『${pluginName}』は古い形式なので正しく動作しない可能性があります。` +
-          `(ランタイムの要求: ${PLUGIN_MIN_VERSION_INT}/プラグイン: ${intVersion})`
-        console.warn(errMsg, 'see', 'https://github.com/kujirahand/nadesiko3/issues/1647')
-        this.logger.warn(errMsg)
-        metaValue.nakoVersionResult = false
-      }
-    }
-    // 初期化とクリアを変換する
-    this.__module[pluginName] = po
-    this.pluginfiles[pluginName] = '*'
-    // `初期化`と`クリア`をチェック
-    if (typeof (po['初期化']) === 'object') {
-      const def = po['初期化']
-      delete po['初期化']
-      const initKey = `!${pluginName}:初期化`
-      po[initKey] = def
-    }
-    // プラグインの値を、なでしこシステム変数(Map)にコピー
-    for (const key in po) {
-      const v = po[key]
-      this.funclist.set(key, v)
-      if (persistent) {
-        this.pluginFunclist[key] = JSON.parse(JSON.stringify(v))
-      }
-      if (v.type === 'func') {
-        __v0.set(key, v.fn)
-        if (v.asyncFn) { // asyncFn を正しく実行するために pure に変更する (core#142)
-          v.pure = true
-        }
-      } else if (v.type === 'const' || v.type === 'var') {
-        // メタ情報としての const | var は現在利用していない
-        // meta[key] = { readonly: v.type === 'const' }
-        __v0.set(key, v.value)
-      } else {
-        console.error('[プラグイン追加エラー]', v)
-        throw new Error('プラグインの追加でエラー。')
-      }
-      // コマンドを登録するか?
-      if (key === '初期化' || key.substring(0, 1) === '!') { // 登録しない関数名
-        continue
-      }
-      this.commandlist.add(key)
-    }
+  addPlugin (po: {[key: string]: any}, persistent = true, fpath = ''): void {
+    this.pluginManager.addPlugin(po, persistent, fpath)
   }
 
   /**
@@ -1038,12 +770,8 @@ export class NakoCompiler {
    * @param po 関数リスト
    * @param persistent falseのとき、次以降の実行では使えない
    */
-  addPluginObject(objName: string, po: {[key: string]: any}, persistent = true): void {
-    // metaプロパティがなければ互換性のため適当に追加
-    if (po.meta === undefined) {
-      po.meta = { type: 'const', value: { pluginName: objName, nakoVersion: '0.0.0' } }
-    }
-    this.addPlugin(po, persistent)
+  addPluginObject (objName: string, po: {[key: string]: any}, persistent = true): void {
+    this.pluginManager.addPluginObject(objName, po, persistent)
   }
 
   /**
@@ -1054,18 +782,18 @@ export class NakoCompiler {
    * @param persistent falseのとき、次以降の実行では使えない
    * @deprecated 利用は非推奨
    */
-  addPluginFile(_objName: string, fpath: string, po: {[key: string]: any}, persistent = true): void {
+  addPluginFile (_objName: string, fpath: string, po: {[key: string]: any}, persistent = true): void {
     this.addPluginFromFile(fpath, po, persistent)
   }
 
   /**
- * プラグイン・ファイルを追加(Node.js向け)
- * @param fpath ファイルパス
- * @param po 登録するオブジェクト
- * @param persistent falseのとき、次以降の実行では使えない
- */
-  addPluginFromFile(fpath: string, po: { [key: string]: any }, persistent = true): void {
-    this.addPlugin(po, persistent, fpath)
+   * プラグイン・ファイルを追加(Node.js向け)
+   * @param fpath ファイルパス
+   * @param po 登録するオブジェクト
+   * @param persistent falseのとき、次以降の実行では使えない
+   */
+  addPluginFromFile (fpath: string, po: { [key: string]: any }, persistent = true): void {
+    this.pluginManager.addPluginFromFile(fpath, po, persistent)
   }
 
   /**
@@ -1076,17 +804,14 @@ export class NakoCompiler {
    * @param {boolean} returnNone 値を返す関数の場合はfalseを指定
    * @param {boolean} asyncFn Promiseを返す関数かを指定
    */
-  addFunc(key: string, josi: FuncArgs, fn: any, returnNone = true, asyncFn = false): void {
-    const funcObj: FuncListItem = { josi, fn, type: 'func', return_none: returnNone, asyncFn, pure: true }
-    this.funclist.set(key, funcObj)
-    this.pluginFunclist[key] = cloneAsJSON(funcObj)
-    this.__varslist[0].set(key, fn)
+  addFunc (key: string, josi: FuncArgs, fn: any, returnNone = true, asyncFn = false): void {
+    this.pluginManager.addFunc(key, josi, fn, returnNone, asyncFn)
   }
 
   /** (非推奨) 互換性のため ... 関数を追加する
    * @deprecated 代わりにaddFuncを使ってください
   */
-  public setFunc(key: string, josi: FuncArgs, fn: any, returnNone = true, asyncFn = false): void {
+  public setFunc (key: string, josi: FuncArgs, fn: any, returnNone = true, asyncFn = false): void {
     this.addFunc(key, josi, fn, returnNone, asyncFn)
   }
 
@@ -1095,8 +820,8 @@ export class NakoCompiler {
    * @param key プラグイン関数の関数名
    * @returns プラグイン・オブジェクト
    */
-  getFunc(key: string): FuncListItem|undefined {
-    return this.funclist.get(key)
+  getFunc (key: string): FuncListItem|undefined {
+    return this.pluginManager.getFunc(key)
   }
 
   /** 同期的になでしこのプログラムcodeを実行する

--- a/core/src/nako_plugin_manager.mts
+++ b/core/src/nako_plugin_manager.mts
@@ -186,7 +186,7 @@ export class NakoPluginManager {
    * Windowsのパスやファイル名に使えない文字列があると、JSファイル書き出しでエラーになるので置換する
    */
   static removeInvalidFilenameChars (str: string): string {
-    return str.replace(/[^a-zA-z0-9\-_\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF\u3400-\u4DBF\uF900-\uFAFF]/g, '_')
+    return str.replace(/[^A-Za-z0-9\-_\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF\u3400-\u4DBF\uF900-\uFAFF]/g, '_')
   }
 
   /**

--- a/core/src/nako_plugin_manager.mts
+++ b/core/src/nako_plugin_manager.mts
@@ -1,0 +1,260 @@
+// deno-lint-ignore-file no-explicit-any
+/**
+ * なでしこ3 のプラグイン管理
+ *
+ * NakoCompiler からプラグイン登録処理を分離したモジュール (#2360)
+ * 循環参照を避けるため、このモジュールは nako3.mts を参照せず、
+ * 必要な機能は NakoPluginHost インターフェイス経由で受け取る。
+ */
+import { FuncArgs, FuncList, FuncListItem, NakoVars } from './nako_types.mjs'
+import { NakoLogger } from './nako_logger.mjs'
+
+const cloneAsJSON = (x: any): any => JSON.parse(JSON.stringify(x))
+
+/** プラグインが要求するランタイムの最低バージョン (= minor * 100 + patch) */
+export const PLUGIN_MIN_VERSION_INT = 600
+
+/** プラグインのメタ情報 */
+export interface NakoPluginMeta {
+  pluginName: string;
+  nakoVersionResult?: boolean;
+  nakoVersion: string;
+  path?: string;
+}
+
+/**
+ * NakoPluginManager がホスト(NakoCompiler)に要求する最小限の機能
+ */
+export interface NakoPluginHost {
+  /** プラグインで定義された関数 + ユーザーが定義した関数。reset() で差し替わるため都度取得する */
+  getFuncList (): FuncList;
+  /** システム領域の変数 (= __varslist[0]) */
+  getSysVars (): NakoVars;
+  getLogger (): NakoLogger;
+}
+
+/**
+ * プラグインの登録と、プラグインが定義した関数・変数・定数の管理を行うクラス
+ */
+export class NakoPluginManager {
+  /** プラグインで定義された関数 (reset() でユーザー定義関数を消すときに使う) */
+  readonly pluginFunclist: Record<string, FuncListItem>
+  /** 取り込んだファイル一覧 */
+  readonly pluginfiles: Record<string, any>
+  /** プラグインで定義された定数・変数・関数の名前 */
+  readonly commandlist: Set<string>
+  /** requireなどで取り込んだモジュールの一覧 (NakoCompiler.__module と同一オブジェクト) */
+  readonly modules: Record<string, Record<string, FuncListItem>>
+  private host: NakoPluginHost
+
+  constructor (host: NakoPluginHost) {
+    this.host = host
+    this.pluginFunclist = {}
+    this.pluginfiles = {}
+    this.commandlist = new Set()
+    this.modules = {}
+  }
+
+  /**
+   * プラグイン・オブジェクトを追加
+   * @param po プラグイン・オブジェクト
+   * @param persistent falseのとき、次以降の実行では使えない
+   * @param fpath ファイルパス
+   */
+  addPlugin (po: {[key: string]: any}, persistent = true, fpath = ''): void {
+    // __v0を取得
+    const __v0 = this.host.getSysVars()
+    // プラグインのメタ情報をチェック (#1034) (#1647)
+    let __pluginInfo = __v0.get('__pluginInfo')
+    if (!__pluginInfo) {
+      __pluginInfo = {}
+      __v0.set('__pluginInfo', __pluginInfo)
+    }
+    // メタ情報を読み取る
+    const meta = this.readPluginMeta(po, fpath)
+    let pluginName = meta.pluginName
+    const metaValue = meta.metaValue
+    // プラグイン名の重複を確認
+    if (__pluginInfo[pluginName] !== undefined) {
+      // プラグイン名が重複した場合はプラグインとして登録しない
+      return
+    }
+    pluginName = NakoPluginManager.removeInvalidFilenameChars(pluginName)
+    // プラグイン情報を記録
+    __pluginInfo[pluginName] = metaValue
+    // バージョンチェック
+    pluginName = this.checkPluginVersion(pluginName, meta.intVersion, po, metaValue)
+    // 初期化とクリアを変換する
+    this.modules[pluginName] = po
+    this.pluginfiles[pluginName] = '*'
+    // `初期化`と`クリア`をチェック
+    if (typeof (po['初期化']) === 'object') {
+      const def = po['初期化']
+      delete po['初期化']
+      const initKey = `!${pluginName}:初期化`
+      po[initKey] = def
+    }
+    // プラグインの値を、なでしこシステム変数(Map)にコピー
+    this.registerPluginEntries(po, persistent, __v0)
+  }
+
+  /**
+   * プラグインのメタ情報を読み取る
+   * @param po プラグイン・オブジェクト
+   * @param fpath ファイルパス
+   */
+  private readPluginMeta (po: {[key: string]: any}, fpath: string): { pluginName: string, intVersion: number, metaValue: NakoPluginMeta } {
+    let intVersion = 0
+    let pluginName = 'unknown'
+    let metaValue: NakoPluginMeta = { pluginName: 'unknown', nakoVersionResult: true, nakoVersion: '0.0.0', path: '' }
+    if (po.meta) {
+      if (po.meta.value && typeof (po.meta) === 'object') {
+        const meta = po.meta
+        metaValue = meta.value || { pluginName: 'unknown', nakoVersion: '0.0.0' }
+        pluginName = metaValue.pluginName || 'unknown'
+        // version check
+        const nakoVersion = (metaValue.nakoVersion || '0.0.0') + '.0.0'
+        const versions = nakoVersion.split('.').map((v) => parseInt(v))
+        intVersion = versions[1] * 100 + versions[2]
+        // fpath
+        metaValue.path = fpath
+      }
+    }
+    // unknown の場合は、関数名からプラグイン名を自動生成する
+    if (pluginName === 'unknown') {
+      pluginName = Object.keys(po).join('-')
+    }
+    return { pluginName, intVersion, metaValue }
+  }
+
+  /**
+   * プラグインが要求するランタイムのバージョンを確認する
+   * @returns プラグイン名 (古い形式で名前が不明な場合は関数名から生成した名前)
+   */
+  private checkPluginVersion (pluginName: string, intVersion: number, po: {[key: string]: any}, metaValue: NakoPluginMeta): string {
+    if (PLUGIN_MIN_VERSION_INT <= intVersion) { return pluginName }
+    const keyStr: string = Object.keys(po).join(',')
+    if (pluginName === 'unknown') {
+      pluginName = keyStr.substring(0, 30) + '...'
+    }
+    if (pluginName !== '') {
+      const errMsg = `なでしこプラグイン『${pluginName}』は古い形式なので正しく動作しない可能性があります。` +
+        `(ランタイムの要求: ${PLUGIN_MIN_VERSION_INT}/プラグイン: ${intVersion})`
+      console.warn(errMsg, 'see', 'https://github.com/kujirahand/nadesiko3/issues/1647')
+      this.host.getLogger().warn(errMsg)
+      metaValue.nakoVersionResult = false
+    }
+    return pluginName
+  }
+
+  /**
+   * プラグインの値を、なでしこシステム変数(Map)にコピーする
+   * @param po プラグイン・オブジェクト
+   * @param persistent falseのとき、次以降の実行では使えない
+   * @param __v0 システム領域の変数
+   */
+  private registerPluginEntries (po: {[key: string]: any}, persistent: boolean, __v0: NakoVars): void {
+    const funclist = this.host.getFuncList()
+    for (const key in po) {
+      const v = po[key]
+      funclist.set(key, v)
+      if (persistent) {
+        this.pluginFunclist[key] = cloneAsJSON(v)
+      }
+      if (v.type === 'func') {
+        __v0.set(key, v.fn)
+        if (v.asyncFn) { // asyncFn を正しく実行するために pure に変更する (core#142)
+          v.pure = true
+        }
+      } else if (v.type === 'const' || v.type === 'var') {
+        // メタ情報としての const | var は現在利用していない
+        // meta[key] = { readonly: v.type === 'const' }
+        __v0.set(key, v.value)
+      } else {
+        console.error('[プラグイン追加エラー]', v)
+        throw new Error('プラグインの追加でエラー。')
+      }
+      // コマンドを登録するか?
+      if (key === '初期化' || key.substring(0, 1) === '!') { // 登録しない関数名
+        continue
+      }
+      this.commandlist.add(key)
+    }
+  }
+
+  /**
+   * Windowsのパスやファイル名に使えない文字列があると、JSファイル書き出しでエラーになるので置換する
+   */
+  static removeInvalidFilenameChars (str: string): string {
+    return str.replace(/[^a-zA-z0-9\-_\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF\u3400-\u4DBF\uF900-\uFAFF]/g, '_')
+  }
+
+  /**
+   * プラグイン・オブジェクトを追加(ブラウザ向け)
+   * @param objName オブジェクト名 (今後プラグイン名は、meta.value.pluginNameに指定する)
+   * @param po 関数リスト
+   * @param persistent falseのとき、次以降の実行では使えない
+   */
+  addPluginObject (objName: string, po: {[key: string]: any}, persistent = true): void {
+    // metaプロパティがなければ互換性のため適当に追加
+    if (po.meta === undefined) {
+      po.meta = { type: 'const', value: { pluginName: objName, nakoVersion: '0.0.0' } }
+    }
+    this.addPlugin(po, persistent)
+  }
+
+  /**
+   * プラグイン・ファイルを追加(Node.js向け)
+   * @param fpath ファイルパス
+   * @param po 登録するオブジェクト
+   * @param persistent falseのとき、次以降の実行では使えない
+   */
+  addPluginFromFile (fpath: string, po: { [key: string]: any }, persistent = true): void {
+    this.addPlugin(po, persistent, fpath)
+  }
+
+  /**
+   * 関数を追加する
+   * @param key 関数名
+   * @param josi 助詞
+   * @param fn 関数
+   * @param returnNone 値を返す関数の場合はfalseを指定
+   * @param asyncFn Promiseを返す関数かを指定
+   */
+  addFunc (key: string, josi: FuncArgs, fn: any, returnNone = true, asyncFn = false): void {
+    const funcObj: FuncListItem = { josi, fn, type: 'func', return_none: returnNone, asyncFn, pure: true }
+    this.host.getFuncList().set(key, funcObj)
+    this.pluginFunclist[key] = cloneAsJSON(funcObj)
+    this.host.getSysVars().set(key, fn)
+  }
+
+  /**
+   * プラグイン関数を参照する
+   * @param key プラグイン関数の関数名
+   * @returns プラグイン・オブジェクト
+   */
+  getFunc (key: string): FuncListItem|undefined {
+    return this.host.getFuncList().get(key)
+  }
+
+  /** プラグインで定義された定数・変数・関数の名前かどうかを返す */
+  hasCommand (name: string): boolean {
+    return this.commandlist.has(name)
+  }
+
+  /**
+   * プラグイン由来の命令だけを含む関数一覧を新規に作る (reset() 用)
+   * @param sysVars システム領域の変数 (= __varslist[0])
+   */
+  createFuncListFromPlugins (sysVars: NakoVars): FuncList {
+    const funclist: FuncList = new Map()
+    for (const name of sysVars.keys()) {
+      const original = this.pluginFunclist[name] // record
+      if (!original) {
+        continue
+      }
+      funclist.set(name, cloneAsJSON(original))
+    }
+    return funclist
+  }
+}

--- a/core/src/nako_require.mts
+++ b/core/src/nako_require.mts
@@ -1,0 +1,292 @@
+// deno-lint-ignore-file no-explicit-any
+/**
+ * なでしこ3 の「取り込み」文(require)に関する処理
+ *
+ * NakoCompiler から依存ファイルの読み込み処理を分離したモジュール (#2360)
+ * 循環参照を避けるため、このモジュールは nako3.mts を参照せず、
+ * 必要な機能は NakoRequireHost インターフェイス経由で受け取る。
+ */
+import { Token } from './nako_types.mjs'
+import { NakoLexer } from './nako_lexer.mjs'
+import { NakoImportError, NakoLexerError } from './nako_errors.mjs'
+import { NakoLogger } from './nako_logger.mjs'
+
+const cloneAsJSON = (x: any): any => JSON.parse(JSON.stringify(x))
+
+/** インタプリタに「取り込み」文を追加するために用意するオブジェクト */
+export interface LoaderToolTask<T> {
+  task: Promise<T>;
+}
+export interface LoaderTool {
+  // type: 'nako3' | 'js' | 'invalid' | 'mjs'
+  resolvePath: (name: string, token: Token, fromFile: string) => { type: string, filePath: string };
+  readNako3: (filePath: string, token: Token) => LoaderToolTask<string>;
+  readJs: (filePath: string, token: Token) => LoaderToolTask<any>;
+}
+
+export interface DependenciesItem {
+  tokens: Token[];
+  alias: Set<string>;
+  addPluginFile: () => void;
+  funclist: any;
+  moduleExport: any;
+}
+export type Dependencies = { [key:string]:DependenciesItem }
+
+/** 取り込み文を処理する際に必要となるコード分割機能 */
+export interface NakoRequireScanner {
+  rawtokenize (code: string, line: number, filename: string, preCode?: string): Token[];
+}
+
+/**
+ * NakoRequireLoader がホスト(NakoCompiler)に要求する最小限の機能
+ */
+export interface NakoRequireHost extends NakoRequireScanner {
+  /** JSプラグインを登録する */
+  addPluginFromFile (fpath: string, po: { [key: string]: any }, persistent?: boolean): void;
+  getLogger (): NakoLogger;
+  /** 名前空間(modList)を汚さずにトークン化するための一時的なコンパイラを作る */
+  createScanner (): NakoRequireScanner;
+  /** 非同期読み込みに失敗した回数を数える */
+  countFailure (): void;
+}
+
+/**
+ * ファイル内のrequire文の位置を列挙する。出力の配列はstartでソートされている。
+ * @param {Token[]} tokens rawtokenizeの出力
+ */
+export function listRequireStatements (tokens: Token[]): Token[] {
+  const requireStatements: Token[] = []
+  for (let i = 0; i + 2 < tokens.length; i++) {
+    // not (string|string_ex) '取り込み'
+    if (!(tokens[i].type === 'not' &&
+      (tokens[i + 1].type === 'string' || tokens[i + 1].type === 'string_ex') &&
+      tokens[i + 2].value === '取込')) {
+      continue
+    }
+    // 取り込むライブラリ
+    let filename = String(tokens[i + 1].value) + ''
+    // 全角コロン「：」を半角コロン「:」に正規化する（「貯蔵庫：」「拡張プラグイン：」の記法に対応 #2282）
+    filename = filename.replace(/^(貯蔵庫|拡張プラグイン)：/, '$1:')
+    // 『取り込む』文で「拡張プラグイン:」機構を追加する #139
+    // (ex) !『貯蔵庫:ojyo-sama.nako3』を取り込む → https://n3s.nadesi.com/plain/ojyo-sama.nako3
+    if (filename.startsWith('貯蔵庫:') || filename.startsWith('貯蔵庫：')) {
+      filename = `https://n3s.nadesi.com/plain/${filename.substring(4)}`
+    }
+    // (ex) !『拡張プラグイン:music.js@1.0.2』を取り込む → https://cdn.jsdelivr.net/npm/nadesiko3-music@1.0.2/nadesiko3-music.js
+    if (filename.startsWith('拡張プラグイン:') || filename.startsWith('拡張プラグイン：')) {
+      const name = filename.substring('拡張プラグイン:'.length)
+      const m = name.match(/^([a-zA-Z0-9_-]+)\.(js|mjs|nako3)(@[0-9.]+)?$/)
+      if (m) {
+        let basename = m[1]
+        const ext = m[2]
+        const version = m[3] || '@latest'
+        if (ext === 'js' || ext === 'mjs') {
+          // JSプラグイン
+          if (!basename.startsWith('nadesiko3-')) {
+            basename = `nadesiko3-${basename}`
+          }
+          filename = `https://cdn.jsdelivr.net/npm/${basename}${version}/${basename}.${ext}`
+        } else {
+          // なでしこ3プラグイン
+          filename = `https://n3s.nadesi.com/plain/${basename}.${ext}`
+        }
+      } else {
+        throw new NakoImportError('『取込』の指定エラー。『拡張プラグイン:(ファイル名).(js|nako3)(@ver)』の書式で指定してください。', tokens[i].file, tokens[i].line)
+      }
+    }
+    // push
+    requireStatements.push({
+      ...tokens[i],
+      start: i,
+      end: i + 3,
+      value: filename,
+      firstToken: tokens[i],
+      lastToken: tokens[i + 2]
+    })
+    i += 2
+  }
+  return requireStatements
+}
+
+/**
+ * 「取り込み」文で指定された依存ファイルを読み込み、トークン列を置換するクラス
+ */
+export class NakoRequireLoader {
+  /**
+   * 取り込み文を置換するためのオブジェクト。
+   * 正規化されたファイル名がキーになり、取り込み文の引数に指定された正規化されていないファイル名はaliasに入れられる。
+   * JavaScriptファイルによるプラグインの場合、contentは空文字列。
+   * funclistはシンタックスハイライトの高速化のために事前に取り出した、ファイルが定義する関数名のリスト。
+   */
+  dependencies: Dependencies
+  private host: NakoRequireHost
+
+  constructor (host: NakoRequireHost) {
+    this.host = host
+    this.dependencies = {}
+  }
+
+  /**
+   * プログラムが依存するファイルを再帰的に取得する。
+   * - 依存するファイルがJavaScriptファイルの場合、そのファイルを実行して評価結果をaddPluginFromFileに渡す。
+   * - 依存するファイルがなでしこ言語の場合、ファイルの中身を取得して変数に保存し、再帰する。
+   *
+   * @param {string} code
+   * @param {string} filename
+   * @param {string} preCode
+   * @param {LoaderTool} tools 実行環境 (ブラウザ or Node.js) によって外部ファイルの取得・実行方法は異なるため、引数でそれらを行う関数を受け取る。
+   *  - resolvePath は指定した名前をもつファイルを検索し、正規化されたファイル名を返す関数。返されたファイル名はreadNako3かreadJsの引数になる。
+   *  - readNako3は指定されたファイルの中身を返す関数。
+   *  - readJsは指定したファイルをJavaScriptのプログラムとして実行し、`export default` でエクスポートされた値を返す関数。
+   * @returns {Promise<unknown> | void}
+   */
+  load (code: string, filename: string, preCode: string, tools: LoaderTool): Promise<unknown>|void {
+    const dependencies: Dependencies = {}
+    const host = this.host
+    // 名前空間(modList)を汚さないように、取り込み文の検出には別のコンパイラを使う
+    const scanner = host.createScanner()
+    /**
+     * @param {any} item
+     * @param {any} tasks
+     */
+    const loadJS = (item: any, tasks: any) => {
+      // jsならプラグインとして読み込む。(ESMでは必ず動的に読む)
+      const obj = tools.readJs(item.filePath, item.firstToken)
+      tasks.push(obj.task.then((res: any) => {
+        const pluginFuncs = res()
+        host.addPluginFromFile(item.filePath, pluginFuncs)
+        dependencies[item.filePath].funclist = pluginFuncs
+        dependencies[item.filePath].moduleExport = {}
+        dependencies[item.filePath].addPluginFile = () => { host.addPluginFromFile(item.filePath, pluginFuncs) }
+      }))
+    }
+    const loadNako3 = (item: any, tasks: any) => {
+      // nako3ならファイルを読んでdependenciesに保存する。
+      const content = tools.readNako3(item.filePath, item.firstToken)
+      const registerFile = (code: string) => {
+        // シンタックスハイライトの高速化のために、事前にファイルが定義する関数名のリストを取り出しておく。
+        // preDefineFuncはトークン列に変更を加えるため、事前にクローンしておく。
+        // 「プラグイン名設定」を行う (#956)
+        const modName = NakoLexer.filenameToModName(item.filePath)
+        code = `『${modName}』に名前空間設定;『${modName}』にプラグイン名設定;` + code + ';名前空間ポップ;'
+        const tokens = host.rawtokenize(code, 0, item.filePath)
+        dependencies[item.filePath].tokens = tokens
+        const funclist = new Map()
+        const moduleexport = new Map()
+        NakoLexer.preDefineFunc(cloneAsJSON(tokens), host.getLogger(), funclist, moduleexport)
+        dependencies[item.filePath].funclist = funclist
+        dependencies[item.filePath].moduleExport = moduleexport
+        // 再帰
+        return loadRec(code, item.filePath, '')
+      }
+      // 取り込み構文における問題を減らすため、必ず非同期でプログラムを読み込む仕様とした #1219
+      tasks.push(content.task.then((res) => registerFile(res)))
+    }
+    const loadRec = (code: string, filename: string, preCode: string): Promise<unknown>|void => {
+      const tasks: Promise<unknown>[] = []
+      // 取り込みが必要な情報一覧を調べる(トークン分割して、取り込みタグを得る)
+      const tags = listRequireStatements(scanner.rawtokenize(code, 0, filename, preCode))
+      // パスを解決する
+      const tagsResolvePath = tags.map((v) => ({ ...v, ...tools.resolvePath(v.value, v.firstToken as Token, filename) }))
+      // 取り込み開始
+      for (const item of tagsResolvePath) {
+        // 2回目以降の読み込み
+        // eslint-disable-next-line no-prototype-builtins
+        if (dependencies.hasOwnProperty(item.filePath)) {
+          dependencies[item.filePath].alias.add(item.value)
+          continue
+        }
+
+        // 初回の読み込み
+        dependencies[item.filePath] = { tokens: [], alias: new Set([item.value]), addPluginFile: ():void => {}, funclist: {}, moduleExport: {} }
+        if (item.type === 'js' || item.type === 'mjs') {
+          loadJS(item, tasks)
+        } else if (item.type === 'nako3') {
+          loadNako3(item, tasks)
+        } else {
+          throw new NakoImportError(`ファイル『${String(item.value)}』を読み込めません。ファイルが存在しないか未対応の拡張子です。`,
+            (item.firstToken as Token).file, (item.firstToken as Token).line)
+        }
+      }
+      if (tasks.length > 0) {
+        return Promise.all(tasks)
+      }
+      return undefined
+    }
+
+    try {
+      const result = loadRec(code, filename, preCode)
+
+      // 非同期な場合のエラーハンドリング
+      if (result !== undefined) {
+        result.catch((err) => {
+          // 読み込みに失敗したら処理を中断する
+          host.getLogger().error(err.msg)
+          host.countFailure()
+        })
+      }
+
+      // すべてが終わってからthis.dependenciesに代入する。そうしないと、「実行」ボタンを連打した場合など、
+      // load() が並列実行されるときに正しく動作しない。
+      this.dependencies = dependencies
+      return result
+    } catch (err) {
+      // 同期処理では素直に例外を投げる
+      host.getLogger().error(String(err))
+      throw err
+    }
+  }
+
+  /**
+   * 再帰的にrequire文を置換する。
+   * .jsであれば削除し、.nako3であればそのファイルのトークン列で置換する。
+   * @param {Token[]} tokens
+   * @param {Set<string>} [includeGuard]
+   * @returns {Token[]} 削除された取り込み文のトークン
+   */
+  replaceRequireStatements (tokens: Token[], includeGuard: Set<string> = new Set()): Token[] {
+    const deletedTokens: Token[] = []
+    for (const r of listRequireStatements(tokens).reverse()) {
+      // C言語のinclude guardと同じ仕組みで無限ループを防ぐ。
+      if (includeGuard.has(r.value)) {
+        deletedTokens.push(...tokens.splice((r.start || 0), (r.end || 0) - (r.start || 0)))
+        continue
+      }
+      const filePath = Object.keys(this.dependencies).find((key) => this.dependencies[key].alias.has(r.value))
+      if (filePath === undefined) {
+        if (!r.firstToken) { throw new Error(`ファイル『${String(r.value)}』が読み込まれていません。`) }
+        throw new NakoLexerError(`ファイル『${String(r.value)}』が読み込まれていません。`,
+          (r.firstToken).startOffset || 0,
+          (r.firstToken).endOffset || 0,
+          (r.firstToken).line, (r.firstToken).file)
+      }
+      this.dependencies[filePath].addPluginFile()
+      const children = cloneAsJSON(this.dependencies[filePath].tokens)
+      includeGuard.add(r.value)
+      deletedTokens.push(...this.replaceRequireStatements(children, includeGuard))
+      deletedTokens.push(...tokens.splice(r.start || 0, (r.end || 0) - (r.start || 0), ...children))
+    }
+    return deletedTokens
+  }
+
+  /**
+   * replaceRequireStatementsのシンタックスハイライト用の実装。
+   * @param {Token[]} tokens
+   * @returns {Token[]} 削除された取り込み文のトークン
+   */
+  removeRequireStatements (tokens: Token[]): Token[] {
+    const deletedTokens: Token[] = []
+    for (const r of listRequireStatements(tokens).reverse()) {
+      // プラグイン命令のシンタックスハイライトのために、addPluginFileを呼んで関数のリストをthis.dependencies[filePath].funclistに保存させる。
+      const filePath = Object.keys(this.dependencies).find((key) => this.dependencies[key].alias.has(r.value))
+      if (filePath !== undefined) {
+        this.dependencies[filePath].addPluginFile()
+      }
+
+      // 全ての取り込み文を削除する。そうしないとトークン化に時間がかかりすぎる。
+      deletedTokens.push(...tokens.splice(r.start || 0, (r.end || 0) - (r.start || 0)))
+    }
+    return deletedTokens
+  }
+}

--- a/core/src/nako_require.mts
+++ b/core/src/nako_require.mts
@@ -248,11 +248,6 @@ export class NakoRequireLoader {
   replaceRequireStatements (tokens: Token[], includeGuard: Set<string> = new Set()): Token[] {
     const deletedTokens: Token[] = []
     for (const r of listRequireStatements(tokens).reverse()) {
-      // C言語のinclude guardと同じ仕組みで無限ループを防ぐ。
-      if (includeGuard.has(r.value)) {
-        deletedTokens.push(...tokens.splice((r.start || 0), (r.end || 0) - (r.start || 0)))
-        continue
-      }
       const filePath = Object.keys(this.dependencies).find((key) => this.dependencies[key].alias.has(r.value))
       if (filePath === undefined) {
         if (!r.firstToken) { throw new Error(`ファイル『${String(r.value)}』が読み込まれていません。`) }
@@ -261,9 +256,14 @@ export class NakoRequireLoader {
           (r.firstToken).endOffset || 0,
           (r.firstToken).line, (r.firstToken).file)
       }
+      // C言語のinclude guardと同じ仕組みで無限ループを防ぐ。(同一ファイルを別名で取り込むケースがあるため filePath を使う)
+      if (includeGuard.has(filePath)) {
+        deletedTokens.push(...tokens.splice((r.start || 0), (r.end || 0) - (r.start || 0)))
+        continue
+      }
       this.dependencies[filePath].addPluginFile()
       const children = cloneAsJSON(this.dependencies[filePath].tokens)
-      includeGuard.add(r.value)
+      includeGuard.add(filePath)
       deletedTokens.push(...this.replaceRequireStatements(children, includeGuard))
       deletedTokens.push(...tokens.splice(r.start || 0, (r.end || 0) - (r.start || 0), ...children))
     }

--- a/core/test/nako_plugin_manager_test.mjs
+++ b/core/test/nako_plugin_manager_test.mjs
@@ -1,0 +1,185 @@
+/* eslint-disable no-undef */
+import { describe, it } from 'node:test'
+import assert from 'assert'
+
+import { NakoCompiler } from '../src/nako3.mjs'
+import { NakoPluginManager, PLUGIN_MIN_VERSION_INT } from '../src/nako_plugin_manager.mjs'
+import { NakoLogger } from '../src/nako_logger.mjs'
+
+/**
+ * プラグイン管理を NakoCompiler から分離したモジュールのテスト (#2360)
+ */
+describe('nako_plugin_manager_test', () => {
+  /** テスト用にホストを差し替えた NakoPluginManager を作る */
+  const createManager = () => {
+    const funclist = new Map()
+    const sysVars = new Map()
+    const logger = new NakoLogger()
+    const manager = new NakoPluginManager({
+      getFuncList: () => funclist,
+      getSysVars: () => sysVars,
+      getLogger: () => logger
+    })
+    return { manager, funclist, sysVars, logger }
+  }
+
+  /** 現在のバージョン要求を満たすメタ情報を作る */
+  const newMeta = (pluginName, nakoVersion = '3.6.0') => {
+    return { type: 'const', value: { pluginName, nakoVersion } }
+  }
+
+  it('プラグイン名が重複した場合は登録されない', () => {
+    const nako = new NakoCompiler()
+    nako.addPlugin({
+      meta: newMeta('DuplicatedPlugin'),
+      重複テスト値: { type: 'const', value: 1 }
+    })
+    nako.addPlugin({
+      meta: newMeta('DuplicatedPlugin'),
+      重複テスト値: { type: 'const', value: 2 }
+    })
+    // 2回目の登録は無視されるので、最初に登録した値のままになる
+    assert.strictEqual(nako.getFunc('重複テスト値').value, 1)
+  })
+
+  it('metaが無い場合はプラグイン名をキー名から自動生成する', () => {
+    const { manager, sysVars } = createManager()
+    manager.addPlugin({ hoge: { type: 'const', value: 1 } })
+    const pluginInfo = sysVars.get('__pluginInfo')
+    assert.ok(pluginInfo.hoge !== undefined, 'キー名からプラグイン名が作られること')
+    assert.ok(manager.pluginfiles.hoge !== undefined)
+  })
+
+  it('古い形式のプラグインは nakoVersionResult が false になる', () => {
+    const { manager, sysVars } = createManager()
+    // PLUGIN_MIN_VERSION_INT(600) より小さいバージョンを指定する
+    manager.addPlugin({
+      meta: newMeta('OldPlugin', '3.5.99'),
+      古い値: { type: 'const', value: 1 }
+    })
+    const pluginInfo = sysVars.get('__pluginInfo')
+    assert.strictEqual(pluginInfo.OldPlugin.nakoVersionResult, false)
+    assert.strictEqual(PLUGIN_MIN_VERSION_INT, 600)
+  })
+
+  it('新しい形式のプラグインは nakoVersionResult が true のまま', () => {
+    const { manager, sysVars } = createManager()
+    manager.addPlugin({
+      meta: newMeta('NewPlugin', '3.6.0'),
+      新しい値: { type: 'const', value: 1 }
+    })
+    const pluginInfo = sysVars.get('__pluginInfo')
+    assert.notStrictEqual(pluginInfo.NewPlugin.nakoVersionResult, false)
+  })
+
+  it('「初期化」は「!プラグイン名:初期化」へ変換される', () => {
+    const { manager } = createManager()
+    const po = {
+      meta: newMeta('InitPlugin'),
+      初期化: { type: 'func', josi: [], fn: () => {} }
+    }
+    manager.addPlugin(po)
+    assert.strictEqual(po['初期化'], undefined)
+    assert.strictEqual(typeof po['!InitPlugin:初期化'], 'object')
+  })
+
+  it('ファイル名に使えない文字はアンダースコアに置換される', () => {
+    assert.strictEqual(NakoPluginManager.removeInvalidFilenameChars('my plugin/name'), 'my_plugin_name')
+    // 日本語(ひらがな・カタカナ・漢字)はそのまま残る
+    assert.strictEqual(NakoPluginManager.removeInvalidFilenameChars('プラグイン漢字かな'), 'プラグイン漢字かな')
+  })
+
+  it('プラグイン名の不正文字を置換した名前で登録される', () => {
+    const { manager, sysVars } = createManager()
+    manager.addPlugin({
+      meta: newMeta('my plugin/name'),
+      置換テスト値: { type: 'const', value: 1 }
+    })
+    const pluginInfo = sysVars.get('__pluginInfo')
+    assert.ok(pluginInfo.my_plugin_name !== undefined)
+    assert.ok(manager.modules.my_plugin_name !== undefined)
+  })
+
+  it('「初期化」と「!」で始まるキーはコマンド一覧に登録されない', () => {
+    const { manager } = createManager()
+    manager.addPlugin({
+      meta: newMeta('CommandListPlugin'),
+      普通の値: { type: 'const', value: 1 },
+      '!クリア': { type: 'func', josi: [], fn: () => {} },
+      初期化: { type: 'func', josi: [], fn: () => {} }
+    })
+    assert.strictEqual(manager.hasCommand('普通の値'), true)
+    assert.strictEqual(manager.hasCommand('!クリア'), false)
+    assert.strictEqual(manager.hasCommand('初期化'), false)
+    assert.strictEqual(manager.hasCommand('!CommandListPlugin:初期化'), false)
+  })
+
+  it('addFuncで登録した関数をgetFuncで参照できる', () => {
+    const { manager, sysVars } = createManager()
+    const fn = (a) => a
+    manager.addFunc('テスト関数', [['を']], fn, false)
+    const f = manager.getFunc('テスト関数')
+    assert.strictEqual(f.type, 'func')
+    assert.strictEqual(f.return_none, false)
+    assert.strictEqual(sysVars.get('テスト関数'), fn)
+  })
+
+  it('createFuncListFromPluginsはプラグイン由来の関数だけを返す', () => {
+    const { manager, sysVars } = createManager()
+    manager.addPlugin({
+      meta: newMeta('ResetPlugin'),
+      プラグイン値: { type: 'const', value: 1 }
+    })
+    // ユーザー定義関数を模したものはシステム領域には登録されない
+    const funclist = manager.createFuncListFromPlugins(sysVars)
+    assert.strictEqual(funclist.has('プラグイン値'), true)
+    assert.strictEqual(funclist.has('ユーザー関数'), false)
+  })
+
+  it('reset()するとユーザー定義関数は消えプラグイン関数は残る', async () => {
+    const nako = new NakoCompiler()
+    await nako.runAsync('●(Aを)ユーザー関数とは\nAを戻す\nここまで', 'main.nako3')
+    // ユーザー定義関数は名前空間付きで登録される
+    assert.ok(nako.getFunc('main__ユーザー関数') !== undefined)
+    nako.reset()
+    assert.strictEqual(nako.getFunc('main__ユーザー関数'), undefined)
+    assert.ok(nako.getFunc('表示') !== undefined, 'プラグインの命令は残ること')
+  })
+
+  it('NakoCompiler.__module と NakoPluginManager.modules は同じ内容を指す', () => {
+    const nako = new NakoCompiler()
+    nako.addPlugin({
+      meta: newMeta('ModuleSharePlugin'),
+      共有テスト値: { type: 'const', value: 1 }
+    })
+    assert.ok(nako.__module.ModuleSharePlugin !== undefined)
+    assert.ok(nako.getPluginfiles().ModuleSharePlugin !== undefined)
+  })
+
+  it('addPluginObjectはmetaが無いプラグインに名前を付ける', () => {
+    const { manager, sysVars } = createManager()
+    manager.addPluginObject('ObjectPlugin', { オブジェクト値: { type: 'const', value: 1 } })
+    const pluginInfo = sysVars.get('__pluginInfo')
+    assert.ok(pluginInfo.ObjectPlugin !== undefined)
+  })
+
+  it('addPluginFromFileはメタ情報にファイルパスを記録する', () => {
+    const { manager, sysVars } = createManager()
+    manager.addPluginFromFile('/path/to/plugin.mjs', {
+      meta: newMeta('FilePlugin'),
+      ファイル値: { type: 'const', value: 1 }
+    })
+    const pluginInfo = sysVars.get('__pluginInfo')
+    assert.strictEqual(pluginInfo.FilePlugin.path, '/path/to/plugin.mjs')
+  })
+
+  it('未知のtypeを持つプラグインはエラーになる', () => {
+    const { manager } = createManager()
+    assert.throws(() => {
+      manager.addPlugin({
+        meta: newMeta('BrokenPlugin'),
+        壊れた値: { type: 'unknown', value: 1 }
+      })
+    }, /プラグインの追加でエラー/)
+  })
+})

--- a/core/test/nako_require_test.mjs
+++ b/core/test/nako_require_test.mjs
@@ -1,0 +1,153 @@
+/* eslint-disable no-undef */
+import { describe, it } from 'node:test'
+import assert from 'assert'
+
+import { NakoCompiler } from '../src/nako3.mjs'
+import { listRequireStatements, NakoRequireLoader } from '../src/nako_require.mjs'
+import { NakoImportError } from '../src/nako_errors.mjs'
+
+/**
+ * 取り込み文(require)の処理を NakoCompiler から分離したモジュールのテスト (#2360)
+ */
+describe('nako_require_test', () => {
+  /** テスト用のローダーを作る。addPluginFromFile の呼び出し履歴も返す */
+  const createLoader = () => {
+    const nako = new NakoCompiler()
+    const addedPlugins = []
+    const loader = new NakoRequireLoader({
+      rawtokenize: (code, line, filename, preCode) => nako.rawtokenize(code, line, filename, preCode),
+      addPluginFromFile: (fpath, po) => { addedPlugins.push({ fpath, po }) },
+      getLogger: () => nako.getLogger(),
+      createScanner: () => new NakoCompiler(),
+      countFailure: () => {}
+    })
+    return { nako, loader, addedPlugins }
+  }
+
+  /** 依存ファイルの情報を作る */
+  const newDependency = (nako, filePath, code) => {
+    return {
+      tokens: nako.rawtokenize(code, 0, filePath),
+      alias: new Set([filePath]),
+      addPluginFile: () => {},
+      funclist: new Map(),
+      moduleExport: new Map()
+    }
+  }
+
+  it('export関数とNakoCompilerのstaticメソッドは同じ結果を返す', () => {
+    const nako = new NakoCompiler()
+    const tokens = nako.rawtokenize('!「hoge.nako3」を取り込む\n「テスト」を表示\n', 0, 'main.nako3')
+    const a = listRequireStatements(tokens).map((t) => t.value)
+    const b = NakoCompiler.listRequireStatements(tokens).map((t) => t.value)
+    assert.deepStrictEqual(a, ['hoge.nako3'])
+    assert.deepStrictEqual(a, b)
+  })
+
+  it('複数の取り込み文をstartの昇順で列挙する', () => {
+    const nako = new NakoCompiler()
+    const code = '!「a.nako3」を取り込む\n!「b.nako3」を取り込む\n!「c.nako3」を取り込む\n'
+    const tokens = nako.rawtokenize(code, 0, 'main.nako3')
+    const list = listRequireStatements(tokens)
+    assert.deepStrictEqual(list.map((t) => t.value), ['a.nako3', 'b.nako3', 'c.nako3'])
+    for (let i = 0; i < list.length; i++) {
+      assert.strictEqual(list[i].end, list[i].start + 3, '取り込み文は3トークンで構成される')
+      if (i > 0) {
+        assert.ok(list[i - 1].start < list[i].start, 'startの昇順に並んでいること')
+      }
+    }
+  })
+
+  it('相互に取り込み合うファイルでも無限ループしない', () => {
+    const { nako, loader } = createLoader()
+    // a.nako3 は b.nako3 を、b.nako3 は a.nako3 を取り込む
+    loader.dependencies = {
+      'a.nako3': newDependency(nako, 'a.nako3', '!「b.nako3」を取り込む\n「A」を表示\n'),
+      'b.nako3': newDependency(nako, 'b.nako3', '!「a.nako3」を取り込む\n「B」を表示\n')
+    }
+    const tokens = nako.rawtokenize('!「a.nako3」を取り込む\n「M」を表示\n', 0, 'main.nako3')
+    const deleted = loader.replaceRequireStatements(tokens)
+    assert.ok(deleted.length > 0, '取り込み文が削除されること')
+    assert.strictEqual(listRequireStatements(tokens).length, 0, '取り込み文がすべて置換されること')
+  })
+
+  it('removeRequireStatementsは取り込み文を削除する', () => {
+    const { nako, loader } = createLoader()
+    let called = 0
+    loader.dependencies = {
+      'a.nako3': { ...newDependency(nako, 'a.nako3', '「A」を表示\n'), addPluginFile: () => { called++ } }
+    }
+    const tokens = nako.rawtokenize('!「a.nako3」を取り込む\n「M」を表示\n', 0, 'main.nako3')
+    const deleted = loader.removeRequireStatements(tokens)
+    assert.strictEqual(deleted.length, 3)
+    assert.strictEqual(listRequireStatements(tokens).length, 0)
+    assert.strictEqual(called, 1, 'シンタックスハイライトのためにaddPluginFileが呼ばれること')
+  })
+
+  it('読み込まれていないファイルを取り込むとエラーになる', () => {
+    const { nako, loader } = createLoader()
+    const tokens = nako.rawtokenize('!「notfound.nako3」を取り込む\n', 0, 'main.nako3')
+    assert.throws(() => loader.replaceRequireStatements(tokens), /読み込まれていません/)
+  })
+
+  it('未対応の拡張子ではNakoImportErrorになる', () => {
+    const { loader } = createLoader()
+    const tools = {
+      resolvePath: (name) => ({ filePath: name, type: 'txt' }),
+      readNako3: () => ({ task: Promise.resolve('') }),
+      readJs: () => ({ task: Promise.resolve(() => ({})) })
+    }
+    assert.throws(
+      () => loader.load('!「foo.txt」を取り込む\n', 'main.nako3', '', tools),
+      (err) => {
+        assert.ok(err instanceof NakoImportError)
+        assert.ok(/読み込めません/.test(err.msg))
+        return true
+      }
+    )
+  })
+
+  it('なでしこファイルを読み込んでdependenciesに保存する', async () => {
+    const { loader } = createLoader()
+    const tools = {
+      resolvePath: (name) => ({ filePath: name, type: 'nako3' }),
+      readNako3: () => ({ task: Promise.resolve('●(Aを)ライブラリ関数とは\nAを戻す\nここまで\n') }),
+      readJs: () => ({ task: Promise.resolve(() => ({})) })
+    }
+    await loader.load('!「lib.nako3」を取り込む\n', 'main.nako3', '', tools)
+    const dep = loader.dependencies['lib.nako3']
+    assert.ok(dep !== undefined, 'dependenciesに登録されること')
+    assert.ok(dep.tokens.length > 0, 'トークン列が保存されること')
+    const names = [...dep.funclist.keys()].filter((k) => String(k).includes('ライブラリ関数'))
+    assert.ok(names.length > 0, '関数名の一覧が事前に取り出されること')
+  })
+
+  it('JSプラグインを読み込んでaddPluginFromFileを呼ぶ', async () => {
+    const { loader, addedPlugins } = createLoader()
+    const pluginObject = {
+      meta: { type: 'const', value: { pluginName: 'RequireTestPlugin', nakoVersion: '3.6.0' } },
+      取込テスト値: { type: 'const', value: 123 }
+    }
+    const tools = {
+      resolvePath: (name) => ({ filePath: name, type: 'mjs' }),
+      readNako3: () => ({ task: Promise.resolve('') }),
+      readJs: () => ({ task: Promise.resolve(() => pluginObject) })
+    }
+    await loader.load('!「plugin.mjs」を取り込む\n', 'main.nako3', '', tools)
+    assert.strictEqual(addedPlugins.length, 1)
+    assert.strictEqual(addedPlugins[0].fpath, 'plugin.mjs')
+    assert.strictEqual(loader.dependencies['plugin.mjs'].funclist, pluginObject)
+  })
+
+  it('同じファイルを2回取り込んでもエイリアスにまとめられる', async () => {
+    const { loader } = createLoader()
+    const tools = {
+      resolvePath: (name) => ({ filePath: 'lib.nako3', type: 'nako3' }),
+      readNako3: () => ({ task: Promise.resolve('「LIB」を表示\n') }),
+      readJs: () => ({ task: Promise.resolve(() => ({})) })
+    }
+    await loader.load('!「lib.nako3」を取り込む\n!「./lib.nako3」を取り込む\n', 'main.nako3', '', tools)
+    assert.strictEqual(Object.keys(loader.dependencies).length, 1)
+    assert.deepStrictEqual([...loader.dependencies['lib.nako3'].alias].sort(), ['./lib.nako3', 'lib.nako3'])
+  })
+})


### PR DESCRIPTION
## 概要

#2360 の対応です。

`NakoCompiler` (`core/src/nako3.mts`) が依存ファイル読み込み・字句解析・構文変換・実行・プラグイン管理を広く担当していたため、まず **依存ファイル読み込み** と **プラグイン登録系** を別モジュールへ切り出しました。

`core/src/nako3.mts` は **1141行 → 866行** になりました。

## 変更内容

### 新規 `core/src/nako_require.mts` (取り込み文の処理)

- `listRequireStatements()` — `NakoCompiler` の static メソッドを export 関数として移動
- `NakoRequireLoader` — `load` (旧 `_loadDependencies`) / `replaceRequireStatements` / `removeRequireStatements` と `dependencies` を所有
- `LoaderTool` / `LoaderToolTask` / `Dependencies` / `DependenciesItem` の型定義

### 新規 `core/src/nako_plugin_manager.mts` (プラグイン管理)

- `NakoPluginManager` — `addPlugin` / `addPluginObject` / `addPluginFromFile` / `addFunc` / `getFunc` / `createFuncListFromPlugins`
- `pluginFunclist` / `pluginfiles` / `commandlist` / `__module` を所有
- 長かった `addPlugin` を `readPluginMeta` / `checkPluginVersion` / `registerPluginEntries` に分割

### 循環参照の回避

新しいモジュールは `nako3.mts` を import せず、`NakoRequireHost` / `NakoPluginHost` インターフェイス経由で `NakoCompiler` の機能を受け取ります。

- `funclist` は `reset()` で差し替わるため、スナップショットではなくゲッター経由で参照
- `__module` / `pluginfiles` などは再代入されないため、`NakoCompiler` と同じオブジェクトを共有

## 公開APIは完全互換

`core` は `nadesiko3core` として別途公開されており、`cnako3mod` / `wnako3mod` がサブクラスとして利用しているため、外から見える形は一切変えていません。

- `NakoCompiler` 側に薄い委譲メソッドを残しました
- `static listRequireStatements` / `_loadDependencies` / `addPlugin` 系 / `@deprecated` メソッドはそのまま
- `LoaderTool` などの型は `nako3.mts` から再エクスポート
- `wnako3_editor.mts` がシンタックスハイライトで参照する `nako3.dependencies` は getter として維持
- `__module` はプラグイン管理と同じオブジェクトを共有するため、`nako_gen.mts` / `nako_global.mts` は無改修

## テスト

新規テストを追加しました。

### `core/test/nako_require_test.mjs`
- export関数と `NakoCompiler.listRequireStatements` が同じ結果を返す
- 複数の取り込み文を `start` の昇順で列挙する
- 相互に取り込み合うファイルでも無限ループしない (include guard)
- `removeRequireStatements` が取り込み文を削除する
- 読み込まれていないファイル・未対応拡張子のエラー
- なでしこファイル / JSプラグインの読み込みと `dependencies` への保存
- 同じファイルを2回取り込んだ場合のエイリアス集約

### `core/test/nako_plugin_manager_test.mjs`
- プラグイン名が重複した場合は登録されない
- `meta` が無い場合のプラグイン名の自動生成
- 古い形式のプラグインで `nakoVersionResult` が `false` になる
- 「初期化」が「!プラグイン名:初期化」へ変換される
- ファイル名に使えない文字の置換
- 「初期化」と「!」で始まるキーはコマンド一覧に登録されない
- `addFunc` / `getFunc` / `createFuncListFromPlugins`
- `reset()` するとユーザー定義関数は消えプラグイン関数は残る

### 実行結果

| 項目 | 結果 |
|---|---|
| `npx tsc --noEmit` | エラーなし |
| `npm run lint` | 指摘なし |
| `npm test` (core/node/common) | 878件すべて pass (新規24件を含む) |
| `npm run test:e` (エディタ) | 21件 pass |
| CLI実行・取り込み文の実動作確認 | 正常 |

## 今後の分割案 (このPRの対象外)

残る約650行はさらに分割できます。別Issueにするのが良さそうです。

1. `nako_tokenizer.mts` — `rawtokenize` / `converttoken` / `lexCodeToken` / `lex` とソースマップ処理 (約220行)
2. `nako_runner.mts` — `evalJS` / `runSync` / `runAsync` / `getNakoGlobal` と非推奨のrun系 (約150行)
3. イベント機構 — 5箇所に散らばる `eventList.filter(...).map(...)` を `NakoEventEmitter` に
4. `nako_basic_plugins.mts` — 基本プラグイン6個のimportと登録順の集約

🤖 Generated with [Claude Code](https://claude.com/claude-code)