### PR TITLE
非同期関数終了時のローカル変数復元を修正 #1758

### DIFF
--- a/core/src/nako_gen.mts
+++ b/core/src/nako_gen.mts
@@ -380,6 +380,23 @@ export class NakoGen {
     code += 'const __v0 = __self.__v0 = __self.__varslist[0];\n'
     code += 'const __v1 = __self.__v1 = __self.__varslist[1];\n'
     code += 'const __vars = __self.__vars = __self.__varslist[2];\n'
+    code += 'const __nako_scope_parents = new WeakMap();\n' +
+      'const __nako_active_scopes = new WeakSet();\n' +
+      'const __nako_scope_enter = () => {\n' +
+      '  const local = new Map();\n' +
+      '  __nako_scope_parents.set(local, __self.__vars);\n' +
+      '  __nako_active_scopes.add(local);\n' +
+      '  __self.__vars = local;\n' +
+      '  return local;\n' +
+      '};\n' +
+      'const __nako_scope_leave = (local) => {\n' +
+      '  __nako_active_scopes.delete(local);\n' +
+      '  let parent = __nako_scope_parents.get(local) || __vars;\n' +
+      '  while (parent !== __vars && !__nako_active_scopes.has(parent)) {\n' +
+      '    parent = __nako_scope_parents.get(parent) || __vars;\n' +
+      '  }\n' +
+      '  __self.__vars = parent;\n' +
+      '};\n'
     code += 'const __nako_make_closure = (local, parent) => ({\n' +
       '  has: (key) => local.has(key) || (parent !== null && parent.has(key)),\n' +
       '  get: (key) => local.has(key) ? local.get(key) : (parent !== null ? parent.get(key) : undefined),\n' +
@@ -941,16 +958,16 @@ export class NakoGen {
     }
 
     // ローカル変数を生成 (再帰関数呼び出しで引数の値が壊れる問題があるので修正 #1663 / タイミングによって壊れるので修理 #1758)
-    // 暫定変数__localVarsに現在のローカル変数の値をPUSHし、変数を抜ける時にPOPする)
+    // 呼び出しごとのローカル変数を登録し、関数を抜ける時に有効な呼び出し元へ戻す。
+    // 非同期関数が開始順と異なる順番で終了しても、終了済みのスコープは復元しない。
     // 関数として宣言しているが、JS関数となでしこ関数では変数管理の方法が異なるため、完全なローカル変数としては使えない
     // 必ず、pushStack/popStack する必要がある
     pushStack += '\n// PUSH STACK\n'
-    pushStack += 'const __localvars = __self.__vars;\n'
-    pushStack += '__self.__vars = new Map();\n'
+    pushStack += 'const __localvars = __nako_scope_enter();\n'
     pushStack += 'try {\n'
     popStack += '} finally {\n'
     popStack += indent + '// POP STACK\n'
-    popStack += indent + 'self.__vars = __localvars;\n'
+    popStack += indent + '__nako_scope_leave(__localvars);\n'
     popStack += '}\n'
 
     // 宣言済みの名前を保存

--- a/core/src/nako_parser_async.mts
+++ b/core/src/nako_parser_async.mts
@@ -17,13 +17,16 @@ import { FuncList } from './nako_types.mjs'
 interface CheckContext {
   modified: boolean
   /**
-   * 非同期の無名関数を保持している変数名
+   * 無名関数を保持している変数名 → その無名関数が非同期かどうか
    *
    * `F=●()...ここまで` のように変数へ代入された無名関数は funclist に載らないため、
    * 代入を覚えておかないと `F()` の呼び出しに asyncFn を付けられない。
    * 変数のシャドーイングを考慮して、関数定義ごとにスコープを積む。
+   *
+   * 同期な無名関数の代入も記録する。記録しないと、内側のスコープで同名の変数へ
+   * 同期な無名関数を代入しても外側の非同期な代入が見えてしまう。
    */
-  asyncVarScopes: Set<string>[]
+  funcObjVarScopes: Map<string, boolean>[]
 }
 
 /**
@@ -34,30 +37,37 @@ interface CheckContext {
  * @returns AST を書き換えたら true。呼び出し側は false になるまで繰り返すこと
  */
 export function checkAsyncFn (node: Ast, funclist: FuncList): boolean {
-  const ctx: CheckContext = { modified: false, asyncVarScopes: [new Set()] }
+  const ctx: CheckContext = { modified: false, funcObjVarScopes: [new Map()] }
   checkNode(node, funclist, ctx)
   return ctx.modified
 }
 
-/** 変数名が非同期の無名関数を指しているかどうかを、内側のスコープから順に調べる */
+/**
+ * 変数名が非同期の無名関数を指しているかどうかを、内側のスコープから順に調べる。
+ * 見つかった時点で打ち切るので、内側の代入が外側の代入をシャドーイングする。
+ */
 function isAsyncVar (ctx: CheckContext, name: string): boolean {
-  for (let i = ctx.asyncVarScopes.length - 1; i >= 0; i--) {
-    if (ctx.asyncVarScopes[i].has(name)) { return true }
+  for (let i = ctx.funcObjVarScopes.length - 1; i >= 0; i--) {
+    const asyncFn = ctx.funcObjVarScopes[i].get(name)
+    if (asyncFn !== undefined) { return asyncFn }
   }
   return false
 }
 
 /**
- * 変数への代入が非同期の無名関数なら、現在のスコープに覚えておく
+ * 変数へ無名関数を代入していたら、現在のスコープに覚えておく
  * (`let` と `def_local_var` はどちらも blocks[0] が代入する値)
+ *
+ * 無名関数以外の代入は記録しない。`F=Gの参照` のような代入まで同期扱いにすると、
+ * 逆に await の付け漏れという、より悪い誤りになるため。
  */
-function checkAsyncVarAssign (node: Ast, ctx: CheckContext): void {
+function checkFuncObjVarAssign (node: Ast, ctx: CheckContext): void {
   const letNode = node as AstLet
   if (!letNode.name) { return }
   const value = (letNode.blocks || [])[0]
   if (!value || value.type !== 'func_obj') { return }
-  if (!(value as AstDefFunc).asyncFn) { return }
-  ctx.asyncVarScopes[ctx.asyncVarScopes.length - 1].add(letNode.name)
+  const scope = ctx.funcObjVarScopes[ctx.funcObjVarScopes.length - 1]
+  scope.set(letNode.name, !!(value as AstDefFunc).asyncFn)
 }
 
 /**
@@ -71,12 +81,12 @@ function checkNode (node: Ast, funclist: FuncList, ctx: CheckContext): boolean {
     const def: AstDefFunc = node as AstDefFunc
     // 既に非同期と分かっていても中身の走査は省略しない。
     // 途中で打ち切ると、それより後ろにある呼び出しに asyncFn が付かなくなる
-    ctx.asyncVarScopes.push(new Set())
+    ctx.funcObjVarScopes.push(new Map())
     let isAsyncFn = false
     for (const n of def.blocks) {
       if (checkNode(n, funclist, ctx)) { isAsyncFn = true }
     }
-    ctx.asyncVarScopes.pop()
+    ctx.funcObjVarScopes.pop()
     // 関数定義の中身が非同期であるならasyncFnをtrueに変更する
     if (isAsyncFn && !def.asyncFn) {
       def.asyncFn = true
@@ -98,7 +108,7 @@ function checkNode (node: Ast, funclist: FuncList, ctx: CheckContext): boolean {
     for (const n of (node as AstBlocks).blocks) {
       if (checkNode(n, funclist, ctx)) { containsAsync = true }
     }
-    checkAsyncVarAssign(node, ctx)
+    checkFuncObjVarAssign(node, ctx)
     return containsAsync
   }
   // 関数呼び出しを調べて非同期処理が必要ならtrueを返す

--- a/core/test/func_call.mjs
+++ b/core/test/func_call.mjs
@@ -221,6 +221,24 @@ TIDのタイマー停止
 　test2`
     await cmp(code, '1\n2')
   })
+  it('並行した非同期関数の終了後にローカル変数領域を残さない #1758', async () => {
+    const nako = new NakoCompiler()
+    const code = `
+●test1():
+　xとは変数= 1
+　0.05秒待つ
+●test2():
+　xとは変数= 2
+　0.05秒待つ
+
+0.01秒後には:
+　test1
+0.03秒後には:
+　test2`
+    const g = await nako.runAsync(code, 'main.nako3')
+    await forceWait(120)
+    assert.strictEqual(g.__vars, g.__varslist[2])
+  })
   it('後方で宣言した関数がasyncFnだったときその関数が正しく実行できない(2) #1758', async () => {
     const code = `
 0.1秒後には:

--- a/core/test/func_call.mjs
+++ b/core/test/func_call.mjs
@@ -236,7 +236,7 @@ TIDのタイマー停止
 0.03秒後には:
 　test2`
     const g = await nako.runAsync(code, 'main.nako3')
-    await forceWait(120)
+    await forceWait(200)
     assert.strictEqual(g.__vars, g.__varslist[2])
   })
   it('後方で宣言した関数がasyncFnだったときその関数が正しく実行できない(2) #1758', async () => {

--- a/core/test/nako_parser_async_test.mjs
+++ b/core/test/nako_parser_async_test.mjs
@@ -190,6 +190,63 @@ describe('nako_parser_async_test', () => {
       assert.strictEqual(innerAnon.asyncFn, true)
       assert.strictEqual(outerCallX.asyncFn, false, '関数の外の X は非同期にならない')
     })
+
+    it('内側で同名の同期な無名関数を代入すると外側の非同期をシャドーイングする', () => {
+      // 外側の X は非同期だが、内側の関数で同名の同期な無名関数を代入しているので、
+      // 内側の X() は非同期にならない
+      const funclist = new Map([['待つ', { type: 'func', asyncFn: true }]])
+      const outerAnon = funcObjNode([funcNode('待つ')])
+      const innerAnon = funcObjNode([funcNode('表示')])
+      const innerCallX = funcNode('X')
+      const defG = defFuncNode('G', [letNode('X', innerAnon), innerCallX])
+      const ast = blockNode([letNode('X', outerAnon), defG])
+
+      let count = 0
+      while (checkAsyncFn(ast, funclist)) {
+        count++
+        assert.ok(count < 10, '不動点に収束しない')
+      }
+      assert.strictEqual(outerAnon.asyncFn, true)
+      assert.strictEqual(innerAnon.asyncFn, false)
+      assert.strictEqual(innerCallX.asyncFn, false, '内側の同期な X が優先される')
+      assert.strictEqual(defG.asyncFn, false, 'G も非同期にならない')
+    })
+
+    it('内側で同名の変数を使っていなければ外側の非同期が見える', () => {
+      // 上のシャドーイングと対になる確認。内側に代入が無ければ外側の X を参照する
+      const funclist = new Map([['待つ', { type: 'func', asyncFn: true }]])
+      const outerAnon = funcObjNode([funcNode('待つ')])
+      const innerCallX = funcNode('X')
+      const defG = defFuncNode('G', [innerCallX])
+      const ast = blockNode([letNode('X', outerAnon), defG])
+
+      let count = 0
+      while (checkAsyncFn(ast, funclist)) {
+        count++
+        assert.ok(count < 10, '不動点に収束しない')
+      }
+      assert.strictEqual(innerCallX.asyncFn, true, '外側の非同期な X が見える')
+    })
+
+    it('同じスコープで同期な無名関数へ代入し直すと非同期でなくなる', () => {
+      const funclist = new Map([['待つ', { type: 'func', asyncFn: true }]])
+      const callBefore = funcNode('X')
+      const callAfter = funcNode('X')
+      const ast = blockNode([
+        letNode('X', funcObjNode([funcNode('待つ')])),
+        callBefore,
+        letNode('X', funcObjNode([funcNode('表示')])),
+        callAfter
+      ])
+
+      let count = 0
+      while (checkAsyncFn(ast, funclist)) {
+        count++
+        assert.ok(count < 10, '不動点に収束しない')
+      }
+      assert.strictEqual(callBefore.asyncFn, true, '代入し直す前は非同期')
+      assert.strictEqual(callAfter.asyncFn, false, '代入し直した後は同期')
+    })
   })
 
   describe('NakoParser 経由での結合確認', () => {
@@ -294,6 +351,28 @@ G=●()
 ここまで。
 F()とG()を足して表示。`
       assert.strictEqual(await runAndGetLog(code), '17')
+    })
+
+    it('内側で同名の同期な無名関数を代入しても実行結果が変わらない', async () => {
+      // 外側の F は非同期、内側の F は同期。取り違えると値が壊れる
+      const code = `●A
+    Fとは変数
+    F=●()
+        b=1に2を足して3を掛ける。
+        bを戻す。
+    ここまで。
+    G=●()
+        Fとは変数
+        F=●()
+            5を戻す。
+        ここまで。
+        F()を戻す。
+    ここまで。
+    G()を表示。
+    F()を表示。
+ここまで。
+Aを実行。`
+      assert.strictEqual(await runAndGetLog(code), '5\n9')
     })
 
     it('非同期処理を含まない無名関数はawaitされない', async () => {


### PR DESCRIPTION
## 概要

非同期関数が並行して実行され、開始順と異なる順番で終了した場合でも、終了済みのローカル変数領域を復元しないように修正します。

Fixes #1758

## 原因

従来は関数開始時の `__self.__vars` を保存し、終了時に無条件で復元していました。そのため、並行していた呼び出し元が先に終了すると、後から終了した関数がすでに無効なローカル変数 `Map` を復元し、実行環境に残していました。

## 変更内容

- ローカルスコープの親子関係を `WeakMap` で管理
- 実行中のスコープを `WeakSet` で管理
- 関数終了時に終了済みスコープを飛ばし、現在も有効な呼び出し元またはグローバル領域へ復元
- 並行した非同期関数の終了後にローカル変数領域が残らない回帰テストを追加

## 影響

非同期処理が重なった場合でも、ローカル変数が別の終了済み関数の領域へ切り替わらず、後続処理で安定して正しい変数領域を参照できます。同期関数、再帰関数、無名関数の既存動作は維持されます。

## 確認

- `npm run build:tsc`
- `node --test core/test/func_call.mjs`（37件成功）
- `npm run eslint`
- `npm run test:core`（885件成功）
- `npm run test:node`（119件成功）
- `npm run test:common`（30件成功）
- `npm run test:nako3server`（12件成功）
- `npm run test:nako3edit`（15件成功）