### PR TITLE
1月のとき「先月」が0月になる問題を修正 #2412

### DIFF
--- a/core/src/plugin_system_datetime.mts
+++ b/core/src/plugin_system_datetime.mts
@@ -98,20 +98,22 @@ export default {
       return (new Date()).getMonth() + 1
     }
   },
-  '来月': { // @来月が何月かを返す // @らいげつ
+  '来月': { // @来月が何月かを返す(12月の場合は1を返す) // @らいげつ
     type: 'func',
     josi: [],
     pure: true,
     fn: function() {
-      return (new Date()).getMonth() + 2
+      // 12月の翌月は1月になるように調整する (#2412)
+      return ((new Date()).getMonth() + 1) % 12 + 1
     }
   },
-  '先月': { // @先月が何月かを返す // @せんげつ
+  '先月': { // @先月が何月かを返す(1月の場合は12を返す) // @せんげつ
     type: 'func',
     josi: [],
     pure: true,
     fn: function() {
-      return (new Date()).getMonth()
+      // 1月の前月は12月になるように調整する (#2412)
+      return ((new Date()).getMonth() + 11) % 12 + 1
     }
   },
   '曜日': { // @Sに指定した日付の曜日を返す。不正な日付の場合は今日の曜日を返す。 // @ようび

--- a/core/test/plugin_system_test.mjs
+++ b/core/test/plugin_system_test.mjs
@@ -574,6 +574,34 @@ describe('plugin_system_test', async () => {
     await cmp('1488726000を日時変換して表示', '2017/03/06 00:00:00')
     await cmp('1504191600を日時変換して表示', '2017/09/01 00:00:00')
   })
+  it('今月・先月・来月 #2412', async () => {
+    const now = new Date()
+    const m = now.getMonth() + 1 // 1-12
+    await cmp('今月を表示', String(m))
+    await cmp('先月を表示', String(m === 1 ? 12 : m - 1))
+    await cmp('来月を表示', String(m === 12 ? 1 : m + 1))
+    // 月をずらして境界(1月と12月)を確認する
+    const RealDate = globalThis.Date
+    const withMonth = async (/** @type {number} */ month, /** @type {() => Promise<void>} */ body) => {
+      class FakeDate extends RealDate {
+        constructor (/** @type {any[]} */ ...args) {
+          if (args.length === 0) { super(2024, month, 15) } else { super(...args) }
+        }
+      }
+      globalThis.Date = FakeDate
+      try { await body() } finally { globalThis.Date = RealDate }
+    }
+    await withMonth(0, async () => { // 2024年1月
+      await cmp('今月を表示', '1')
+      await cmp('先月を表示', '12')
+      await cmp('来月を表示', '2')
+    })
+    await withMonth(11, async () => { // 2024年12月
+      await cmp('今月を表示', '12')
+      await cmp('先月を表示', '11')
+      await cmp('来月を表示', '1')
+    })
+  })
   it('日時差 #1117', async () => {
     await cmp('「2017/03/06」から「2018/03/06」までの年数差。それを表示', '1')
     await cmp('「2017/03/06」と「2018/03/06」の年数差。それを表示', '1')

--- a/doc/command_list.json
+++ b/doc/command_list.json
@@ -3805,7 +3805,7 @@
     ],
     "category": "日時処理(簡易)",
     "url": "https://github.com/kujirahand/nadesiko3/blob/master/core/src/plugin_system_datetime.mts#L105",
-    "description": "来月が何月かを返す"
+    "description": "来月が何月かを返す(12月の場合は1を返す)"
   },
   {
     "type": "関数",
@@ -3821,7 +3821,7 @@
     ],
     "category": "日時処理(簡易)",
     "url": "https://github.com/kujirahand/nadesiko3/blob/master/core/src/plugin_system_datetime.mts#L113",
-    "description": "先月が何月かを返す"
+    "description": "先月が何月かを返す(1月の場合は12を返す)"
   },
   {
     "type": "関数",


### PR DESCRIPTION
## 概要

`先月`命令が1月のときに`0`を返す問題を修正しました。 #2412

あわせて、`来月`命令が12月のときに`13`を返す問題も同様に修正しています。

## 変更内容

- `core/src/plugin_system_datetime.mts`
  - `先月`: 1月のときは`12`を返す
  - `来月`: 12月のときは`1`を返す
- `core/test/plugin_system_test.mjs`
  - 現在の月に対する`今月`/`先月`/`来月`の値を確認するテストを追加
  - `Date`を差し替えて1月・12月の境界を確認するテストを追加
- `doc/command_list.json`: 説明文の更新を反映

## テスト

`npm run test:core` が全て通ることを確認しました(933件 pass)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)