### PR TITLE
連文を含む複数関数の非同期判定を修正 (#2170)

### DIFF
--- a/core/src/nako_parser_async.mts
+++ b/core/src/nako_parser_async.mts
@@ -41,7 +41,15 @@ function checkNode (node: Ast, funclist: FuncList, ctx: CheckContext): boolean {
   if (node.type === 'def_func' || node.type === 'def_test' || node.type === 'func_obj') {
     // 関数定義でasyncFnが指定されているならtrueを返す
     const def: AstDefFunc = node as AstDefFunc
-    if (def.asyncFn) { return true } // 既にasyncFnが指定されている
+    if (def.asyncFn) {
+      // 後から判明した非同期情報を、呼び出し側の判定に使う関数一覧にも反映する
+      const func = funclist.get(def.name)
+      if (func && !func.asyncFn) {
+        func.asyncFn = true
+        ctx.modified = true
+      }
+      return true
+    }
     // 関数定義の中身を調べてasyncFnであるならtrueに変更する
     let isAsyncFn = false
     for (const n of def.blocks) {
@@ -49,6 +57,8 @@ function checkNode (node: Ast, funclist: FuncList, ctx: CheckContext): boolean {
         isAsyncFn = true
         def.asyncFn = isAsyncFn
         def.meta.asyncFn = isAsyncFn
+        const func = funclist.get(def.name)
+        if (func) { func.asyncFn = true }
         ctx.modified = true
         return true
       }
@@ -87,11 +97,13 @@ function checkNode (node: Ast, funclist: FuncList, ctx: CheckContext): boolean {
   }
   // その他
   if ((node as AstBlocks).blocks) {
+    let containsAsync = false
     for (const n of (node as AstBlocks).blocks) {
       if (checkNode(n, funclist, ctx)) {
-        return true
+        containsAsync = true
       }
     }
+    return containsAsync
   }
   return false
 }

--- a/core/src/nako_parser_async.mts
+++ b/core/src/nako_parser_async.mts
@@ -10,12 +10,20 @@
  * 1 回の走査では行き渡らないことがある。呼び出し側は変化が無くなるまで
  * `checkAsyncFn()` を繰り返し呼ぶこと。
  */
-import { Ast, AstBlocks, AstDefFunc, AstCallFunc } from './nako_ast.mjs'
+import { Ast, AstBlocks, AstDefFunc, AstCallFunc, AstLet } from './nako_ast.mjs'
 import { FuncList } from './nako_types.mjs'
 
 /** 走査中に AST を書き換えたかどうかを持ち回るための入れ物 */
 interface CheckContext {
   modified: boolean
+  /**
+   * 非同期の無名関数を保持している変数名
+   *
+   * `F=●()...ここまで` のように変数へ代入された無名関数は funclist に載らないため、
+   * 代入を覚えておかないと `F()` の呼び出しに asyncFn を付けられない。
+   * 変数のシャドーイングを考慮して、関数定義ごとにスコープを積む。
+   */
+  asyncVarScopes: Set<string>[]
 }
 
 /**
@@ -26,9 +34,30 @@ interface CheckContext {
  * @returns AST を書き換えたら true。呼び出し側は false になるまで繰り返すこと
  */
 export function checkAsyncFn (node: Ast, funclist: FuncList): boolean {
-  const ctx: CheckContext = { modified: false }
+  const ctx: CheckContext = { modified: false, asyncVarScopes: [new Set()] }
   checkNode(node, funclist, ctx)
   return ctx.modified
+}
+
+/** 変数名が非同期の無名関数を指しているかどうかを、内側のスコープから順に調べる */
+function isAsyncVar (ctx: CheckContext, name: string): boolean {
+  for (let i = ctx.asyncVarScopes.length - 1; i >= 0; i--) {
+    if (ctx.asyncVarScopes[i].has(name)) { return true }
+  }
+  return false
+}
+
+/**
+ * 変数への代入が非同期の無名関数なら、現在のスコープに覚えておく
+ * (`let` と `def_local_var` はどちらも blocks[0] が代入する値)
+ */
+function checkAsyncVarAssign (node: Ast, ctx: CheckContext): void {
+  const letNode = node as AstLet
+  if (!letNode.name) { return }
+  const value = (letNode.blocks || [])[0]
+  if (!value || value.type !== 'func_obj') { return }
+  if (!(value as AstDefFunc).asyncFn) { return }
+  ctx.asyncVarScopes[ctx.asyncVarScopes.length - 1].add(letNode.name)
 }
 
 /**
@@ -39,30 +68,38 @@ function checkNode (node: Ast, funclist: FuncList, ctx: CheckContext): boolean {
   if (!node) { return false }
   // 関数定義があれば関数
   if (node.type === 'def_func' || node.type === 'def_test' || node.type === 'func_obj') {
-    // 関数定義でasyncFnが指定されているならtrueを返す
     const def: AstDefFunc = node as AstDefFunc
-    if (def.asyncFn) {
-      // 後から判明した非同期情報を、呼び出し側の判定に使う関数一覧にも反映する
-      const func = funclist.get(def.name)
-      if (func && !func.asyncFn) {
-        func.asyncFn = true
-        ctx.modified = true
-      }
-      return true
-    }
-    // 関数定義の中身を調べてasyncFnであるならtrueに変更する
+    // 既に非同期と分かっていても中身の走査は省略しない。
+    // 途中で打ち切ると、それより後ろにある呼び出しに asyncFn が付かなくなる
+    ctx.asyncVarScopes.push(new Set())
     let isAsyncFn = false
     for (const n of def.blocks) {
-      if (checkNode(n, funclist, ctx)) {
-        isAsyncFn = true
-        def.asyncFn = isAsyncFn
-        def.meta.asyncFn = isAsyncFn
-        const func = funclist.get(def.name)
-        if (func) { func.asyncFn = true }
-        ctx.modified = true
-        return true
-      }
+      if (checkNode(n, funclist, ctx)) { isAsyncFn = true }
     }
+    ctx.asyncVarScopes.pop()
+    // 関数定義の中身が非同期であるならasyncFnをtrueに変更する
+    if (isAsyncFn && !def.asyncFn) {
+      def.asyncFn = true
+      def.meta.asyncFn = true
+      ctx.modified = true
+    }
+    if (!def.asyncFn) { return false }
+    // 後から判明した非同期情報を、呼び出し側の判定に使う関数一覧にも反映する
+    const func = funclist.get(def.name)
+    if (func && !func.asyncFn) {
+      func.asyncFn = true
+      ctx.modified = true
+    }
+    return true
+  }
+  // 変数へ代入された無名関数を覚えておく(呼び出し側の判定に使う)
+  if (node.type === 'let' || node.type === 'def_local_var') {
+    let containsAsync = false
+    for (const n of (node as AstBlocks).blocks) {
+      if (checkNode(n, funclist, ctx)) { containsAsync = true }
+    }
+    checkAsyncVarAssign(node, ctx)
+    return containsAsync
   }
   // 関数呼び出しを調べて非同期処理が必要ならtrueを返す
   if (node.type === 'func') {
@@ -73,18 +110,27 @@ function checkNode (node: Ast, funclist: FuncList, ctx: CheckContext): boolean {
     }
     // 続けて、以下の関数呼び出しの引数などに非同期処理があるかどうか調べる
     // 関数の引数は、node.blocksに格納されている
+    // (2つ目以降の引数にも asyncFn が必要なので、最初の1つで打ち切らない)
     if (callNode.blocks) {
+      let hasAsyncArg = false
       for (const n of callNode.blocks) {
-        if (checkNode(n, funclist, ctx)) {
-          callNode.asyncFn = true
-          ctx.modified = true
-          return true
-        }
+        if (checkNode(n, funclist, ctx)) { hasAsyncArg = true }
+      }
+      if (hasAsyncArg) {
+        callNode.asyncFn = true
+        ctx.modified = true
+        return true
       }
     }
     // さらに、関数のリンクを調べる
     const func = funclist.get(callNode.name)
     if (func && func.asyncFn) {
+      callNode.asyncFn = true
+      ctx.modified = true
+      return true
+    }
+    // 非同期の無名関数を保持している変数の呼び出しかどうかを調べる
+    if (isAsyncVar(ctx, callNode.name)) {
       callNode.asyncFn = true
       ctx.modified = true
       return true

--- a/core/test/nako_parser_async_test.mjs
+++ b/core/test/nako_parser_async_test.mjs
@@ -25,6 +25,28 @@ function blockNode (blocks) {
   return { type: 'block', blocks, josi: '' }
 }
 
+/** テスト用に func_obj(無名関数) ノードを作る */
+function funcObjNode (blocks = [], asyncFn = false) {
+  return { type: 'func_obj', name: '', blocks, meta: {}, asyncFn, josi: '' }
+}
+
+/** テスト用に let(代入) ノードを作る */
+function letNode (name, value) {
+  return { type: 'let', name, blocks: [value], josi: '' }
+}
+
+/**
+ * なでしこのプログラムを実行してログを得る
+ *
+ * runAsync は生成コードの非同期IIFEを開始した時点で戻るため、
+ * 実行完了までイベントループを進める必要がある (課題は #2381 を参照)
+ */
+async function runAndGetLog (code) {
+  const g = await new NakoCompiler().runAsync(code, 'main.nako3')
+  await new Promise((resolve) => setTimeout(resolve, 10))
+  return g.log
+}
+
 describe('nako_parser_async_test', () => {
   describe('checkAsyncFn', () => {
     it('非同期処理が無ければ書き換えない', () => {
@@ -63,6 +85,23 @@ describe('nako_parser_async_test', () => {
       assert.strictEqual(outer.asyncFn, true)
     })
 
+    it('引数の走査も最初の非同期ノードで打ち切らない', () => {
+      const funclist = new Map([['待つ', { type: 'func', asyncFn: true }]])
+      const arg1 = funcNode('待つ')
+      const arg2 = funcNode('待つ')
+      const outer = funcNode('足', [arg1, arg2])
+      const ast = blockNode([outer])
+
+      let count = 0
+      while (checkAsyncFn(ast, funclist)) {
+        count++
+        assert.ok(count < 10, '不動点に収束しない')
+      }
+      assert.strictEqual(outer.asyncFn, true)
+      assert.strictEqual(arg1.asyncFn, true)
+      assert.strictEqual(arg2.asyncFn, true, '2つ目の引数も訪問される')
+    })
+
     it('連文は常に非同期として扱う', () => {
       const def = defFuncNode('F', [{ type: 'renbun', blocks: [], josi: '' }])
       assert.strictEqual(checkAsyncFn(blockNode([def]), new Map()), true)
@@ -88,6 +127,68 @@ describe('nako_parser_async_test', () => {
       assert.strictEqual(defG.asyncFn, true, 'F の後ろにある G も訪問される')
       assert.strictEqual(funclist.get('F').asyncFn, true)
       assert.strictEqual(funclist.get('G').asyncFn, true)
+    })
+
+    it('関数定義の本体も最初の非同期ノードで打ち切らない', () => {
+      // 本体の1文目が非同期でも、2文目以降を走査しないと
+      // そこにある呼び出しに asyncFn が付かない
+      const funclist = new Map([
+        ['待つ', { type: 'func', asyncFn: true }],
+        ['G', { type: 'func', asyncFn: true }],
+        ['F', { type: 'func', asyncFn: false }]
+      ])
+      const callG = funcNode('G')
+      const def = defFuncNode('F', [funcNode('待つ'), callG])
+
+      let count = 0
+      while (checkAsyncFn(blockNode([def]), funclist)) {
+        count++
+        assert.ok(count < 10, '不動点に収束しない')
+      }
+      assert.strictEqual(def.asyncFn, true)
+      assert.strictEqual(callG.asyncFn, true, '1文目より後ろの呼び出しも訪問される')
+    })
+
+    it('非同期な無名関数を保持する変数の呼び出しも非同期になる', () => {
+      // F=●()...ここまで のように変数へ代入された無名関数は funclist に載らないため、
+      // 代入を追跡しないと呼び出し側に asyncFn が付かない
+      const funclist = new Map([['待つ', { type: 'func', asyncFn: true }]])
+      const anon = funcObjNode([funcNode('待つ')])
+      const callF = funcNode('F')
+      const ast = blockNode([letNode('F', anon), callF])
+
+      let count = 0
+      while (checkAsyncFn(ast, funclist)) {
+        count++
+        assert.ok(count < 10, '不動点に収束しない')
+      }
+      assert.strictEqual(anon.asyncFn, true)
+      assert.strictEqual(callF.asyncFn, true, '変数経由の呼び出しにも asyncFn が付く')
+    })
+
+    it('同期な無名関数を保持する変数は非同期にならない', () => {
+      const anon = funcObjNode([funcNode('表示')])
+      const callF = funcNode('F')
+      const ast = blockNode([letNode('F', anon), callF])
+      assert.strictEqual(checkAsyncFn(ast, new Map()), false)
+      assert.strictEqual(callF.asyncFn, false)
+    })
+
+    it('無名関数の変数はその関数スコープの外へ漏れない', () => {
+      // 関数 F の中のローカル変数 X と、外側の変数 X は別物として扱う
+      const funclist = new Map([['待つ', { type: 'func', asyncFn: true }]])
+      const innerAnon = funcObjNode([funcNode('待つ')])
+      const defF = defFuncNode('F', [letNode('X', innerAnon)])
+      const outerCallX = funcNode('X')
+      const ast = blockNode([defF, outerCallX])
+
+      let count = 0
+      while (checkAsyncFn(ast, funclist)) {
+        count++
+        assert.ok(count < 10, '不動点に収束しない')
+      }
+      assert.strictEqual(innerAnon.asyncFn, true)
+      assert.strictEqual(outerCallX.asyncFn, false, '関数の外の X は非同期にならない')
     })
   })
 
@@ -119,10 +220,89 @@ Bを表示。
     「B関数内：」&bを表示。
     bを戻す。
 ここまで。`
-      const result = await new NakoCompiler().runAsync(code, 'main.nako3')
-      // runAsyncは生成コードの非同期IIFEを開始した時点で戻るため、完了まで1tick待つ
-      await new Promise((resolve) => setTimeout(resolve, 10))
-      assert.strictEqual(result.log, 'A関数内：70\n70\nB関数内：70\n70')
+      assert.strictEqual(await runAndGetLog(code), 'A関数内：70\n70\nB関数内：70\n70')
+    })
+  })
+
+  describe('無名関数(関数オブジェクト)の非同期判定', () => {
+    it('連文を含む無名関数の呼び出しがawaitされる', async () => {
+      const code = `F=●()
+    b=1に2を足して3を掛ける。
+    bを戻す。
+ここまで。
+F()を表示。`
+      assert.strictEqual(await runAndGetLog(code), '9')
+    })
+
+    it('「変数」で宣言した無名関数の呼び出しもawaitされる', async () => {
+      const code = `変数 F=●()
+    b=1に2を足して3を掛ける。
+    bを戻す。
+ここまで。
+F()を表示。`
+      assert.strictEqual(await runAndGetLog(code), '9')
+    })
+
+    it('非同期のユーザー関数を呼ぶ無名関数もawaitされる', async () => {
+      const code = `●B
+    b=1に2を足して3を掛ける。
+    bを戻す。
+ここまで。
+F=●()
+    Bを戻す。
+ここまで。
+F()を表示。`
+      assert.strictEqual(await runAndGetLog(code), '9')
+    })
+
+    it('関数の中で定義した無名関数の呼び出しもawaitされる', async () => {
+      const code = `Aを実行。
+●A
+    F=●()
+        b=1に2を足して3を掛ける。
+        bを戻す。
+    ここまで。
+    F()を表示。
+ここまで。`
+      assert.strictEqual(await runAndGetLog(code), '9')
+    })
+
+    it('非同期の文より後ろで定義した無名関数の呼び出しもawaitされる', async () => {
+      // 関数本体の走査が1文目で打ち切られていると F() に asyncFn が付かない
+      const code = `Aを実行。
+●A
+    a=30に5を足して2を掛ける。
+    aを表示。
+    F=●()
+        b=1に2を足して3を掛ける。
+        bを戻す。
+    ここまで。
+    F()を表示。
+ここまで。`
+      assert.strictEqual(await runAndGetLog(code), '70\n9')
+    })
+
+    it('引数が2つとも非同期の無名関数でもすべてawaitされる', async () => {
+      // 引数の走査が1つ目で打ち切られていると G() に asyncFn が付かない
+      const code = `F=●()
+    b=1に2を足して3を掛ける。
+    bを戻す。
+ここまで。
+G=●()
+    c=2に2を足して2を掛ける。
+    cを戻す。
+ここまで。
+F()とG()を足して表示。`
+      assert.strictEqual(await runAndGetLog(code), '17')
+    })
+
+    it('非同期処理を含まない無名関数はawaitされない', async () => {
+      const code = `F=●()
+    b=1に2を足す。
+    bを戻す。
+ここまで。
+F()を表示。`
+      assert.strictEqual(await runAndGetLog(code), '3')
     })
   })
 })

--- a/core/test/nako_parser_async_test.mjs
+++ b/core/test/nako_parser_async_test.mjs
@@ -69,18 +69,11 @@ describe('nako_parser_async_test', () => {
       assert.strictEqual(def.asyncFn, true)
     })
 
-    it('[現状の挙動] block の走査は最初の非同期ノードで打ち切られる', () => {
-      // ブロックの走査は子が非同期だと分かった時点で return するため、
-      // それより後ろの兄弟はそのパスでは訪問されない。
-      // したがって G は、この走査だけでは非同期と判定されない。
-      //
-      // 実際のパーサでは yDefFuncCommon が解析中に usedAsyncFn を追跡して
-      // 関数定義に asyncFn を付けるので、この走査に頼らなくても G は非同期になる
-      // (下の「NakoParser 経由での結合確認」を参照)。
-      // 分離前からの挙動なので、そのまま固定しておく。
+    it('block 内の複数の非同期関数をすべて走査する', () => {
       const funclist = new Map([
         ['待つ', { type: 'func', asyncFn: true }],
-        ['F', { type: 'func', asyncFn: true }]
+        ['F', { type: 'func', asyncFn: false }],
+        ['G', { type: 'func', asyncFn: false }]
       ])
       const defF = defFuncNode('F', [funcNode('待つ')])
       const defG = defFuncNode('G', [funcNode('F')])
@@ -92,7 +85,9 @@ describe('nako_parser_async_test', () => {
         assert.ok(count < 10, '不動点に収束しない')
       }
       assert.strictEqual(defF.asyncFn, true)
-      assert.strictEqual(defG.asyncFn, false, 'F の後ろにある G は訪問されない')
+      assert.strictEqual(defG.asyncFn, true, 'F の後ろにある G も訪問される')
+      assert.strictEqual(funclist.get('F').asyncFn, true)
+      assert.strictEqual(funclist.get('G').asyncFn, true)
     })
   })
 
@@ -107,6 +102,27 @@ describe('nako_parser_async_test', () => {
       const ast = new NakoCompiler().parse('●Fとは\n1を表示\nここまで\nF\n', 'main.nako3')
       const def = ast.blocks.find((n) => n.type === 'def_func')
       assert.strictEqual(def.asyncFn, false)
+    })
+
+    it('連文を代入する関数が複数続いてもすべてawaitされる (#2170)', async () => {
+      const code = `Aを表示。
+Bを表示。
+
+●A
+    a=30に5を足して2を掛ける。
+    「A関数内：」&aを表示。
+    aを戻す。
+ここまで。
+
+●B
+    b=30に5を足して2を掛ける。
+    「B関数内：」&bを表示。
+    bを戻す。
+ここまで。`
+      const result = await new NakoCompiler().runAsync(code, 'main.nako3')
+      // runAsyncは生成コードの非同期IIFEを開始した時点で戻るため、完了まで1tick待つ
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      assert.strictEqual(result.log, 'A関数内：70\n70\nB関数内：70\n70')
     })
   })
 })


### PR DESCRIPTION
## 概要

連文を代入する関数が複数続いたとき、後続関数の戻り値が `[object Promise]` になる問題を修正します。

Closes #2170

## 原因

非同期判定のAST走査が、最初の非同期ノードを見つけた時点で兄弟ノードの走査を打ち切っていました。また、後から判明した関数の非同期情報が、呼び出し側の判定に使う関数一覧へ反映されていませんでした。

## 変更内容

- block内の兄弟ノードを最後まで走査するように変更
- 後から判明した `asyncFn` を関数一覧へ同期
- 複数の非同期関数と前方参照への伝播を単体テストで確認
- Issue #2170のプログラムを回帰テストとして追加

## 確認

- `npm run build:tsc`
- `node --test core/test/nako_parser_async_test.mjs`
- `npm run test:core`（858件成功）
- `npm test`（全1,034件成功）
- `npm run eslint`
- `git diff --check`