### PR TITLE
簡易HTTPサーバに変数『HTTPメソッド』を追加 #2336

### DIFF
--- a/src/plugin_httpserver.mts
+++ b/src/plugin_httpserver.mts
@@ -48,7 +48,10 @@ class EasyURLDispather {
   doRequest(req: any, res: any) {
     this.curReq = req
     this.curRes = res
-    console.log(`${HTTPSERVER_LOGID} 要求あり URL=` + req.url)
+    // HTTPメソッド(GET/POST/PUT/DELETEなど)を設定
+    const method = String(req.method || '').toUpperCase()
+    this.sys.__setSysVar('HTTPメソッド', method)
+    console.log(`${HTTPSERVER_LOGID} 要求あり METHOD=${method} URL=` + req.url)
     const params = this.parseURL(req.url)
     const url = params['?URL']
     this.sys.__setSysVar('GETデータ', params)
@@ -68,7 +71,7 @@ class EasyURLDispather {
       }
     }
 
-    if (req.method === 'POST') {
+    if (method === 'POST') {
       let bodySize = 0
       const chunks: Buffer[] = []
       req.on('data', (chunk: Buffer) => {
@@ -344,6 +347,7 @@ const PluginHttpServer = {
     }
   },
   // @簡易HTTPサーバ
+  'HTTPメソッド': { type: 'const', value: '' }, // @HTTPめそっど
   'GETデータ': { type: 'const', value: '' }, // @GETでーた
   'POSTデータ': { type: 'const', value: '' }, // @POSTでーた
   'FILESデータ': { type: 'const', value: '' }, // @FILESでーた

--- a/test/node/plugin_httpserver_test.mjs
+++ b/test/node/plugin_httpserver_test.mjs
@@ -236,4 +236,42 @@ describe('plugin_httpserver_test', () => {
       fs.writeFileSync = originalWriteFileSync
     }
   })
+
+  it('HTTPメソッドにGET/POST/PUT/DELETEが設定されること', async () => {
+    let port = 0
+    const code = `
+●ダミー起動
+  戻る。
+ここまで。
+●受信処理
+  「M={HTTPメソッド}」を簡易HTTPサーバ出力。
+ここまで。
+「ダミー起動」を${port}で簡易HTTPサーバ起動時。
+「受信処理」を「/method」に簡易HTTPサーバ受信時。
+`
+    const g = await nako.runAsync(code, 'main')
+    serverDp = g.__httpserver
+    await wait(100)
+    port = serverDp.server.address().port
+
+    const request = (method) => new Promise((resolve, reject) => {
+      const req = http.request({
+        hostname: 'localhost',
+        port: port,
+        path: '/method',
+        method: method
+      }, (res) => {
+        let data = ''
+        res.on('data', (chunk) => { data += chunk })
+        res.on('end', () => { resolve(data) })
+      })
+      req.on('error', reject)
+      req.end()
+    })
+
+    assert.strictEqual(await request('GET'), 'M=GET')
+    assert.strictEqual(await request('POST'), 'M=POST')
+    assert.strictEqual(await request('PUT'), 'M=PUT')
+    assert.strictEqual(await request('DELETE'), 'M=DELETE')
+  })
 })


### PR DESCRIPTION
## 概要

`src/plugin_httpserver.mts`（簡易HTTPサーバ）で、`簡易HTTPサーバ受信時` のコールバック内から
GET / POST / PUT / DELETE などのHTTPメソッドを参照できるよう、システム変数 `HTTPメソッド` を追加しました。

関連: #2336

## 変更内容

- システム変数 `HTTPメソッド` を追加（`// @HTTPめそっど`）
- `EasyURLDispather.doRequest()` の先頭で `req.method` を大文字化して設定。
  `GETデータ` / `POSTデータ` / `FILESデータ` より先に設定されるため、受信時コールバック内でそのまま参照できます。
- ログ出力を `要求あり METHOD=POST URL=/xxx` の形式に変更
- POST判定を新しい `method` 変数に置き換え（挙動は同じ）

## 使い方

```
「/」へ簡易HTTPサーバ受信した時には、
　　「メソッドは{HTTPメソッド}です」と簡易HTTPサーバ出力。
ここまで。
```

## テスト

`test/node/plugin_httpserver_test.mjs` に「HTTPメソッドにGET/POST/PUT/DELETEが設定されること」を追加しました。
`npm run test:node` の該当ファイルで5件すべてパスすることを確認済みです。

あわせて、cnako3で実際にサーバを起動し、GET/POST/DELETEの各リクエストで
`HTTPメソッド` が期待どおりの値になることを確認しました。

## 補足

- POSTボディの解析は従来どおりPOSTのときのみ行っています。PUT/PATCHでもボディを受け取れるようにするかは別途検討でお願いします。
- `doc/command_list.json` は未更新です。`npm run build:command` の前段 `check:command` が、ローカル環境に存在しない外部プラグイン（`nadesiko3-music.js`）の参照で失敗するため、生成し直せませんでした。

🤖 Generated with [Claude Code](https://claude.com/claude-code)