### PR TITLE
式の中の『戻す』を文法エラーにし、未初期化プラグインのクリアを防ぐ #2064

### DIFF
--- a/core/src/nako_gen.mts
+++ b/core/src/nako_gen.mts
@@ -1781,7 +1781,8 @@ export class NakoGen {
         { isExpr: true, isAsync, startVar: 'sf_start', timeVar: 'sl_time' })
     }
     // ...して
-    if (node.josi === 'して' || (node.josi === '' && !isExpression)) {
+    // (メモ) 式の中では文末の『;』を付けてはいけない。付けると不正なJSになる (#2064)
+    if (!isExpression && (node.josi === 'して' || node.josi === '')) {
       code = this.convLineno(node, false) + code
       code += ';\n'
     }

--- a/core/src/nako_global.mts
+++ b/core/src/nako_global.mts
@@ -144,6 +144,19 @@ export class NakoGlobal {
   }
 
   /**
+   * プラグインの初期化が完了しているかどうかを調べる (#2064)
+   * @param pname プラグイン名
+   * @param po プラグイン・オブジェクト
+   */
+  private isPluginInitialized(pname: string, po: {[key: string]: any}): boolean {
+    const initKey = `!${pname}:初期化`
+    // 初期化関数を持たないプラグインは、常に初期化済みとみなす
+    if (!po[initKey]) { return true }
+    // 初期化関数は生成されたJavaScriptの中で実行され、完了すると「初期化済」が設定される
+    return this.__varslist[0].has(`${initKey}済`)
+  }
+
+  /**
    * 毎プラグインの「!クリア」関数を実行
    */
   clearPlugins() {
@@ -152,6 +165,11 @@ export class NakoGlobal {
     const clearName = '!クリア'
     for (const pname in this.pluginfiles) {
       const po = this.__module[pname]
+      if (!po) { continue }
+      // 初期化されていないプラグインのクリア関数は呼ばない (#2064)
+      // (メモ) プラグインの初期化は生成されたJavaScriptの中で行われるため、
+      // コンパイルや実行に失敗すると初期化されないまま実行環境が残ることがある。
+      if (!this.isPluginInitialized(pname, po)) { continue }
       if (po[clearName] && po[clearName].fn) {
         try {
           po[clearName].fn(this)

--- a/core/src/nako_parser3.mts
+++ b/core/src/nako_parser3.mts
@@ -2167,6 +2167,10 @@ export class NakoParser extends NakoParserBase {
     let fCalc:Ast = t1
     // それが連文か助詞を読んで確認
     if (RenbunJosi.indexOf(t1.josi || '') >= 0) {
+      // 『(式)して戻す』のように、式の途中に『戻る』文は書けない (#2064)
+      if (this.check('戻る')) {
+        throw NakoSyntaxError.fromNode('式の中で『戻る』文は使えません。『(値)を(変数)に代入』などで一度値を受け取ってから『戻る』と書いてください。', map)
+      }
       // 連文なら右側を読んで左側とくっつける
       const t2 = this.yCalc()
       if (t2) {

--- a/core/src/nako_parser3.mts
+++ b/core/src/nako_parser3.mts
@@ -2167,9 +2167,9 @@ export class NakoParser extends NakoParserBase {
     let fCalc:Ast = t1
     // それが連文か助詞を読んで確認
     if (RenbunJosi.indexOf(t1.josi || '') >= 0) {
-      // 『(式)して戻す』のように、式の途中に『戻る』文は書けない (#2064)
+      // 『(式)して戻す』のように、式の途中に『戻す』文は書けない (#2064)
       if (this.check('戻る')) {
-        throw NakoSyntaxError.fromNode('式の中で『戻る』文は使えません。『(値)を(変数)に代入』などで一度値を受け取ってから『戻る』と書いてください。', map)
+        throw NakoSyntaxError.fromNode('式の中で『戻す(戻る)』文は使えません。『(値)を(変数)に代入』などで一度値を受け取ってから『(変数)を戻す』と書いてください。', map)
       }
       // 連文なら右側を読んで左側とくっつける
       const t2 = this.yCalc()

--- a/core/test/func_test.mjs
+++ b/core/test/func_test.mjs
@@ -2,6 +2,7 @@
 import { describe, it } from 'node:test'
 import assert from 'assert'
 import { NakoCompiler } from '../src/nako3.mjs'
+import { NakoSyntaxError } from '../src/nako_errors.mjs'
 
 describe('func_test', async () => {
   // nako.logger.addListener('trace', ({ browserConsole }) => { console.log(...browserConsole) })
@@ -9,6 +10,19 @@ describe('func_test', async () => {
     const nako = new NakoCompiler()
     nako.getLogger().debug('code=' + code)
     assert.strictEqual((await nako.runAsync(code, 'main.nako3')).log, res)
+  }
+  /** 文法エラー(NakoSyntaxError)になることを確認する */
+  const cmpError = async (/** @type {string} */ code) => {
+    const nako = new NakoCompiler()
+    nako.getLogger().debug('code=' + code)
+    await assert.rejects(
+      async () => { await nako.runAsync(code, 'main.nako3') },
+      (err) => {
+        assert(err instanceof NakoSyntaxError, `NakoSyntaxErrorではありません: ${err}`)
+        assert(err.message.includes('式の中で『戻る』文は使えません'), `想定外のエラーです: ${err.message}`)
+        return true
+      }
+    )
   }
   // --- test ---
 
@@ -145,5 +159,17 @@ describe('func_test', async () => {
   it('関数で使える「引数」が使えなくなっている #1741', async () => {
     await cmp('●(AとBを)加算処理とは\n引数[0]と引数[1]を足すこと。。。3と5を加算処理して表示。', '8')
     await cmp('●(AとBをCで)加算処理とは\nそれ=引数[0]+引数[1]+引数[2]。。。3と5を2で加算処理して表示。', '10')
+  })
+  it('代入文の値の中に『戻す』は書けない #2064', async () => {
+    // 『(式)して戻す』を代入文の値に書くと不正なJavaScriptが生成されていた
+    await cmpError('●テストとは\n定数の結果は「あ」を真偽判定して戻す。\nここまで\nテストを表示。')
+    await cmpError('●テストとは\n変数の結果は「あ」を真偽判定して戻す。\nここまで\nテストを表示。')
+    await cmpError('●テストとは\n結果は「あ」を真偽判定して戻す。\nここまで\nテストを表示。')
+  })
+  it('『戻す』の正しい書き方は動く #2064', async () => {
+    await cmp('●テストとは\n「あ」を真偽判定して戻す。\nここまで\nテストを表示。', '真')
+    await cmp('●テストとは\n定数の結果は「あ」を真偽判定。\n結果で戻す。\nここまで\nテストを表示。', '真')
+    // 『戻す』以外の連文は今まで通り動く
+    await cmp('1に2を足して3を掛けて表示。', '9')
   })
 })

--- a/core/test/func_test.mjs
+++ b/core/test/func_test.mjs
@@ -19,7 +19,7 @@ describe('func_test', async () => {
       async () => { await nako.runAsync(code, 'main.nako3') },
       (err) => {
         assert(err instanceof NakoSyntaxError, `NakoSyntaxErrorではありません: ${err}`)
-        assert(err.message.includes('式の中で『戻る』文は使えません'), `想定外のエラーです: ${err.message}`)
+        assert(err.message.includes('式の中で『戻す(戻る)』文は使えません'), `想定外のエラーです: ${err.message}`)
         return true
       }
     )
@@ -165,6 +165,8 @@ describe('func_test', async () => {
     await cmpError('●テストとは\n定数の結果は「あ」を真偽判定して戻す。\nここまで\nテストを表示。')
     await cmpError('●テストとは\n変数の結果は「あ」を真偽判定して戻す。\nここまで\nテストを表示。')
     await cmpError('●テストとは\n結果は「あ」を真偽判定して戻す。\nここまで\nテストを表示。')
+    // 『戻る』の書き方でも同じエラーになる
+    await cmpError('●テストとは\n定数の結果は1に2を足して戻る。\nここまで\nテストを表示。')
   })
   it('『戻す』の正しい書き方は動く #2064', async () => {
     await cmp('●テストとは\n「あ」を真偽判定して戻す。\nここまで\nテストを表示。', '真')

--- a/core/test/nako_runner_test.mjs
+++ b/core/test/nako_runner_test.mjs
@@ -111,4 +111,52 @@ describe('nako_runner_test', () => {
       await nako.runAsync('『存在しない関数』のエラー発生', 'main.nako3')
     })
   })
+
+  it('初期化に失敗したプラグインのクリア関数は呼ばれない #2064', async () => {
+    // プラグインの初期化は生成されたJavaScriptの中で実行されるため、
+    // 実行に失敗すると初期化されないまま実行環境が残ってしまう。
+    // その状態で次の実行を行うと「!クリア」でエラーが出ていた。
+    let failInit = true
+    let clearCount = 0
+    const plugin = {
+      meta: { type: 'const', value: { pluginName: 'plugin_dummy2064', nakoVersion: '3.6.0' } },
+      初期化: {
+        type: 'func',
+        josi: [],
+        pure: true,
+        fn: (sys) => {
+          if (failInit) { throw new Error('初期化に失敗') }
+          sys.__dummyClear2064 = () => { clearCount++ }
+        }
+      },
+      '!クリア': {
+        type: 'func',
+        josi: [],
+        pure: true,
+        // 初期化されていなければ、ここで TypeError になる
+        fn: (sys) => { sys.__dummyClear2064() }
+      }
+    }
+    const errors = []
+    const nako = new NakoCompiler()
+    nako.getLogger().addListener('error', (data) => { errors.push(data.noColor) })
+    nako.addPluginObject('plugin_dummy2064', plugin)
+
+    // 1回目 … 初期化に失敗して実行環境だけが残る
+    await assert.rejects(async () => { await nako.runReset('「NG」を表示', 'main.nako3') })
+
+    // 2回目 … 初期化されていないのでクリア関数は呼ばれない
+    failInit = false
+    const g2 = await nako.runReset('「OK」を表示', 'main.nako3')
+    assert.strictEqual(g2.log, 'OK')
+    assert.strictEqual(clearCount, 0, 'クリア関数が呼ばれないこと')
+    assert.strictEqual(
+      errors.filter((e) => e.includes('クリア関数でエラーが発生しました')).length, 0,
+      'クリア関数のエラーが出ないこと')
+
+    // 3回目 … 2回目で初期化が成功しているのでクリア関数が呼ばれる
+    const g3 = await nako.runReset('「OK2」を表示', 'main.nako3')
+    assert.strictEqual(g3.log, 'OK2')
+    assert.strictEqual(clearCount, 1, '初期化済みならクリア関数が呼ばれること')
+  })
 })


### PR DESCRIPTION
#2064 の修正です。

簡易エディタで報告された3つのエラーを調査したところ、独立した2つのバグが原因でした。

## 1. `…して戻す` が不正なJavaScriptを生成する

```
●テストとは
  定数の結果は「あ」を真偽判定して戻す。
ここまで。
```

このコードから、式の途中に `;` が入った壊れたJSが生成されていました。

```js
/*定数*/__self.__vars.set("結果", (__self.__setSore(...真偽判定...);
));
return __self.__vars.get("それ");
```

Issueの `missing ) in parenthetical` は、これを `new Function()` に渡したときのFirefoxのエラーメッセージです（Node/V8では `Unexpected token ';'`）。つまり、なでしこの文法エラーではなく、コード生成が不正なJSを吐いていました。

原因は次の通りです。

1. `yCalc()` は連文（助詞『して』）の右側を `yCalc()` で読みますが、右側が『戻す』の場合は値として読めないため `renbun` ノードが作られず、『戻る』は次の文として解析される
2. その結果、関数呼び出しのノードが `josi: 'して'` を持ったまま、代入文の値（式）の位置に残る
3. `genValueCallCode()` が `josi === 'して'` のときに `isExpression` を見ずに `;` を付ける

『戻す』『抜ける』『続ける』は値を持たない制御文なので連文にできず、他の『〜して〜』と同じようには扱えません。Issueのコメントにある「『戻す』構文の判定を厳しくします」という方針に沿って、**分かりやすい文法エラー**にしました。

```
[文法エラー]main.nako3(2行目): 式の中で『戻る』文は使えません。
『(値)を(変数)に代入』などで一度値を受け取ってから『戻る』と書いてください。
```

あわせて、他の経路からも不正なJSが出ないよう、コード生成側で式の中では文末の `;` を付けないようにしました。

## 2. 初期化されていないプラグインに『!クリア』が呼ばれる

`plugin_browser` と `plugin_turtle` のエラーはこちらが原因です。

プラグインの『初期化』は生成されたJavaScriptの中で実行されるため（`getPluginInitCode`）、1回目の実行がJSの評価時点で失敗すると、**初期化されないままの実行環境**が `runner.globals` に残ります。2回目の実行時に `clearPlugins()` がその実行環境に対して『!クリア』を呼ぶため、

- `plugin_browser` … 『初期化』で生やす `sys.__removeAllDomEvents()` が無い
- `plugin_turtle` … `sys.tags.turtles` が無い

となって、報告されたエラーになっていました。`NakoGlobal.clearPlugins()` に `!<プラグイン名>:初期化済` の判定を追加し、初期化済みのプラグインだけをクリアするようにしています。プラグイン個別に防御を書くと数だけ漏れが出るため、呼び出し側で塞ぐ方針にしました。

## テスト

- `core/test/func_test.mjs` … `定数の` / `変数の` / 代入の3形式でエラーになること、正しい書き方（`「あ」を真偽判定して戻す`、2文に分ける、通常の連文）が今まで通り動くこと
- `core/test/nako_runner_test.mjs` … 初期化に失敗した実行環境ではクリア関数が呼ばれず、初期化済みなら呼ばれること

`npm run test:core`（892件）、`npm run test:node`（119件）、`npm run test:common`（30件）、`npm run lint` すべて通っています。

## 備考

調査中に見つけた別件として、`Aは1に2を足して表示` が `A` に `undefined` を入れる（連文の右辺の戻り値が代入される）挙動があります。本Issueとは別の話なので、今回は触っていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)