### PR TITLE
runAsyncで非同期処理の完了を待つ

### DIFF
--- a/core/src/nako_gen.mts
+++ b/core/src/nako_gen.mts
@@ -2436,6 +2436,7 @@ ${syncMain}(__self)
   }
   // ---
   const initCode = gen.getPluginInitCode()
+  // runtimeEnvはnew Functionの関数本体として実行するコードで、非同期時はトップレベルのreturnを含む。
   const runtimeEnvCode = `
 // <runtimeEnvCode>
 const self = this

--- a/core/src/nako_gen.mts
+++ b/core/src/nako_gen.mts
@@ -2344,6 +2344,7 @@ export function generateJS(com: NakoCompiler, ast: Ast, opt: NakoGenOptions): Na
 
   // ランダムな関数名を生成
   const funcID = String((new Date()).getTime()) + '_' + Math.floor(0xFFFFFFFF * Math.random()).toString()
+  let runtimeResult = ''
   // テストの実行
   if (js && opt.isTest) {
     js += '\n__self._runTests(__tests);\n'
@@ -2351,6 +2352,8 @@ export function generateJS(com: NakoCompiler, ast: Ast, opt: NakoGenOptions): Na
   // async method
   if (gen.numAsyncFn > 0 || gen.debugOption.useDebug) {
     const asyncMain = '__eval_nako3async_' + funcID + '__'
+    const asyncMainPromise = '__eval_nako3async_promise_' + funcID + '__'
+    runtimeResult = `return ${asyncMainPromise}`
     js = `
 // ------------------------------------------------------------------
 // <nadesiko3::gen::async id="${funcID}" times="${gen.numAsyncFn}">
@@ -2363,12 +2366,11 @@ async function ${asyncMain}(__self) {
 } // end of ${asyncMain}
 // ------------------------------------------------------------------
 // call ${asyncMain}
-(async () => {
+const ${asyncMainPromise} = (async () => {
   if (__self.__v0.get('__standalone')) {
     await ${asyncMain}(self);
   } else {
-    ${asyncMain}.call(self, self)
-    .then(() => { /* __async_ok__ */ })
+    await ${asyncMain}.call(self, self)
     .catch(err => {
       if (err.message === '__終わる__') { return }
       __self.numFailures++
@@ -2441,6 +2443,7 @@ ${opt.codeEnv}
 ${jsInit}
 ${initCode}
 ${js}
+${runtimeResult}
 // </runtimeEnvCode>
 `
   com.getLogger().trace('--- generate::jsInit ---\n' + jsInit)

--- a/core/src/nako_runner.mts
+++ b/core/src/nako_runner.mts
@@ -69,12 +69,12 @@ export class NakoRunner {
    * @param code JavaScriptのコード
    * @param nakoGlobal 実行環境
    */
-  evalJS (code: string, nakoGlobal: NakoGlobal): unknown {
+  evalJS (code: string, nakoGlobal: NakoGlobal): Promise<void>|void {
     this.currentGlobal = nakoGlobal // 現在のnakoGlobalを記録
     this.currentGlobal.lastJSCode = code
     // 実行前に環境を初期化するイベントを実行(beforeRun)
     this.host.fireEvent('beforeRun', nakoGlobal)
-    let result: unknown
+    let result: Promise<void>|void
     try {
       const f = new Function(nakoGlobal.lastJSCode)
       result = f.apply(nakoGlobal)
@@ -95,6 +95,7 @@ export class NakoRunner {
    * @param filename ファイル名
    * @param options オプション
    * @returns 実行に利用したグローバルオブジェクト
+   * @remarks 非同期プログラムでは完了を待たず、従来通り実行中のPromiseを破棄する。
    * @deprecated 代わりにrunAsyncメソッドを使ってください。(core #52)
    */
   runSync (code: string, filename: string, options: CompilerOptions|undefined = undefined): NakoGlobal {

--- a/core/src/nako_runner.mts
+++ b/core/src/nako_runner.mts
@@ -69,14 +69,15 @@ export class NakoRunner {
    * @param code JavaScriptのコード
    * @param nakoGlobal 実行環境
    */
-  evalJS (code: string, nakoGlobal: NakoGlobal): void {
+  evalJS (code: string, nakoGlobal: NakoGlobal): unknown {
     this.currentGlobal = nakoGlobal // 現在のnakoGlobalを記録
     this.currentGlobal.lastJSCode = code
     // 実行前に環境を初期化するイベントを実行(beforeRun)
     this.host.fireEvent('beforeRun', nakoGlobal)
+    let result: unknown
     try {
       const f = new Function(nakoGlobal.lastJSCode)
-      f.apply(nakoGlobal)
+      result = f.apply(nakoGlobal)
     } catch (err: any) {
       // なでしこコードのエラーは抑止してログにのみ記録
       nakoGlobal.numFailures++
@@ -85,6 +86,7 @@ export class NakoRunner {
     }
     // 実行後に終了イベントを実行(finish)
     this.host.fireEvent('finish', nakoGlobal)
+    return result
   }
 
   /**
@@ -120,7 +122,7 @@ export class NakoRunner {
     // 実行前に環境を生成
     const nakoGlobal = this.getNakoGlobal(options, compiledCode.gen, filename)
     // 実行
-    this.evalJS(compiledCode.runtimeEnv, nakoGlobal)
+    await this.evalJS(compiledCode.runtimeEnv, nakoGlobal)
     return nakoGlobal
   }
 

--- a/core/test/nako_parser_async_test.mjs
+++ b/core/test/nako_parser_async_test.mjs
@@ -38,12 +38,10 @@ function letNode (name, value) {
 /**
  * なでしこのプログラムを実行してログを得る
  *
- * runAsync は生成コードの非同期IIFEを開始した時点で戻るため、
- * 実行完了までイベントループを進める必要がある (課題は #2381 を参照)
+ * runAsync は生成コードの実行完了を待ってから戻る。
  */
 async function runAndGetLog (code) {
   const g = await new NakoCompiler().runAsync(code, 'main.nako3')
-  await new Promise((resolve) => setTimeout(resolve, 10))
   return g.log
 }
 

--- a/core/test/nako_runner_test.mjs
+++ b/core/test/nako_runner_test.mjs
@@ -44,6 +44,12 @@ describe('nako_runner_test', () => {
     assert.strictEqual(g.log, '完了')
   })
 
+  it('非同期処理中のエラーがrunAsync完了時に反映される (#2381)', async () => {
+    const nako = new NakoCompiler()
+    const g = await nako.runAsync('0.01秒待つ\n「ぐぬ」のエラー発生', 'main.nako3')
+    assert.strictEqual(g.numFailures, 1)
+  })
+
   it('__globalObjは代入もできる(後方互換)', () => {
     const nako = new NakoCompiler()
     assert.strictEqual(nako.__globalObj, null)

--- a/core/test/nako_runner_test.mjs
+++ b/core/test/nako_runner_test.mjs
@@ -38,6 +38,12 @@ describe('nako_runner_test', () => {
     assert.strictEqual(nako.__globals[0], g)
   })
 
+  it('runAsyncは非同期プログラムの実行完了を待つ (#2381)', async () => {
+    const nako = new NakoCompiler()
+    const g = await nako.runAsync('0.02秒待つ\n「完了」を表示', 'main.nako3')
+    assert.strictEqual(g.log, '完了')
+  })
+
   it('__globalObjは代入もできる(後方互換)', () => {
     const nako = new NakoCompiler()
     assert.strictEqual(nako.__globalObj, null)

--- a/core/test/plugin_system_debug_test.mjs
+++ b/core/test/plugin_system_debug_test.mjs
@@ -61,15 +61,12 @@ describe('plugin_system_debug_test', async () => {
     const nako = new NakoCompiler()
     const code = 'F=「a=>a*2」をJS実行\nFを[21]でAWAIT実行して表示'
     const g = await nako.runAsync(code, 'main.nako3')
-    // AWAIT実行はPromiseをawaitするため、実行完了までイベントループを1tick進める
-    await new Promise((resolve) => setTimeout(resolve, 10))
     assert.strictEqual(g.log, '42')
   })
   it('特殊命令 - AWAIT実行（配列以外の引数）', async () => {
     const nako = new NakoCompiler()
     const code = 'F=「a=>a*2」をJS実行\nFを21でAWAIT実行して表示'
     const g = await nako.runAsync(code, 'main.nako3')
-    await new Promise((resolve) => setTimeout(resolve, 10))
     assert.strictEqual(g.log, '42')
   })
   it('特殊命令 - ナデシコ', async () => {


### PR DESCRIPTION
## 概要

`NakoRunner.runAsync` が、生成された非同期ななでしこプログラムの実行完了を待ってから戻るように修正します。

Fixes #2381

## 原因

生成された非同期メイン処理の Promise を `new Function` の呼び出し元へ返しておらず、`runAsync` は非同期IIFEを開始した直後に戻っていました。そのため、テスト側で任意時間の `setTimeout` 待機が必要になっていました。

## 変更内容

- 生成コードから非同期メイン処理の Promise を返す
- `NakoRunner.runAsync` で返された Promise を待つ
- 20ms待機後の出力を、追加待機なしで確認する回帰テストを追加
- 非同期処理中のエラーが完了時に `numFailures` へ反映される回帰テストを追加
- 既存テストの `setTimeout(10)` を削除
- `runtimeEnv` の実行条件と、`runSync` が非同期処理を待たない従来仕様をコメントで明記

## 影響

非同期命令を含むプログラムでは、`await runAsync(...)` の完了時点でプログラムの実行結果と `numFailures` を安全に参照できます。これにより、`cnako3` の非同期プログラムでも、実行完了後の失敗数に基づく終了コード判定が正しく機能します。

同期プログラムおよび非推奨の `runSync` の挙動は維持します。

## 確認

- `npm run build:tsc`
- `npm run eslint`
- `npm test`（全1,062件成功）
