### PR TITLE
NakoCompilerから字句解析・実行・イベント・基本プラグインを分離 (#2360)

### DIFF
--- a/core/src/nako3.mts
+++ b/core/src/nako3.mts
@@ -1,6 +1,6 @@
- 
- 
- 
+
+
+
 // deno-lint-ignore-file no-explicit-any
 /**
  * nadesiko v3
@@ -11,41 +11,28 @@ import { Ast, AstBlocks } from './nako_ast.mjs'
 // parser / lexer
 import { NakoParser } from './nako_parser3.mjs'
 import { NakoLexer } from './nako_lexer.mjs'
-import { NakoPrepare } from './nako_prepare.mjs'
 import { NakoGen, generateJS, NakoGenOptions, NakoGenResult } from './nako_gen.mjs'
-import { convertInlineIndent, convertIndentSyntax } from './nako_indent_inline.mjs'
-import { convertDNCL } from './nako_from_dncl.mjs'
-import { convertDNCL2 } from './nako_from_dncl2.mjs'
-import { SourceMappingOfTokenization, SourceMappingOfIndentSyntax, OffsetToLineColumn, subtractSourceMapByPreCodeLength } from './nako_source_mapping.mjs'
-import { NakoLexerError, NakoSyntaxError, InternalLexerError } from './nako_errors.mjs'
+import { NakoSyntaxError } from './nako_errors.mjs'
 import { NakoLogger } from './nako_logger.mjs'
 import { NakoGlobal } from './nako_global.mjs'
 // 取り込み文(require)の処理 / プラグイン管理 (#2360)
 import { Dependencies, LoaderTool, listRequireStatements, NakoRequireHost, NakoRequireLoader, NakoRequireScanner } from './nako_require.mjs'
 import { NakoPluginHost, NakoPluginManager } from './nako_plugin_manager.mjs'
+// 字句解析 / 実行 / イベント / 基本プラグイン (#2360)
+import { LexResult, NakoTokenizer } from './nako_tokenizer.mjs'
+import { NakoRunner, NakoRunnerHost, newCompilerOptions } from './nako_runner.mjs'
+import { NakoEventEmitter } from './nako_event.mjs'
+import { registerBasicPlugins } from './nako_basic_plugins.mjs'
 // version info
 import coreVersion from './nako_core_version.mjs'
-// basic plugins
-import PluginSystem from './plugin_system.mjs'
-import PluginMath from './plugin_math.mjs'
-import PluginCSV from './plugin_csv.mjs'
-import PluginPromise from './plugin_promise.mjs'
-import PluginTOML from './plugin_toml.mjs'
-import PluginTest from './plugin_test.mjs'
 
 export interface NakoCompilerOption {
   useBasicPlugin: boolean;
 }
 
-// 取り込み文に関する型は nako_require.mts へ移動したが、
-// 外部から `nako3.mjs` 経由で参照されているため再エクスポートする (#2360)
+// 分離したモジュールの型・関数は、外部から `nako3.mjs` 経由で参照されているため再エクスポートする (#2360)
 export type { LoaderTool, LoaderToolTask, Dependencies, DependenciesItem } from './nako_require.mjs'
-
-interface LexResult {
-  commentTokens: Token[];
-  tokens: Token[];
-  requireTokens: Token[];
-}
+export { newCompilerOptions } from './nako_runner.mjs'
 
 type NakoVars = Map<string, any>
 
@@ -53,43 +40,33 @@ export interface NakoResetOption {
   needToClearPlugin: boolean
 }
 
-/** コンパイラ実行オプションを生成 */
-export function newCompilerOptions(initObj: Partial<CompilerOptions> = {}): CompilerOptions {
-  if (typeof initObj !== 'object') { initObj = {} }
-  initObj.testOnly = initObj.testOnly || false
-  initObj.resetEnv = initObj.resetEnv || false
-  initObj.resetAll = initObj.resetAll || false
-  initObj.preCode = initObj.preCode || ''
-  initObj.nakoGlobal = initObj.nakoGlobal || null
-  return initObj as CompilerOptions
-}
-
 /** なでしこコンパイラ */
 export class NakoCompiler {
   private nakoFuncList: FuncList
   private funclist: FuncList
   private moduleExport: ExportMap
-  private prepare: NakoPrepare
   private parser: NakoParser
-  private lexer: NakoLexer
   /** プラグイン管理 (#2360) */
   private pluginManager: NakoPluginManager
   /** 取り込み文の処理 (#2360) */
   private requireLoader: NakoRequireLoader
+  /** 字句解析 (#2360) */
+  private tokenizer: NakoTokenizer
+  /** プログラムの実行 (#2360) */
+  private runner: NakoRunner
+  /** イベント管理 (#2360) */
+  protected events: NakoEventEmitter
   private usedFuncs: Set<string>
   private codeGenerateor: {[key: string]: any}
   protected logger: NakoLogger
-  protected eventList: NakoEvent[]
   // global objects
   __varslist: NakoVars[]
   __locals: NakoVars
-   
+
   __self: NakoCompiler
   __vars: NakoVars
   __v0: NakoVars
   __v1: NakoVars
-  __globals: NakoGlobal[]
-  __globalObj: NakoGlobal|null // 現在のNakoGlobalオブジェクト
   __module: Record<string, Record<string, FuncListItem>>
   numFailures: number // エラーレポートの数を記録
   public version: string
@@ -115,17 +92,17 @@ export class NakoCompiler {
     // バージョンを設定
     this.version = coreVersion.version
     this.coreVersion = coreVersion.version
-    this.__globals = [] // 生成した NakoGlobal のインスタンスを保持
-    this.__globalObj = null
     this.funclist = this.newVaiables() // プラグインで定義された関数 + ユーザーが定義した関数
     this.moduleExport = this.newVaiables()
     this.nakoFuncList = this.newVaiables() // __v1に配置するJavaScriptのコードで定義された関数
-    this.eventList = [] // 実行前に環境を変更するためのイベント
     this.codeGenerateor = {} // コードジェネレータ
     this.debugOption = { useDebug: false, waitTime: 0 }
 
     this.logger = new NakoLogger()
     this.filename = 'main.nako3'
+
+    // 実行前に環境を変更するためのイベント (#2360)
+    this.events = new NakoEventEmitter()
 
     // プラグイン管理を生成する (#2360)
     const pluginHost: NakoPluginHost = {
@@ -148,14 +125,27 @@ export class NakoCompiler {
     }
     this.requireLoader = new NakoRequireLoader(requireHost)
 
+    // 実行部を生成する (#2360)
+    const runnerHost: NakoRunnerHost = {
+      compileFromCode: (code, filename, opts) => this.compileFromCode(code, filename, opts),
+      createNakoGlobal: (gen: NakoGen, guid: number) => new NakoGlobal(this, gen, guid),
+      getLogger: () => this.logger,
+      fireEvent: (eventName, event) => { this.events.fire(eventName, event) }
+    }
+    this.runner = new NakoRunner(runnerHost)
+
     this.usedFuncs = new Set()
     this.numFailures = 0
 
     if (options.useBasicPlugin) { this.addBasicPlugins() }
     // 必要なオブジェクトを覚えておく
-    this.prepare = NakoPrepare.getInstance()
     this.parser = new NakoParser(this.logger)
-    this.lexer = new NakoLexer(this.logger)
+    // 字句解析を生成する (#2360)
+    this.tokenizer = new NakoTokenizer({
+      getLogger: () => this.logger,
+      replaceRequireStatements: (tokens, includeGuard) => this.replaceRequireStatements(tokens, includeGuard),
+      removeRequireStatements: (tokens) => this.removeRequireStatements(tokens)
+    })
     // 関数一覧を設定
     this.lexer.setFuncList(this.funclist)
     this.lexer.setModuleExport(this.moduleExport)
@@ -165,9 +155,37 @@ export class NakoCompiler {
     this.josiList = JSON.parse(JSON.stringify(this.lexer.josiList))
   }
 
+  /** 字句解析器(実体は NakoTokenizer が所有する) */
+  private get lexer (): NakoLexer {
+    return this.tokenizer.lexer
+  }
+
+  /** 実行前に環境を変更するためのイベント一覧 */
+  protected get eventList (): NakoEvent[] {
+    return this.events.getEventList()
+  }
+
+  /** 生成した NakoGlobal のインスタンスを保持 */
+  get __globals (): NakoGlobal[] {
+    return this.runner.globals
+  }
+
+  set __globals (values: NakoGlobal[]) {
+    this.runner.globals = values
+  }
+
+  /** 現在のNakoGlobalオブジェクト */
+  get __globalObj (): NakoGlobal|null {
+    return this.runner.currentGlobal
+  }
+
+  set __globalObj (value: NakoGlobal|null) {
+    this.runner.currentGlobal = value
+  }
+
   /** モジュール(名前空間)の一覧を取得する */
   getModList(): string[] {
-    return this.lexer.modList
+    return this.tokenizer.getModList()
   }
 
   getLogger(): NakoLogger {
@@ -199,14 +217,10 @@ export class NakoCompiler {
 
   /**
    * 基本的なプラグインを追加する
+   * (プラグインの一覧は nako_basic_plugins.mts にある)
    */
   addBasicPlugins() {
-    this.addPlugin(PluginSystem)
-    this.addPlugin(PluginMath)
-    this.addPlugin(PluginPromise)
-    this.addPlugin(PluginTest)
-    this.addPlugin(PluginCSV)
-    this.addPlugin(PluginTOML)
+    registerBasicPlugins(this)
   }
 
   /**
@@ -243,6 +257,7 @@ export class NakoCompiler {
 
   /**
    * コードを単語に分割する
+   * (実体は nako_tokenizer.mts の NakoTokenizer.rawtokenize)
    * @param code なでしこのプログラム
    * @param line なでしこのプログラムの行番号
    * @param filename
@@ -250,79 +265,19 @@ export class NakoCompiler {
    * @returns トークンのリスト
    */
   rawtokenize(code: string, line: number, filename: string, preCode = ''): Token[] {
-    if (!code.startsWith(preCode)) {
-      throw new Error('codeの先頭にはpreCodeを含める必要があります。')
-    }
-    // 名前空間のモジュールリストに自身を追加
-    const modName = NakoLexer.filenameToModName(filename)
-    const modList = this.getModList()
-    if (modList.indexOf(modName) < 0) { modList.unshift(modName) }
-    // 全角半角の統一処理
-    const preprocessed = this.prepare.convert(code)
-    const tokenizationSourceMapping = new SourceMappingOfTokenization(code.length, preprocessed)
-    const indentationSyntaxSourceMapping = new SourceMappingOfIndentSyntax(code, [], [])
-    const offsetToLineColumn = new OffsetToLineColumn(code)
-    // トークン分割
-    let tokens: Token[]
-    try {
-      tokens = this.lexer.tokenize(preprocessed.map((v) => v.text).join(''), line, filename)
-    } catch (err) {
-      if (!(err instanceof InternalLexerError)) {
-        throw err
-      }
-      // エラー位置をソースコード上の位置に変換して返す
-      const dest = indentationSyntaxSourceMapping.map(tokenizationSourceMapping.map(err.preprocessedCodeStartOffset), tokenizationSourceMapping.map(err.preprocessedCodeEndOffset))
-      const line: number|undefined = dest.startOffset === null ? err.line : offsetToLineColumn.map(dest.startOffset, false).line
-      const map = subtractSourceMapByPreCodeLength({ ...dest, line }, preCode)
-      throw new NakoLexerError(err.msg, map.startOffset, map.endOffset, map.line, filename)
-    }
-    // DNCL ver2 (core #41)
-    tokens = convertDNCL2(tokens)
-    // DNCL ver1 (#1140)
-    tokens = convertDNCL(tokens)
-    // インデント構文を変換 #596
-    tokens = convertIndentSyntax(tokens)
-    // インラインインデントを変換 #1215
-    tokens = convertInlineIndent(tokens)
-
-    // ソースコード上の位置に変換
-    tokens = tokens.map((token) => {
-      const dest = indentationSyntaxSourceMapping.map(
-        tokenizationSourceMapping.map(token.preprocessedCodeOffset || 0),
-        tokenizationSourceMapping.map((token.preprocessedCodeOffset || 0) + (token.preprocessedCodeLength || 0))
-      )
-      let line = token.line
-      let column = 0
-      if (token.type === 'eol' && dest.endOffset !== null) {
-        // eolはnako_genで `line = ${eolToken.line};` に変換されるため、
-        // 行末のeolのlineは次の行の行数を表す必要がある。
-        const out = offsetToLineColumn.map(dest.endOffset, false)
-        line = out.line
-        column = out.column
-      } else if (dest.startOffset !== null) {
-        const out = offsetToLineColumn.map(dest.startOffset, false)
-        line = out.line
-        column = out.column
-      }
-      return {
-        ...token,
-        ...subtractSourceMapByPreCodeLength({ line, column, startOffset: dest.startOffset, endOffset: dest.endOffset }, preCode),
-        rawJosi: token.josi
-      }
-    })
-    return tokens
+    return this.tokenizer.rawtokenize(code, line, filename, preCode)
   }
 
   /**
    * 単語の属性を構文解析に先立ち補正する
+   * (実体は nako_tokenizer.mts の NakoTokenizer.converttoken)
    * @param {Token[]} tokens トークンのリスト
    * @param {boolean} isFirst 最初の呼び出しかどうか
    * @param {string} filename
    * @returns コード (なでしこ)
    */
   converttoken(tokens: Token[], isFirst: boolean, filename: string): Token[] {
-    const tok = this.lexer.replaceTokens(tokens, isFirst, filename)
-    return tok
+    return this.tokenizer.converttoken(tokens, isFirst, filename)
   }
 
   /**
@@ -366,6 +321,7 @@ export class NakoCompiler {
 
   /**
    * typeがcodeのトークンを単語に分割するための処理
+   * (実体は nako_tokenizer.mts の NakoTokenizer.lexCodeToken)
    * @param {string} code
    * @param {number} line
    * @param {string} filename
@@ -374,33 +330,7 @@ export class NakoCompiler {
    * @private
    */
   lexCodeToken(code: string, line: number, filename: string, startOffset: number|null): {commentTokens: Token[], tokens: Token[]} {
-    // 単語に分割
-    let tokens = this.rawtokenize(code, line, filename, '')
-
-    // 文字列内位置からファイル内位置へ変換
-    if (startOffset === null) {
-      for (const token of tokens) {
-        token.startOffset = undefined
-        token.endOffset = undefined
-      }
-    } else {
-      for (const token of tokens) {
-        if (token.startOffset !== undefined) {
-          token.startOffset += startOffset
-        }
-        if (token.endOffset !== undefined) {
-          token.endOffset += startOffset
-        }
-      }
-    }
-
-    // convertTokenで消されるコメントのトークンを残す
-    const commentTokens = tokens.filter((t) => t.type === 'line_comment' || t.type === 'range_comment')
-      .map((v) => ({ ...v })) // clone
-
-    tokens = this.converttoken(tokens, false, filename)
-
-    return { tokens, commentTokens }
+    return this.tokenizer.lexCodeToken(code, line, filename, startOffset)
   }
 
   /**
@@ -425,48 +355,12 @@ export class NakoCompiler {
     return this.requireLoader.removeRequireStatements(tokens)
   }
 
-  /** 字句解析を行う */
+  /**
+   * 字句解析を行う
+   * (実体は nako_tokenizer.mts の NakoTokenizer.lex)
+   */
   lex(code: string, filename = 'main.nako3', preCode = '', syntaxHighlighting = false): LexResult {
-    // 単語に分割
-    let tokens = this.rawtokenize(code, 0, filename, preCode)
-
-    // require文を再帰的に置換する
-    const requireStatementTokens = syntaxHighlighting ? this.removeRequireStatements(tokens) : this.replaceRequireStatements(tokens, undefined)
-    for (const t of requireStatementTokens) {
-      if (t.type === 'word' || t.type === 'not') {
-        t.type = 'require'
-      }
-    }
-    if (requireStatementTokens.length >= 3) {
-      // modList を更新
-      for (let i = 0; i < requireStatementTokens.length; i += 3) {
-        let modName = requireStatementTokens[i + 1].value
-        modName = NakoLexer.filenameToModName(modName)
-        if (this.lexer.modList.indexOf(modName) < 0) {
-          this.lexer.modList.push(modName)
-        }
-      }
-    }
-
-    // convertTokenで消されるコメントのトークンを残す
-    const commentTokens: Token[] = tokens.filter((t) => t.type === 'line_comment' || t.type === 'range_comment')
-      .map((v) => ({ ...v })) // clone
-
-    tokens = this.converttoken(tokens, true, filename)
-
-    // 'string_ex'トークンから変換された'code'トークンを字句解析する
-    for (let i = 0; i < tokens.length; i++) {
-      if (tokens[i] && tokens[i].type === 'code') {
-        const children = this.lexCodeToken(tokens[i].value, tokens[i].line, filename, tokens[i].startOffset || 0)
-        commentTokens.push(...children.commentTokens)
-        tokens.splice(i, 1, ...children.tokens)
-        i--
-      }
-    }
-
-    this.logger.trace('--- lex ---\n' + JSON.stringify(tokens, null, 2))
-
-    return { commentTokens, tokens, requireTokens: requireStatementTokens }
+    return this.tokenizer.lex(code, filename, preCode, syntaxHighlighting)
   }
 
   /**
@@ -549,16 +443,16 @@ export class NakoCompiler {
       if (options.resetEnv) { this.reset() }
       if (options.resetAll) { this.clearPlugins() }
       // onBeforeParse
-      this.eventList.filter(o => o.eventName === 'beforeParse').map(e => e.callback(code))
+      this.events.fire('beforeParse', code)
       // parse
       const ast = this.parse(code, filename, options.preCode)
       // onBeforeGenerate
-      this.eventList.filter(o => o.eventName === 'beforeGenerate').map(e => e.callback(ast))
+      this.events.fire('beforeGenerate', ast)
       // generate
       const genOptions = new NakoGenOptions(options.testOnly)
       const outCode = this.generateCode(ast, genOptions)
       // onAfterGenerate
-      this.eventList.filter(o => o.eventName === 'afterGenerate').map(e => e.callback(outCode))
+      this.events.fire('afterGenerate', outCode)
       return outCode
     } catch (e: any) {
       this.logger.error(e)
@@ -603,55 +497,32 @@ export class NakoCompiler {
    * @param [preCode]
    * @deprecated 代わりにrunAsyncメソッドを使ってください。(core #52)
    */
-   
+
   async _run(code: string, fname: string, isReset: boolean, isTest: boolean, preCode = ''): Promise<NakoGlobal> {
-    const opts: CompilerOptions = newCompilerOptions({
-      resetEnv: isReset,
-      resetAll: isReset,
-      testOnly: isTest,
-      preCode
-    })
-    return this._runEx(code, fname, opts)
+    return this.runner.run(code, fname, isReset, isTest, preCode)
   }
 
-  /** 各プラグインをリセットする */
+  /**
+   * 各プラグインをリセットする
+   * (実体は nako_runner.mts の NakoRunner.clearPlugins)
+   */
   clearPlugins() {
-    // 他に実行している「なでしこ」があればクリアする
-    this.__globals.forEach((sys: NakoGlobal) => {
-      if (!sys) { return }
-      // core #56
-      sys.__setSysVar('__forceClose', true)
-      sys.reset()
-    })
-    this.__globals = [] // clear
+    this.runner.clearPlugins()
   }
 
   /**
    * 環境を指定してJavaScriptのコードを実行する
+   * (実体は nako_runner.mts の NakoRunner.evalJS)
    * @param code JavaScriptのコード
    * @param nakoGlobal 実行環境
    */
   private evalJS(code: string, nakoGlobal: NakoGlobal): void {
-    this.__globalObj = nakoGlobal // 現在のnakoGlobalを記録
-    this.__globalObj.lastJSCode = code
-    // 実行前に環境を初期化するイベントを実行(beforeRun)
-    this.eventList.filter(o => o.eventName === 'beforeRun').map(e => e.callback(nakoGlobal))
-    try {
-       
-      const f = new Function(nakoGlobal.lastJSCode)
-      f.apply(nakoGlobal)
-    } catch (err: any) {
-      // なでしこコードのエラーは抑止してログにのみ記録
-      nakoGlobal.numFailures++
-      this.getLogger().error(err)
-      throw err
-    }
-    // 実行後に終了イベントを実行(finish)
-    this.eventList.filter(o => o.eventName === 'finish').map(e => e.callback(nakoGlobal))
+    this.runner.evalJS(code, nakoGlobal)
   }
 
   /**
    * (非推奨) 同期的になでしこのプログラムcodeを実行する
+   * (実体は nako_runner.mts の NakoRunner.runSync)
    * @param code なでしこのプログラム
    * @param filename ファイル名
    * @param options オプション
@@ -659,50 +530,24 @@ export class NakoCompiler {
    * @deprecated 代わりにrunAsyncメソッドを使ってください。(core #52)
    */
   public runSync(code: string, filename: string, options: CompilerOptions|undefined = undefined): NakoGlobal {
-    // コンパイル
-    options = newCompilerOptions(options)
-    const out = this.compileFromCode(code, filename, options)
-    // 実行前に環境を生成
-    const nakoGlobal = this.getNakoGlobal(options, out.gen, filename)
-    // 実行
-    this.evalJS(out.runtimeEnv, nakoGlobal)
-    return nakoGlobal
+    return this.runner.runSync(code, filename, options)
   }
 
   /**
    * 非同期になでしこのプログラムcodeを実行する
+   * (実体は nako_runner.mts の NakoRunner.runAsync)
    * @param code なでしこのプログラム
    * @param filename ファイル名
    * @param options オプション
    * @returns 実行に利用したグローバルオブジェクト
    */
-   
+
   public async runAsync(code: string, filename: string, options: CompilerOptions|undefined = undefined): Promise<NakoGlobal> {
-    // コンパイル
-    options = newCompilerOptions(options)
-    const compiledCode = this.compileFromCode(code, filename, options)
-    // 実行前に環境を生成
-    const nakoGlobal = this.getNakoGlobal(options, compiledCode.gen, filename)
-    // 実行
-    this.evalJS(compiledCode.runtimeEnv, nakoGlobal)
-    return nakoGlobal
+    return this.runner.runAsync(code, filename, options)
   }
 
   private getNakoGlobal(options: CompilerOptions, gen: NakoGen, filename: string): NakoGlobal {
-    // オプションを参照
-    let g: NakoGlobal|null = options.nakoGlobal
-    if (!g) {
-      // 空ならば前回の値を参照(リセットするなら新規で作成する)
-      if (this.__globals.length > 0 && options.resetAll === false && options.resetEnv === false) {
-        g = this.__globals[this.__globals.length - 1]
-      } else {
-        g = new NakoGlobal(this, gen, (this.__globals.length + 1))
-      }
-      // 名前空間を設定
-      g.__varslist[0].set('名前空間', NakoLexer.filenameToModName(filename))
-    }
-    if (this.__globals.indexOf(g) < 0) { this.__globals.push(g) }
-    return g
+    return this.runner.getNakoGlobal(options, gen, filename)
   }
 
   /**
@@ -711,7 +556,7 @@ export class NakoCompiler {
    * @param callback コールバック関数
    */
   addListener(eventName: NakoComEventName, callback: (event:any) => void) {
-    this.eventList.push({ eventName, callback })
+    this.events.on(eventName, callback)
   }
 
   /**
@@ -722,10 +567,7 @@ export class NakoCompiler {
    * @param testOnly
    */
   test(code: string, fname: string, preCode = '', testOnly = false) {
-    const options = newCompilerOptions()
-    options.preCode = preCode
-    options.testOnly = testOnly
-    return this.runSync(code, fname, options)
+    return this.runner.test(code, fname, preCode, testOnly)
   }
 
   /**
@@ -825,13 +667,11 @@ export class NakoCompiler {
   }
 
   /** 同期的になでしこのプログラムcodeを実行する
+   * (実体は nako_runner.mts の NakoRunner.runEx)
    * @deprecated 代わりにrunAsyncメソッドを使ってください。(core #52)
    */
   private _runEx(code: string, filename: string, opts: CompilerOptions, preCode = '', nakoGlobal: NakoGlobal|undefined = undefined): NakoGlobal {
-    // コンパイル
-    opts.preCode = preCode
-    if (nakoGlobal) { opts.nakoGlobal = nakoGlobal }
-    return this.runSync(code, filename, opts)
+    return this.runner.runEx(code, filename, opts, preCode, nakoGlobal)
   }
 
   /** (非推奨) 同期的になでしこのプログラムcodeを実行する
@@ -852,8 +692,7 @@ export class NakoCompiler {
    * @param [preCode]
    */
   async runReset(code: string, fname = 'main.nako3', preCode = ''): Promise<NakoGlobal> {
-    const opts = newCompilerOptions({ resetAll: true, resetEnv: true, preCode })
-    return this.runAsync(code, fname, opts)
+    return this.runner.runReset(code, fname, preCode)
   }
 
   /**

--- a/core/src/nako_basic_plugins.mts
+++ b/core/src/nako_basic_plugins.mts
@@ -1,0 +1,39 @@
+// deno-lint-ignore-file no-explicit-any
+/**
+ * なでしこ3のコアに同梱する基本プラグインの一覧
+ *
+ * NakoCompiler から基本プラグインのimportと登録順を分離したモジュール (#2360)
+ */
+import PluginSystem from './plugin_system.mjs'
+import PluginMath from './plugin_math.mjs'
+import PluginCSV from './plugin_csv.mjs'
+import PluginPromise from './plugin_promise.mjs'
+import PluginTOML from './plugin_toml.mjs'
+import PluginTest from './plugin_test.mjs'
+
+/** 基本プラグインを登録する対象 */
+export interface NakoBasicPluginHost {
+  addPlugin (po: {[key: string]: any}, persistent?: boolean, fpath?: string): void;
+}
+
+/**
+ * コアに同梱する基本プラグインの一覧(この順に登録する)
+ */
+export const basicPlugins: {[key: string]: any}[] = [
+  PluginSystem,
+  PluginMath,
+  PluginPromise,
+  PluginTest,
+  PluginCSV,
+  PluginTOML
+]
+
+/**
+ * 基本的なプラグインをコンパイラへ登録する
+ * @param host 登録先のコンパイラ
+ */
+export function registerBasicPlugins (host: NakoBasicPluginHost): void {
+  for (const po of basicPlugins) {
+    host.addPlugin(po)
+  }
+}

--- a/core/src/nako_event.mts
+++ b/core/src/nako_event.mts
@@ -31,7 +31,8 @@ export class NakoEventEmitter {
    * @param event コールバックに渡す値
    */
   fire (eventName: NakoComEventName, event: any): void {
-    for (const e of this.eventList) {
+    const list = this.eventList.slice()
+    for (const e of list) {
       if (e.eventName === eventName) { e.callback(event) }
     }
   }

--- a/core/src/nako_event.mts
+++ b/core/src/nako_event.mts
@@ -1,0 +1,48 @@
+// deno-lint-ignore-file no-explicit-any
+/**
+ * なでしこ3のコンパイラが発火するイベントの管理
+ *
+ * NakoCompiler に散らばっていたイベント発火処理をまとめたモジュール (#2360)
+ */
+import { NakoComEventName, NakoEvent } from './nako_types.mjs'
+
+/**
+ * コンパイル・実行の前後で呼ばれるイベントを管理するクラス
+ */
+export class NakoEventEmitter {
+  private eventList: NakoEvent[]
+
+  constructor () {
+    this.eventList = []
+  }
+
+  /**
+   * イベントを登録する
+   * @param eventName イベント名
+   * @param callback コールバック関数
+   */
+  on (eventName: NakoComEventName, callback: (event: any) => void): void {
+    this.eventList.push({ eventName, callback })
+  }
+
+  /**
+   * 指定したイベントに登録されたコールバックをすべて呼び出す
+   * @param eventName イベント名
+   * @param event コールバックに渡す値
+   */
+  fire (eventName: NakoComEventName, event: any): void {
+    for (const e of this.eventList) {
+      if (e.eventName === eventName) { e.callback(event) }
+    }
+  }
+
+  /** 登録されているイベントの一覧を返す */
+  getEventList (): NakoEvent[] {
+    return this.eventList
+  }
+
+  /** 登録されているイベントをすべて削除する */
+  clear (): void {
+    this.eventList = []
+  }
+}

--- a/core/src/nako_runner.mts
+++ b/core/src/nako_runner.mts
@@ -14,7 +14,7 @@ import { NakoGen, NakoGenResult } from './nako_gen.mjs'
 
 /** コンパイラ実行オプションを生成 */
 export function newCompilerOptions (initObj: Partial<CompilerOptions> = {}): CompilerOptions {
-  if (typeof initObj !== 'object') { initObj = {} }
+  if (initObj === null || typeof initObj !== 'object') { initObj = {} }
   initObj.testOnly = initObj.testOnly || false
   initObj.resetEnv = initObj.resetEnv || false
   initObj.resetAll = initObj.resetAll || false

--- a/core/src/nako_runner.mts
+++ b/core/src/nako_runner.mts
@@ -1,0 +1,191 @@
+// deno-lint-ignore-file no-explicit-any
+/**
+ * なでしこ3のプログラム実行部
+ *
+ * NakoCompiler から実行系(evalJS / runSync / runAsync など)を分離したモジュール (#2360)
+ * 循環参照を避けるため、このモジュールは nako3.mts を参照せず、
+ * 必要な機能は NakoRunnerHost インターフェイス経由で受け取る。
+ */
+import { CompilerOptions, NakoComEventName } from './nako_types.mjs'
+import { NakoLexer } from './nako_lexer.mjs'
+import { NakoLogger } from './nako_logger.mjs'
+import { NakoGlobal } from './nako_global.mjs'
+import { NakoGen, NakoGenResult } from './nako_gen.mjs'
+
+/** コンパイラ実行オプションを生成 */
+export function newCompilerOptions (initObj: Partial<CompilerOptions> = {}): CompilerOptions {
+  if (typeof initObj !== 'object') { initObj = {} }
+  initObj.testOnly = initObj.testOnly || false
+  initObj.resetEnv = initObj.resetEnv || false
+  initObj.resetAll = initObj.resetAll || false
+  initObj.preCode = initObj.preCode || ''
+  initObj.nakoGlobal = initObj.nakoGlobal || null
+  return initObj as CompilerOptions
+}
+
+/**
+ * NakoRunner がホスト(NakoCompiler)に要求する最小限の機能
+ */
+export interface NakoRunnerHost {
+  /** なでしこのプログラムをコンパイルする */
+  compileFromCode (code: string, filename: string, options?: CompilerOptions): NakoGenResult;
+  /** 実行環境(NakoGlobal)を生成する */
+  createNakoGlobal (gen: NakoGen, guid: number): NakoGlobal;
+  getLogger (): NakoLogger;
+  /** コンパイラのイベントを発火する */
+  fireEvent (eventName: NakoComEventName, event: any): void;
+}
+
+/**
+ * コンパイル済みのJavaScriptを実行し、実行環境(NakoGlobal)を管理するクラス
+ */
+export class NakoRunner {
+  /** 生成した NakoGlobal のインスタンスを保持 */
+  globals: NakoGlobal[]
+  /** 現在の NakoGlobal オブジェクト */
+  currentGlobal: NakoGlobal|null
+  private host: NakoRunnerHost
+
+  constructor (host: NakoRunnerHost) {
+    this.host = host
+    this.globals = []
+    this.currentGlobal = null
+  }
+
+  /** 各プラグインをリセットする */
+  clearPlugins (): void {
+    // 他に実行している「なでしこ」があればクリアする
+    this.globals.forEach((sys: NakoGlobal) => {
+      if (!sys) { return }
+      // core #56
+      sys.__setSysVar('__forceClose', true)
+      sys.reset()
+    })
+    this.globals = [] // clear
+  }
+
+  /**
+   * 環境を指定してJavaScriptのコードを実行する
+   * @param code JavaScriptのコード
+   * @param nakoGlobal 実行環境
+   */
+  evalJS (code: string, nakoGlobal: NakoGlobal): void {
+    this.currentGlobal = nakoGlobal // 現在のnakoGlobalを記録
+    this.currentGlobal.lastJSCode = code
+    // 実行前に環境を初期化するイベントを実行(beforeRun)
+    this.host.fireEvent('beforeRun', nakoGlobal)
+    try {
+      const f = new Function(nakoGlobal.lastJSCode)
+      f.apply(nakoGlobal)
+    } catch (err: any) {
+      // なでしこコードのエラーは抑止してログにのみ記録
+      nakoGlobal.numFailures++
+      this.host.getLogger().error(err)
+      throw err
+    }
+    // 実行後に終了イベントを実行(finish)
+    this.host.fireEvent('finish', nakoGlobal)
+  }
+
+  /**
+   * (非推奨) 同期的になでしこのプログラムcodeを実行する
+   * @param code なでしこのプログラム
+   * @param filename ファイル名
+   * @param options オプション
+   * @returns 実行に利用したグローバルオブジェクト
+   * @deprecated 代わりにrunAsyncメソッドを使ってください。(core #52)
+   */
+  runSync (code: string, filename: string, options: CompilerOptions|undefined = undefined): NakoGlobal {
+    // コンパイル
+    options = newCompilerOptions(options)
+    const out = this.host.compileFromCode(code, filename, options)
+    // 実行前に環境を生成
+    const nakoGlobal = this.getNakoGlobal(options, out.gen, filename)
+    // 実行
+    this.evalJS(out.runtimeEnv, nakoGlobal)
+    return nakoGlobal
+  }
+
+  /**
+   * 非同期になでしこのプログラムcodeを実行する
+   * @param code なでしこのプログラム
+   * @param filename ファイル名
+   * @param options オプション
+   * @returns 実行に利用したグローバルオブジェクト
+   */
+  async runAsync (code: string, filename: string, options: CompilerOptions|undefined = undefined): Promise<NakoGlobal> {
+    // コンパイル
+    options = newCompilerOptions(options)
+    const compiledCode = this.host.compileFromCode(code, filename, options)
+    // 実行前に環境を生成
+    const nakoGlobal = this.getNakoGlobal(options, compiledCode.gen, filename)
+    // 実行
+    this.evalJS(compiledCode.runtimeEnv, nakoGlobal)
+    return nakoGlobal
+  }
+
+  /** 実行環境(NakoGlobal)を取得する。指定が無ければ前回の値を再利用する */
+  getNakoGlobal (options: CompilerOptions, gen: NakoGen, filename: string): NakoGlobal {
+    // オプションを参照
+    let g: NakoGlobal|null = options.nakoGlobal
+    if (!g) {
+      // 空ならば前回の値を参照(リセットするなら新規で作成する)
+      if (this.globals.length > 0 && options.resetAll === false && options.resetEnv === false) {
+        g = this.globals[this.globals.length - 1]
+      } else {
+        g = this.host.createNakoGlobal(gen, this.globals.length + 1)
+      }
+      // 名前空間を設定
+      g.__varslist[0].set('名前空間', NakoLexer.filenameToModName(filename))
+    }
+    if (this.globals.indexOf(g) < 0) { this.globals.push(g) }
+    return g
+  }
+
+  /**
+   * (非推奨) 同期的になでしこのプログラムcodeを実行する
+   * @deprecated 代わりにrunAsyncメソッドを使ってください。(core #52)
+   */
+  runEx (code: string, filename: string, opts: CompilerOptions, preCode = '', nakoGlobal: NakoGlobal|undefined = undefined): NakoGlobal {
+    // コンパイル
+    opts.preCode = preCode
+    if (nakoGlobal) { opts.nakoGlobal = nakoGlobal }
+    return this.runSync(code, filename, opts)
+  }
+
+  /**
+   * (非推奨) 非同期でなでしこのプログラムを実行する
+   * @deprecated 代わりにrunAsyncメソッドを使ってください。(core #52)
+   */
+  async run (code: string, fname: string, isReset: boolean, isTest: boolean, preCode = ''): Promise<NakoGlobal> {
+    const opts: CompilerOptions = newCompilerOptions({
+      resetEnv: isReset,
+      resetAll: isReset,
+      testOnly: isTest,
+      preCode
+    })
+    return this.runEx(code, fname, opts)
+  }
+
+  /**
+   * (非推奨) なでしこのプログラムを実行（他に実行しているインスタンスもリセットする)
+   */
+  async runReset (code: string, fname = 'main.nako3', preCode = ''): Promise<NakoGlobal> {
+    const opts = newCompilerOptions({ resetAll: true, resetEnv: true, preCode })
+    return this.runAsync(code, fname, opts)
+  }
+
+  /**
+   * テストを実行する
+   * @param code
+   * @param fname
+   * @param preCode
+   * @param testOnly
+   */
+  test (code: string, fname: string, preCode = '', testOnly = false): NakoGlobal {
+    const options = newCompilerOptions()
+    options.preCode = preCode
+    options.testOnly = testOnly
+    return this.runSync(code, fname, options)
+  }
+}

--- a/core/src/nako_tokenizer.mts
+++ b/core/src/nako_tokenizer.mts
@@ -1,0 +1,221 @@
+// deno-lint-ignore-file no-explicit-any
+/**
+ * なでしこ3の字句解析パイプライン
+ *
+ * NakoCompiler から字句解析とソースマップ処理を分離したモジュール (#2360)
+ * 循環参照を避けるため、このモジュールは nako3.mts を参照せず、
+ * 必要な機能は NakoTokenizerHost インターフェイス経由で受け取る。
+ */
+import { Token } from './nako_types.mjs'
+import { NakoLexer } from './nako_lexer.mjs'
+import { NakoPrepare } from './nako_prepare.mjs'
+import { convertInlineIndent, convertIndentSyntax } from './nako_indent_inline.mjs'
+import { convertDNCL } from './nako_from_dncl.mjs'
+import { convertDNCL2 } from './nako_from_dncl2.mjs'
+import { SourceMappingOfTokenization, SourceMappingOfIndentSyntax, OffsetToLineColumn, subtractSourceMapByPreCodeLength } from './nako_source_mapping.mjs'
+import { NakoLexerError, InternalLexerError } from './nako_errors.mjs'
+import { NakoLogger } from './nako_logger.mjs'
+
+/** 字句解析の結果 */
+export interface LexResult {
+  commentTokens: Token[];
+  tokens: Token[];
+  requireTokens: Token[];
+}
+
+/**
+ * NakoTokenizer がホスト(NakoCompiler)に要求する最小限の機能
+ */
+export interface NakoTokenizerHost {
+  getLogger (): NakoLogger;
+  /** 取り込み文を依存ファイルのトークン列で置換する */
+  replaceRequireStatements (tokens: Token[], includeGuard?: Set<string>): Token[];
+  /** 取り込み文を削除する(シンタックスハイライト用) */
+  removeRequireStatements (tokens: Token[]): Token[];
+}
+
+/**
+ * なでしこのソースコードをトークン列へ分割するクラス
+ */
+export class NakoTokenizer {
+  readonly prepare: NakoPrepare
+  readonly lexer: NakoLexer
+  private host: NakoTokenizerHost
+
+  constructor (host: NakoTokenizerHost) {
+    this.host = host
+    this.prepare = NakoPrepare.getInstance()
+    this.lexer = new NakoLexer(host.getLogger())
+  }
+
+  /** モジュール(名前空間)の一覧を取得する */
+  getModList (): string[] {
+    return this.lexer.modList
+  }
+
+  /**
+   * コードを単語に分割する
+   * @param code なでしこのプログラム
+   * @param line なでしこのプログラムの行番号
+   * @param filename
+   * @param preCode
+   * @returns トークンのリスト
+   */
+  rawtokenize (code: string, line: number, filename: string, preCode = ''): Token[] {
+    if (!code.startsWith(preCode)) {
+      throw new Error('codeの先頭にはpreCodeを含める必要があります。')
+    }
+    // 名前空間のモジュールリストに自身を追加
+    const modName = NakoLexer.filenameToModName(filename)
+    const modList = this.getModList()
+    if (modList.indexOf(modName) < 0) { modList.unshift(modName) }
+    // 全角半角の統一処理
+    const preprocessed = this.prepare.convert(code)
+    const tokenizationSourceMapping = new SourceMappingOfTokenization(code.length, preprocessed)
+    const indentationSyntaxSourceMapping = new SourceMappingOfIndentSyntax(code, [], [])
+    const offsetToLineColumn = new OffsetToLineColumn(code)
+    // トークン分割
+    let tokens: Token[]
+    try {
+      tokens = this.lexer.tokenize(preprocessed.map((v) => v.text).join(''), line, filename)
+    } catch (err) {
+      if (!(err instanceof InternalLexerError)) {
+        throw err
+      }
+      // エラー位置をソースコード上の位置に変換して返す
+      const dest = indentationSyntaxSourceMapping.map(tokenizationSourceMapping.map(err.preprocessedCodeStartOffset), tokenizationSourceMapping.map(err.preprocessedCodeEndOffset))
+      const line: number|undefined = dest.startOffset === null ? err.line : offsetToLineColumn.map(dest.startOffset, false).line
+      const map = subtractSourceMapByPreCodeLength({ ...dest, line }, preCode)
+      throw new NakoLexerError(err.msg, map.startOffset, map.endOffset, map.line, filename)
+    }
+    // DNCL ver2 (core #41)
+    tokens = convertDNCL2(tokens)
+    // DNCL ver1 (#1140)
+    tokens = convertDNCL(tokens)
+    // インデント構文を変換 #596
+    tokens = convertIndentSyntax(tokens)
+    // インラインインデントを変換 #1215
+    tokens = convertInlineIndent(tokens)
+
+    // ソースコード上の位置に変換
+    tokens = tokens.map((token) => {
+      const dest = indentationSyntaxSourceMapping.map(
+        tokenizationSourceMapping.map(token.preprocessedCodeOffset || 0),
+        tokenizationSourceMapping.map((token.preprocessedCodeOffset || 0) + (token.preprocessedCodeLength || 0))
+      )
+      let line = token.line
+      let column = 0
+      if (token.type === 'eol' && dest.endOffset !== null) {
+        // eolはnako_genで `line = ${eolToken.line};` に変換されるため、
+        // 行末のeolのlineは次の行の行数を表す必要がある。
+        const out = offsetToLineColumn.map(dest.endOffset, false)
+        line = out.line
+        column = out.column
+      } else if (dest.startOffset !== null) {
+        const out = offsetToLineColumn.map(dest.startOffset, false)
+        line = out.line
+        column = out.column
+      }
+      return {
+        ...token,
+        ...subtractSourceMapByPreCodeLength({ line, column, startOffset: dest.startOffset, endOffset: dest.endOffset }, preCode),
+        rawJosi: token.josi
+      }
+    })
+    return tokens
+  }
+
+  /**
+   * 単語の属性を構文解析に先立ち補正する
+   * @param {Token[]} tokens トークンのリスト
+   * @param {boolean} isFirst 最初の呼び出しかどうか
+   * @param {string} filename
+   * @returns コード (なでしこ)
+   */
+  converttoken (tokens: Token[], isFirst: boolean, filename: string): Token[] {
+    const tok = this.lexer.replaceTokens(tokens, isFirst, filename)
+    return tok
+  }
+
+  /**
+   * typeがcodeのトークンを単語に分割するための処理
+   * @param {string} code
+   * @param {number} line
+   * @param {string} filename
+   * @param {number | null} startOffset
+   * @returns
+   */
+  lexCodeToken (code: string, line: number, filename: string, startOffset: number|null): {commentTokens: Token[], tokens: Token[]} {
+    // 単語に分割
+    let tokens = this.rawtokenize(code, line, filename, '')
+
+    // 文字列内位置からファイル内位置へ変換
+    if (startOffset === null) {
+      for (const token of tokens) {
+        token.startOffset = undefined
+        token.endOffset = undefined
+      }
+    } else {
+      for (const token of tokens) {
+        if (token.startOffset !== undefined) {
+          token.startOffset += startOffset
+        }
+        if (token.endOffset !== undefined) {
+          token.endOffset += startOffset
+        }
+      }
+    }
+
+    // convertTokenで消されるコメントのトークンを残す
+    const commentTokens = tokens.filter((t) => t.type === 'line_comment' || t.type === 'range_comment')
+      .map((v) => ({ ...v })) // clone
+
+    tokens = this.converttoken(tokens, false, filename)
+
+    return { tokens, commentTokens }
+  }
+
+  /** 字句解析を行う */
+  lex (code: string, filename = 'main.nako3', preCode = '', syntaxHighlighting = false): LexResult {
+    // 単語に分割
+    let tokens = this.rawtokenize(code, 0, filename, preCode)
+
+    // require文を再帰的に置換する
+    const requireStatementTokens = syntaxHighlighting ? this.host.removeRequireStatements(tokens) : this.host.replaceRequireStatements(tokens, undefined)
+    for (const t of requireStatementTokens) {
+      if (t.type === 'word' || t.type === 'not') {
+        t.type = 'require'
+      }
+    }
+    if (requireStatementTokens.length >= 3) {
+      // modList を更新
+      for (let i = 0; i < requireStatementTokens.length; i += 3) {
+        let modName = requireStatementTokens[i + 1].value
+        modName = NakoLexer.filenameToModName(modName)
+        if (this.lexer.modList.indexOf(modName) < 0) {
+          this.lexer.modList.push(modName)
+        }
+      }
+    }
+
+    // convertTokenで消されるコメントのトークンを残す
+    const commentTokens: Token[] = tokens.filter((t) => t.type === 'line_comment' || t.type === 'range_comment')
+      .map((v) => ({ ...v })) // clone
+
+    tokens = this.converttoken(tokens, true, filename)
+
+    // 'string_ex'トークンから変換された'code'トークンを字句解析する
+    for (let i = 0; i < tokens.length; i++) {
+      if (tokens[i] && tokens[i].type === 'code') {
+        const children = this.lexCodeToken(tokens[i].value, tokens[i].line, filename, tokens[i].startOffset || 0)
+        commentTokens.push(...children.commentTokens)
+        tokens.splice(i, 1, ...children.tokens)
+        i--
+      }
+    }
+
+    this.host.getLogger().trace('--- lex ---\n' + JSON.stringify(tokens, null, 2))
+
+    return { commentTokens, tokens, requireTokens: requireStatementTokens }
+  }
+}

--- a/core/test/nako_basic_plugins_test.mjs
+++ b/core/test/nako_basic_plugins_test.mjs
@@ -1,0 +1,44 @@
+/* eslint-disable no-undef */
+import { describe, it } from 'node:test'
+import assert from 'assert'
+
+import { NakoCompiler } from '../src/nako3.mjs'
+import { basicPlugins, registerBasicPlugins } from '../src/nako_basic_plugins.mjs'
+
+/**
+ * 基本プラグインの一覧を NakoCompiler から分離したモジュールのテスト (#2360)
+ */
+describe('nako_basic_plugins_test', () => {
+  it('基本プラグインの一覧を取得できる', () => {
+    assert.strictEqual(basicPlugins.length, 6)
+    const names = basicPlugins.map((po) => po.meta.value.pluginName)
+    assert.deepStrictEqual(names, [
+      'plugin_system', 'plugin_math', 'plugin_promise', 'plugin_test', 'plugin_csv', 'plugin_toml'
+    ])
+  })
+
+  it('registerBasicPluginsは一覧の順にaddPluginを呼ぶ', () => {
+    const called = []
+    registerBasicPlugins({ addPlugin: (po) => { called.push(po) } })
+    assert.deepStrictEqual(called, basicPlugins)
+  })
+
+  it('useBasicPluginがtrueなら基本プラグインの命令を使える', () => {
+    const nako = new NakoCompiler({ useBasicPlugin: true })
+    assert.ok(nako.getFunc('表示') !== undefined, 'PluginSystemの命令')
+    assert.ok(nako.getFunc('SIN') !== undefined, 'PluginMathの命令')
+  })
+
+  it('useBasicPluginがfalseなら基本プラグインは登録されない', () => {
+    const nako = new NakoCompiler({ useBasicPlugin: false })
+    assert.strictEqual(nako.getFunc('表示'), undefined)
+    assert.deepStrictEqual(Object.keys(nako.getPluginfiles()), [])
+  })
+
+  it('addBasicPluginsを後から呼んでも登録できる', () => {
+    const nako = new NakoCompiler({ useBasicPlugin: false })
+    nako.addBasicPlugins()
+    assert.ok(nako.getFunc('表示') !== undefined)
+    assert.strictEqual(Object.keys(nako.getPluginfiles()).length, basicPlugins.length)
+  })
+})

--- a/core/test/nako_event_test.mjs
+++ b/core/test/nako_event_test.mjs
@@ -1,0 +1,85 @@
+/* eslint-disable no-undef */
+import { describe, it } from 'node:test'
+import assert from 'assert'
+
+import { NakoCompiler } from '../src/nako3.mjs'
+import { NakoEventEmitter } from '../src/nako_event.mjs'
+
+/**
+ * イベント機構を NakoCompiler から分離したモジュールのテスト (#2360)
+ */
+describe('nako_event_test', () => {
+  it('onで登録したコールバックがfireで呼ばれる', () => {
+    const emitter = new NakoEventEmitter()
+    const log = []
+    emitter.on('beforeParse', (v) => { log.push(`a:${v}`) })
+    emitter.on('beforeParse', (v) => { log.push(`b:${v}`) })
+    emitter.fire('beforeParse', 1)
+    assert.deepStrictEqual(log, ['a:1', 'b:1'])
+  })
+
+  it('登録していないイベントを発火しても何も起きない', () => {
+    const emitter = new NakoEventEmitter()
+    let called = 0
+    emitter.on('beforeParse', () => { called++ })
+    emitter.fire('finish', null)
+    assert.strictEqual(called, 0)
+  })
+
+  it('別のイベント名のコールバックは呼ばれない', () => {
+    const emitter = new NakoEventEmitter()
+    const log = []
+    emitter.on('beforeParse', () => { log.push('parse') })
+    emitter.on('finish', () => { log.push('finish') })
+    emitter.fire('finish', null)
+    assert.deepStrictEqual(log, ['finish'])
+  })
+
+  it('getEventListで登録済みのイベントを取得できる', () => {
+    const emitter = new NakoEventEmitter()
+    emitter.on('beforeRun', () => {})
+    assert.strictEqual(emitter.getEventList().length, 1)
+    assert.strictEqual(emitter.getEventList()[0].eventName, 'beforeRun')
+  })
+
+  it('clearで登録済みのイベントを削除できる', () => {
+    const emitter = new NakoEventEmitter()
+    let called = 0
+    emitter.on('finish', () => { called++ })
+    emitter.clear()
+    emitter.fire('finish', null)
+    assert.strictEqual(called, 0)
+    assert.strictEqual(emitter.getEventList().length, 0)
+  })
+
+  it('NakoCompilerのaddListenerでイベントが発火する順番', async () => {
+    const nako = new NakoCompiler()
+    const log = []
+    nako.addListener('beforeParse', () => { log.push('beforeParse') })
+    nako.addListener('beforeGenerate', () => { log.push('beforeGenerate') })
+    nako.addListener('afterGenerate', () => { log.push('afterGenerate') })
+    nako.addListener('beforeRun', () => { log.push('beforeRun') })
+    nako.addListener('finish', () => { log.push('finish') })
+    await nako.runAsync('「テスト」を表示', 'main.nako3')
+    assert.deepStrictEqual(log, ['beforeParse', 'beforeGenerate', 'afterGenerate', 'beforeRun', 'finish'])
+  })
+
+  it('beforeParseにはソースコードが渡される', async () => {
+    const nako = new NakoCompiler()
+    let received = null
+    nako.addListener('beforeParse', (code) => { received = code })
+    await nako.runAsync('1と2を足して表示', 'main.nako3')
+    assert.strictEqual(received, '1と2を足して表示')
+  })
+
+  it('beforeRunとfinishには実行環境が渡される', async () => {
+    const nako = new NakoCompiler()
+    const received = []
+    nako.addListener('beforeRun', (g) => { received.push(g) })
+    nako.addListener('finish', (g) => { received.push(g) })
+    const g = await nako.runAsync('「テスト」を表示', 'main.nako3')
+    assert.strictEqual(received.length, 2)
+    assert.strictEqual(received[0], g)
+    assert.strictEqual(received[1], g)
+  })
+})

--- a/core/test/nako_runner_test.mjs
+++ b/core/test/nako_runner_test.mjs
@@ -1,0 +1,114 @@
+/* eslint-disable no-undef */
+import { describe, it } from 'node:test'
+import assert from 'assert'
+
+import { NakoCompiler, newCompilerOptions } from '../src/nako3.mjs'
+import { newCompilerOptions as newCompilerOptionsFromRunner } from '../src/nako_runner.mjs'
+
+/**
+ * 実行部を NakoCompiler から分離したモジュールのテスト (#2360)
+ */
+describe('nako_runner_test', () => {
+  it('newCompilerOptionsは既定値を埋める', () => {
+    const opt = newCompilerOptions()
+    assert.strictEqual(opt.testOnly, false)
+    assert.strictEqual(opt.resetEnv, false)
+    assert.strictEqual(opt.resetAll, false)
+    assert.strictEqual(opt.preCode, '')
+    assert.strictEqual(opt.nakoGlobal, null)
+  })
+
+  it('newCompilerOptionsは指定した値を残す', () => {
+    const opt = newCompilerOptions({ testOnly: true, preCode: 'A=1;' })
+    assert.strictEqual(opt.testOnly, true)
+    assert.strictEqual(opt.preCode, 'A=1;')
+    assert.strictEqual(opt.resetEnv, false)
+  })
+
+  it('nako3.mjsとnako_runner.mjsのnewCompilerOptionsは同じ関数', () => {
+    assert.strictEqual(newCompilerOptions, newCompilerOptionsFromRunner)
+  })
+
+  it('runAsyncが実行環境を返し__globalObjに記録される', async () => {
+    const nako = new NakoCompiler()
+    const g = await nako.runAsync('「テスト」を表示', 'main.nako3')
+    assert.strictEqual(g.log, 'テスト')
+    assert.strictEqual(nako.__globalObj, g, '現在の実行環境が記録されること')
+    assert.strictEqual(nako.__globals.length, 1)
+    assert.strictEqual(nako.__globals[0], g)
+  })
+
+  it('__globalObjは代入もできる(後方互換)', () => {
+    const nako = new NakoCompiler()
+    assert.strictEqual(nako.__globalObj, null)
+    const dummy = { dummy: true }
+    nako.__globalObj = dummy
+    assert.strictEqual(nako.__globalObj, dummy)
+  })
+
+  it('__globalsは代入もできる(後方互換)', () => {
+    const nako = new NakoCompiler()
+    nako.__globals = []
+    assert.deepStrictEqual(nako.__globals, [])
+  })
+
+  it('連続して実行すると同じ実行環境を再利用する', async () => {
+    const nako = new NakoCompiler()
+    const g1 = await nako.runAsync('A=10', 'main.nako3')
+    const g2 = await nako.runAsync('Aを表示', 'main.nako3')
+    assert.strictEqual(g1, g2, '実行環境が共有されること')
+    assert.strictEqual(g2.log, '10')
+    assert.strictEqual(nako.__globals.length, 1)
+  })
+
+  it('clearPluginsで実行環境の一覧が空になる', async () => {
+    const nako = new NakoCompiler()
+    await nako.runAsync('「テスト」を表示', 'main.nako3')
+    assert.strictEqual(nako.__globals.length, 1)
+    nako.clearPlugins()
+    assert.strictEqual(nako.__globals.length, 0)
+  })
+
+  it('resetAllを指定すると新しい実行環境が作られる', async () => {
+    const nako = new NakoCompiler()
+    const g1 = await nako.runAsync('A=10', 'main.nako3')
+    const g2 = await nako.runAsync('「テスト」を表示', 'main.nako3', newCompilerOptions({ resetAll: true, resetEnv: true }))
+    assert.notStrictEqual(g1, g2, '実行環境が作り直されること')
+  })
+
+  it('nakoGlobalを指定すると、その実行環境を使う', async () => {
+    const nako = new NakoCompiler()
+    const g1 = await nako.runAsync('A=10', 'main.nako3')
+    const g2 = await nako.runAsync('Aを表示', 'main.nako3', newCompilerOptions({ nakoGlobal: g1 }))
+    assert.strictEqual(g1, g2)
+    assert.strictEqual(g2.log, '10')
+  })
+
+  it('runSyncも同じように動作する', () => {
+    const nako = new NakoCompiler()
+    const g = nako.runSync('「同期」を表示', 'main.nako3')
+    assert.strictEqual(g.log, '同期')
+  })
+
+  it('testメソッドはpreCodeを反映する', () => {
+    const nako = new NakoCompiler()
+    // preCode は code の先頭に含めて渡す仕様
+    const g = nako.test('A=5;Aを表示', 'main.nako3', 'A=5;')
+    assert.strictEqual(g.log, '5')
+  })
+
+  it('runReset は他の実行インスタンスもリセットする', async () => {
+    const nako = new NakoCompiler()
+    await nako.runAsync('A=10', 'main.nako3')
+    const g = await nako.runReset('「リセット」を表示', 'main.nako3')
+    assert.strictEqual(g.log, 'リセット')
+    assert.strictEqual(nako.__globals.length, 1, '古い実行環境が破棄されること')
+  })
+
+  it('実行時エラーはログに記録された上で例外になる', async () => {
+    const nako = new NakoCompiler()
+    await assert.rejects(async () => {
+      await nako.runAsync('『存在しない関数』のエラー発生', 'main.nako3')
+    })
+  })
+})

--- a/core/test/nako_tokenizer_test.mjs
+++ b/core/test/nako_tokenizer_test.mjs
@@ -1,0 +1,115 @@
+/* eslint-disable no-undef */
+import { describe, it } from 'node:test'
+import assert from 'assert'
+
+import { NakoCompiler } from '../src/nako3.mjs'
+import { NakoTokenizer } from '../src/nako_tokenizer.mjs'
+import { NakoLogger } from '../src/nako_logger.mjs'
+
+/**
+ * 字句解析パイプラインを NakoCompiler から分離したモジュールのテスト (#2360)
+ */
+describe('nako_tokenizer_test', () => {
+  /** 取り込み文を扱わない、単体テスト用のトークナイザを作る */
+  const createTokenizer = () => {
+    const logger = new NakoLogger()
+    return new NakoTokenizer({
+      getLogger: () => logger,
+      // 取り込み文は扱わないので、何もせず空配列を返す
+      replaceRequireStatements: () => [],
+      removeRequireStatements: () => []
+    })
+  }
+
+  it('rawtokenizeがトークン列を返す', () => {
+    const tokenizer = createTokenizer()
+    // 単体のトークナイザは関数一覧を持たないため、命令は word になる
+    const tokens = tokenizer.rawtokenize('1と2を足す', 0, 'main.nako3')
+    const types = tokens.map((t) => t.type)
+    assert.ok(types.includes('number'), '数値トークンが含まれること')
+    assert.ok(types.includes('word'), '単語トークンが含まれること')
+    assert.deepStrictEqual(tokens.filter((t) => t.type === 'number').map((t) => t.value), [1, 2])
+  })
+
+  it('rawtokenizeはpreCodeがcodeの先頭にないとエラーになる', () => {
+    const tokenizer = createTokenizer()
+    assert.throws(
+      () => tokenizer.rawtokenize('「A」を表示', 0, 'main.nako3', '「B」を表示'),
+      /preCodeを含める必要があります/
+    )
+  })
+
+  it('rawtokenizeがモジュールリストへ自身を追加する', () => {
+    const tokenizer = createTokenizer()
+    tokenizer.rawtokenize('「A」を表示', 0, 'sample.nako3')
+    assert.ok(tokenizer.getModList().includes('sample'))
+  })
+
+  it('全角の記号が半角へ正規化される', () => {
+    const tokenizer = createTokenizer()
+    // 全角の「＝」が半角の「=」として解釈される
+    const tokens = tokenizer.rawtokenize('Ａ＝１', 0, 'main.nako3')
+    const types = tokens.map((t) => t.type)
+    assert.ok(types.includes('eq'), '代入のトークンになること')
+  })
+
+  it('トークンに行番号と桁位置が設定される', () => {
+    const tokenizer = createTokenizer()
+    const tokens = tokenizer.rawtokenize('「A」を表示\n「B」を表示\n', 0, 'main.nako3')
+    const second = tokens.filter((t) => t.type === 'string' && t.value === 'B')[0]
+    assert.ok(second !== undefined)
+    assert.strictEqual(second.line, 1, '2行目のトークンの行番号は1になること')
+  })
+
+  it('コメントのトークンが残る', () => {
+    const tokenizer = createTokenizer()
+    const tokens = tokenizer.rawtokenize('# これはコメント\n「A」を表示\n', 0, 'main.nako3')
+    const comments = tokens.filter((t) => t.type === 'line_comment')
+    assert.strictEqual(comments.length, 1)
+  })
+
+  it('lexCodeTokenがstartOffsetを加算する', () => {
+    const tokenizer = createTokenizer()
+    const res = tokenizer.lexCodeToken('1に2を足す', 0, 'main.nako3', 100)
+    const withOffset = res.tokens.filter((t) => t.startOffset !== undefined)
+    assert.ok(withOffset.length > 0)
+    assert.ok(withOffset.every((t) => t.startOffset >= 100), 'startOffsetが加算されること')
+  })
+
+  it('lexCodeTokenにstartOffsetがnullならオフセットを消す', () => {
+    const tokenizer = createTokenizer()
+    const res = tokenizer.lexCodeToken('1に2を足す', 0, 'main.nako3', null)
+    assert.ok(res.tokens.every((t) => t.startOffset === undefined))
+    assert.ok(res.tokens.every((t) => t.endOffset === undefined))
+  })
+
+  it('lexが字句解析の結果を返す', () => {
+    const tokenizer = createTokenizer()
+    const res = tokenizer.lex('# コメント\n「A」を表示\n', 'main.nako3')
+    assert.ok(res.tokens.length > 0)
+    assert.strictEqual(res.commentTokens.length, 1)
+    assert.deepStrictEqual(res.requireTokens, [])
+  })
+
+  it('NakoCompilerの各メソッドはトークナイザへ委譲される', () => {
+    const nako = new NakoCompiler()
+    const viaCompiler = nako.rawtokenize('1と2を足す', 0, 'main.nako3')
+    const viaTokenizer = nako.tokenizer.rawtokenize('1と2を足す', 0, 'main.nako3')
+    assert.deepStrictEqual(viaCompiler.map((t) => t.type), viaTokenizer.map((t) => t.type))
+    // getModList もトークナイザが持つモジュールリストを返す
+    assert.strictEqual(nako.getModList(), nako.tokenizer.getModList())
+  })
+
+  it('replaceLoggerを呼ぶとトークナイザのロガーも差し替わる', () => {
+    const nako = new NakoCompiler()
+    const logger = nako.replaceLogger()
+    assert.strictEqual(nako.tokenizer.lexer.logger, logger)
+    assert.strictEqual(nako.getLogger(), logger)
+  })
+
+  it('文字列展開の中のコードも字句解析される', async () => {
+    const nako = new NakoCompiler()
+    const g = await nako.runAsync('A=3;「値は{A}です」を表示', 'main.nako3')
+    assert.strictEqual(g.log, '値は3です')
+  })
+})


### PR DESCRIPTION
## 概要

#2360 の対応 (第2弾) です。#2362 に続き、`NakoCompiler` の残りの責務を別モジュールへ切り出しました。

`core/src/nako3.mts` は **866行 → 705行** になり、`parse` / `generateCode` 以外はほぼ委譲だけのファサードになりました。

## 変更内容

### 新規 `core/src/nako_tokenizer.mts` (字句解析パイプライン)

- `NakoTokenizer` — `rawtokenize` / `converttoken` / `lexCodeToken` / `lex`
- ソースマップ処理 (`SourceMappingOfTokenization` / `SourceMappingOfIndentSyntax` / `OffsetToLineColumn`)、DNCL変換、インデント構文変換の呼び出し
- `NakoPrepare` と `NakoLexer` のインスタンスを所有
- `LexResult` の型定義

### 新規 `core/src/nako_runner.mts` (実行部)

- `NakoRunner` — `evalJS` / `runSync` / `runAsync` / `getNakoGlobal` / `clearPlugins` と、非推奨の `run` / `runEx` / `runReset` / `test`
- `__globals` / `__globalObj` を所有
- `newCompilerOptions` を移動 (実行オプションの生成なので実行部が自然な置き場所)

### 新規 `core/src/nako_event.mts` (イベント機構)

- `NakoEventEmitter` — `on` / `fire` / `getEventList` / `clear`
- 5箇所に散らばっていた `this.eventList.filter(o => o.eventName === 'X').map(e => e.callback(v))` を `this.events.fire('X', v)` の1行に統一

### 新規 `core/src/nako_basic_plugins.mts` (基本プラグイン)

- `PluginSystem` / `PluginMath` / `PluginPromise` / `PluginTest` / `PluginCSV` / `PluginTOML` の import と登録順を集約
- `basicPlugins` 配列と `registerBasicPlugins()` を公開

### 循環参照の回避

前回と同様、新しいモジュールは `nako3.mts` を import せず、`NakoTokenizerHost` / `NakoRunnerHost` インターフェイス経由で `NakoCompiler` の機能を受け取ります。

- `NakoTokenizerHost` — `getLogger` / `replaceRequireStatements` / `removeRequireStatements`
- `NakoRunnerHost` — `compileFromCode` / `createNakoGlobal` / `getLogger` / `fireEvent`

`new NakoGlobal(compiler, ...)` はホストの `createNakoGlobal` に委ねているため、`nako_runner.mts` は `NakoGlobal` を型としてのみ参照します。

## 公開APIは完全互換

- `NakoCompiler` には薄い委譲メソッドを残しました (`rawtokenize` / `converttoken` / `lexCodeToken` / `lex` / `runSync` / `runAsync` / `test` / `run` / `runEx` / `runReset` / `clearPlugins` / `addListener` など)
- `newCompilerOptions` は `nako3.mts` から再エクスポート (`core/index.mts` と `cnako3mod.mts` が参照)
- `__globals` / `__globalObj` は getter/setter として残しました (`wnako3mod.mts` と `wnako3_editor.mts` が `__globalObj` を参照するため)
- `protected eventList` も getter として残しました
- `private lexer` は `NakoTokenizer` が持つインスタンスを返す getter に変更 (`replaceLogger()` の差し替えも従来どおり動作)

## テスト

新規テスト39件を追加しました。

### `core/test/nako_tokenizer_test.mjs` (12件)
`rawtokenize` のトークン分割・preCodeの検証・モジュールリスト追加・全角半角の正規化・行番号/桁位置、コメントトークンの保持、`lexCodeToken` のオフセット加算とnull時の削除、`lex` の戻り値、`NakoCompiler` からの委譲、`replaceLogger` の反映、文字列展開内のコードの字句解析

### `core/test/nako_runner_test.mjs` (14件)
`newCompilerOptions` の既定値、`nako3.mjs` と `nako_runner.mjs` の同一性、`__globalObj` / `__globals` の getter/setter 互換、実行環境の再利用と作り直し (`resetAll` / `nakoGlobal` 指定)、`clearPlugins`、`runSync` / `test` / `runReset`、実行時エラー

### `core/test/nako_event_test.mjs` (8件)
`NakoEventEmitter` の `on` / `fire` / `getEventList` / `clear`、イベント名の絞り込み、`NakoCompiler.addListener` での発火順序 (beforeParse → beforeGenerate → afterGenerate → beforeRun → finish)、コールバックに渡される値

### `core/test/nako_basic_plugins_test.mjs` (5件)
基本プラグインの一覧と登録順、`registerBasicPlugins`、`useBasicPlugin` の true/false、`addBasicPlugins` の後付け呼び出し

### 実行結果

| 項目 | 結果 |
|---|---|
| `npx tsc --noEmit` | エラーなし |
| `npm run lint` | 指摘なし |
| `npm test` (core/node/common) | 917件すべて pass (新規39件を含む) |
| `npm run test:e` (エディタ) | 21件 pass |
| `npm run test:async` | 24件 pass |
| CLI実行・取り込み文の実動作確認 | 正常 |

## 分離後の構成

```
core/src/nako3.mts              NakoCompiler (ファサード + parse / generateCode)
├── nako_tokenizer.mts          字句解析パイプライン
├── nako_require.mts            取り込み文の処理        (#2362)
├── nako_plugin_manager.mts     プラグイン管理          (#2362)
├── nako_runner.mts             プログラムの実行
├── nako_event.mts              イベント機構
└── nako_basic_plugins.mts      基本プラグインの一覧
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)