### PR TITLE
ブラウザテストをGitHub Actionsへ再接続 #1200

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         # Node.js v20はEOLのため対象外。ドキュメント上の最低サポートに合わせて 22.x を含めます
@@ -22,9 +23,9 @@ jobs:
 
     steps:
       - name: Checkout submodule
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
     
@@ -50,9 +51,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Use Node.js 24.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24.x
           cache: npm

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -41,3 +41,30 @@ jobs:
       - name: npm run test
         run: npm run test
 
+      # ブラウザテストはNode.jsの最新対象バージョンで実行
+      - name: Install browser test dependencies
+        if: matrix.node-version == '24.x'
+        working-directory: test-browser
+        run: |
+          npm install
+          npx playwright install --with-deps chromium
+
+      - name: npm run test (browser)
+        if: matrix.node-version == '24.x'
+        working-directory: test-browser
+        run: npm test
+
+      - name: Use Python
+        if: matrix.node-version == '24.x'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Selenium test dependencies
+        if: matrix.node-version == '24.x'
+        run: python -m pip install -r test-browser/test/selenium/requirements.txt
+
+      - name: npm run test:selenium
+        if: matrix.node-version == '24.x'
+        working-directory: test-browser
+        run: npm run test:selenium

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Use Python
         if: matrix.node-version == '24.x'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.x'
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -3,6 +3,9 @@
 
 name: Node.js CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master ]
@@ -19,15 +22,15 @@ jobs:
 
     steps:
       - name: Checkout submodule
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
     
       # 各種ライブラリをインストール
-      - name: npm install
-        run: npm install
+      - name: npm ci
+        run: npm ci
       
       # 各種ビルド
       - name: npm run build
@@ -41,30 +44,42 @@ jobs:
       - name: npm run test
         run: npm run test
 
-      # ブラウザテストはNode.jsの最新対象バージョンで実行
-      - name: Install browser test dependencies
-        if: matrix.node-version == '24.x'
-        working-directory: test-browser
-        run: |
-          npm install
-          npx playwright install --with-deps chromium
+  browser-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
 
-      - name: npm run test (browser)
-        if: matrix.node-version == '24.x'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            test-browser/package-lock.json
+      - name: Install root dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Install browser test dependencies
+        working-directory: test-browser
+        run: npm ci
+      - name: Install Chromium
+        working-directory: test-browser
+        run: npx playwright install --with-deps chromium
+      - name: Run Playwright browser tests
         working-directory: test-browser
         run: npm test
-
       - name: Use Python
-        if: matrix.node-version == '24.x'
         uses: actions/setup-python@v7
         with:
           python-version: '3.x'
-
       - name: Install Selenium test dependencies
-        if: matrix.node-version == '24.x'
         run: python -m pip install -r test-browser/test/selenium/requirements.txt
-
-      - name: npm run test:selenium
-        if: matrix.node-version == '24.x'
+      - name: Test Selenium runner
+        run: python -m unittest discover -s test-browser/test/selenium -p 'test_chrome_unit.py'
+      - name: Run Selenium smoke tests
         working-directory: test-browser
         run: npm run test:selenium

--- a/doc/browser-tests.md
+++ b/doc/browser-tests.md
@@ -30,11 +30,9 @@ GitHub Actions では、安定して動く smoke test を既定で実行しま�
 
 `.github/workflows/nodejs.yml` では Node.js の通常テストに加えて、`24.x` で以下を実行します。
 
-- `npm run test:browser`
-- `npm run test:ace-editor`
-- `npm run test:bundled`
-- `python3 -m pip install -r test-browser/test/selenium/requirements.txt`
-- `npm run test:selenium`
+- `test-browser/` の `npm test`（設定、Browser、Ace Editor、bundledの各テスト）
+- `python -m pip install -r test-browser/test/selenium/requirements.txt`
+- `test-browser/` の `npm run test:selenium`
 
 ## 今後の改善案
 

--- a/test-browser/package-lock.json
+++ b/test-browser/package-lock.json
@@ -1,0 +1,1340 @@
+{
+  "name": "nadesiko3-test-browser",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nadesiko3-test-browser",
+      "devDependencies": {
+        "@playwright/test": "^1.52.0",
+        "cross-env": "^10.1.0",
+        "vite": "^6.3.4",
+        "yaml": "^2.8.1"
+      }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.1.tgz",
+      "integrity": "sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.1.tgz",
+      "integrity": "sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.1.tgz",
+      "integrity": "sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.1.tgz",
+      "integrity": "sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.1.tgz",
+      "integrity": "sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.1.tgz",
+      "integrity": "sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.1.tgz",
+      "integrity": "sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.1.tgz",
+      "integrity": "sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.1.tgz",
+      "integrity": "sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.1.tgz",
+      "integrity": "sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.1.tgz",
+      "integrity": "sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.1.tgz",
+      "integrity": "sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.1.tgz",
+      "integrity": "sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.1.tgz",
+      "integrity": "sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.1.tgz",
+      "integrity": "sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.1.tgz",
+      "integrity": "sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.1.tgz",
+      "integrity": "sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.1.tgz",
+      "integrity": "sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.1.tgz",
+      "integrity": "sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.1.tgz",
+      "integrity": "sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.1.tgz",
+      "integrity": "sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.1.tgz",
+      "integrity": "sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.1.tgz",
+      "integrity": "sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.1.tgz",
+      "integrity": "sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.63.1",
+        "@rollup/rollup-android-arm64": "4.63.1",
+        "@rollup/rollup-darwin-arm64": "4.63.1",
+        "@rollup/rollup-darwin-x64": "4.63.1",
+        "@rollup/rollup-freebsd-arm64": "4.63.1",
+        "@rollup/rollup-freebsd-x64": "4.63.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.63.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.63.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.63.1",
+        "@rollup/rollup-linux-arm64-musl": "4.63.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.63.1",
+        "@rollup/rollup-linux-loong64-musl": "4.63.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.63.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.63.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.63.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.63.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-musl": "4.63.1",
+        "@rollup/rollup-openbsd-x64": "4.63.1",
+        "@rollup/rollup-openharmony-arm64": "4.63.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.63.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.63.1",
+        "@rollup/rollup-win32-x64-gnu": "4.63.1",
+        "@rollup/rollup-win32-x64-msvc": "4.63.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/test-browser/package.json
+++ b/test-browser/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "description": "Playwrightで実行するブラウザテストの集約パッケージ",
   "scripts": {
-    "test": "npm run test:all",
+    "test": "npm run test:config && npm run test:all",
     "test:all": "npm run test:browser && npm run test:bundled && npm run test:ace-editor",
     "test:browser": "npm run test:browser:smoke",
     "test:browser:smoke": "playwright test test/browser.spec.mjs --config playwright.config.mjs --project chromium --grep 'smoke'",

--- a/test-browser/package.json
+++ b/test-browser/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@playwright/test": "^1.52.0",
     "cross-env": "^10.1.0",
-    "vite": "^6.3.4"
+    "vite": "^6.3.4",
+    "yaml": "^2.8.1"
   }
 }

--- a/test-browser/test/browser.spec.mjs
+++ b/test-browser/test/browser.spec.mjs
@@ -39,6 +39,20 @@ test('browser smoke rejects zero completed tests', () => {
     .toThrow('ブラウザ内のテストが1件も実行されていません')
 })
 
+test('browser smoke case counting follows the executed cases', async ({ page }) => {
+  await page.goto('/test-browser/test/html/browser-smoke-runner.html')
+  const result = await page.evaluate(async () => {
+    const { runBrowserSmokeCases } = await import('/test-browser/test/browser/test/plugin_browser_smoke_test.js')
+    return runBrowserSmokeCases([
+      { title: '成功', fn: () => {} },
+      { title: '失敗', fn: () => { throw new Error('expected failure') } }
+    ])
+  })
+  expect(result.total).toBe(2)
+  expect(result.passes).toBe(1)
+  expect(result.failures).toHaveLength(1)
+})
+
 test('browser full test', async ({ page }) => {
   test.setTimeout(300000)
   // フルテストはより長いタイムアウトを使用する

--- a/test-browser/test/browser.spec.mjs
+++ b/test-browser/test/browser.spec.mjs
@@ -24,12 +24,19 @@ function assertNoFailures (result) {
       .join('\n')
     throw new Error(`${result.failures}件のテストが失敗しました:\n${details}`)
   }
+  expect(result.total, 'ブラウザ内のテストが1件も実行されていません').toBeGreaterThan(0)
+  expect(result.passes + result.failures, 'ブラウザ内のテスト件数が一致しません').toBe(result.total)
   expect(result.failures).toBe(0)
 }
 
 test('browser smoke test', async ({ page }) => {
   const result = await runRunnerPage(page, '/test-browser/test/html/browser-smoke-runner.html')
   assertNoFailures(result)
+})
+
+test('browser smoke rejects zero completed tests', () => {
+  expect(() => assertNoFailures({ failures: 0, passes: 0, total: 0, failures_detail: [] }))
+    .toThrow('ブラウザ内のテストが1件も実行されていません')
 })
 
 test('browser full test', async ({ page }) => {

--- a/test-browser/test/browser.spec.mjs
+++ b/test-browser/test/browser.spec.mjs
@@ -18,15 +18,21 @@ async function runRunnerPage (page, url, timeout = 60000) {
  * @param {object} result - runMochaPageの戻り値
  */
 function assertNoFailures (result) {
-  if (result.failures > 0) {
-    const details = result.failures_detail
+  const failureDetails = Array.isArray(result.failures)
+    ? result.failures
+    : (result.failures_detail || [])
+  const failureCount = Array.isArray(result.failures)
+    ? result.failures.length
+    : result.failures
+  if (failureCount > 0) {
+    const details = failureDetails
       .map((f) => `  - ${f.title}: ${f.error}`)
       .join('\n')
-    throw new Error(`${result.failures}件のテストが失敗しました:\n${details}`)
+    throw new Error(`${failureCount}件のテストが失敗しました:\n${details}`)
   }
   expect(result.total, 'ブラウザ内のテストが1件も実行されていません').toBeGreaterThan(0)
-  expect(result.passes + result.failures, 'ブラウザ内のテスト件数が一致しません').toBe(result.total)
-  expect(result.failures).toBe(0)
+  expect(result.passes + failureCount, 'ブラウザ内のテスト件数が一致しません').toBe(result.total)
+  expect(failureCount).toBe(0)
 }
 
 test('browser smoke test', async ({ page }) => {
@@ -37,6 +43,14 @@ test('browser smoke test', async ({ page }) => {
 test('browser smoke rejects zero completed tests', () => {
   expect(() => assertNoFailures({ failures: 0, passes: 0, total: 0, failures_detail: [] }))
     .toThrow('ブラウザ内のテストが1件も実行されていません')
+})
+
+test('browser smoke accepts raw failure arrays', () => {
+  expect(() => assertNoFailures({
+    failures: [{ title: '失敗', error: 'expected failure' }],
+    passes: 0,
+    total: 1
+  })).toThrow('1件のテストが失敗しました')
 })
 
 test('browser smoke case counting follows the executed cases', async ({ page }) => {

--- a/test-browser/test/browser/test/plugin_browser_smoke_test.js
+++ b/test-browser/test/browser/test/plugin_browser_smoke_test.js
@@ -13,11 +13,13 @@ function assertEqual (actual, expected, message) {
   }
 }
 
-async function runCase (title, fn, failures) {
+async function runCase (title, fn, result) {
+  result.total++
   try {
     await fn()
+    result.passes++
   } catch (error) {
-    failures.push({
+    result.failures.push({
       title,
       error: error?.stack || error?.message || String(error)
     })
@@ -27,61 +29,74 @@ async function runCase (title, fn, failures) {
 /**
  * 旧plugin_browser_smoke_test.jsの内容をMocha非依存で実行する
  */
-export async function runBrowserSmokeCases () {
-  const failures = []
-
-  await runCase('言う', () => {
-    const nako = createCompiler()
-    const originalAlert = window.alert
-    let count = 0
-    window.alert = (msg) => {
-      if (msg === 'あいうえお') count++
+const smokeCases = [
+  {
+    title: '言う',
+    fn: () => {
+      const nako = createCompiler()
+      const originalAlert = window.alert
+      let count = 0
+      window.alert = (msg) => {
+        if (msg === 'あいうえお') count++
+      }
+      try {
+        nako.run('「あいうえお」を言う')
+        assertEqual(count, 1, 'alert呼び出し回数')
+      } finally {
+        window.alert = originalAlert
+      }
     }
-    try {
-      nako.run('「あいうえお」を言う')
-      assertEqual(count, 1, 'alert呼び出し回数')
-    } finally {
-      window.alert = originalAlert
+  },
+  {
+    title: '尋ねる',
+    fn: () => {
+      const nako = createCompiler()
+      const originalPrompt = window.prompt
+      let count = 0
+      window.prompt = (msg) => {
+        if (msg === 'かきくけこ') count++
+        return 'abc'
+      }
+      try {
+        const result = nako.run('A=「かきくけこ」を尋ねる;AをJSONエンコードして表示')
+        assertEqual(result.log, '"abc"', 'prompt戻り値')
+        assertEqual(count, 1, 'prompt呼び出し回数')
+      } finally {
+        window.prompt = originalPrompt
+      }
     }
-  })
-
-  await runCase('尋ねる', () => {
-    const nako = createCompiler()
-    const originalPrompt = window.prompt
-    let count = 0
-    window.prompt = (msg) => {
-      if (msg === 'かきくけこ') count++
-      return 'abc'
+  },
+  {
+    title: '二択',
+    fn: () => {
+      const nako = createCompiler()
+      const originalConfirm = window.confirm
+      let count = 0
+      window.confirm = (msg) => {
+        if (msg === 'これ') count++
+        return true
+      }
+      try {
+        const result = nako.run('A=「これ」で二択;AをJSONエンコードして表示')
+        assertEqual(result.log, 'true', 'confirm戻り値')
+        assertEqual(count, 1, 'confirm呼び出し回数')
+      } finally {
+        window.confirm = originalConfirm
+      }
     }
-    try {
-      const result = nako.run('A=「かきくけこ」を尋ねる;AをJSONエンコードして表示')
-      assertEqual(result.log, '"abc"', 'prompt戻り値')
-      assertEqual(count, 1, 'prompt呼び出し回数')
-    } finally {
-      window.prompt = originalPrompt
-    }
-  })
-
-  await runCase('二択', () => {
-    const nako = createCompiler()
-    const originalConfirm = window.confirm
-    let count = 0
-    window.confirm = (msg) => {
-      if (msg === 'これ') count++
-      return true
-    }
-    try {
-      const result = nako.run('A=「これ」で二択;AをJSONエンコードして表示')
-      assertEqual(result.log, 'true', 'confirm戻り値')
-      assertEqual(count, 1, 'confirm呼び出し回数')
-    } finally {
-      window.confirm = originalConfirm
-    }
-  })
-
-  return {
-    total: 3,
-    failures,
-    passes: 3 - failures.length
   }
+]
+
+export async function runBrowserSmokeCases (cases = smokeCases) {
+  const result = {
+    total: 0,
+    failures: [],
+    passes: 0
+  }
+
+  for (const { title, fn } of cases) {
+    await runCase(title, fn, result)
+  }
+
+  return result
 }

--- a/test-browser/test/config_test.mjs
+++ b/test-browser/test/config_test.mjs
@@ -85,6 +85,22 @@ test('test-browser package.jsonにブラウザ系テストスクリプトを集�
     assert.equal(typeof scripts[scriptName], 'string', `${scriptName}がtest-browser/package.jsonに存在しません`)
     assert.ok(scripts[scriptName].length > 0, `${scriptName}スクリプトが空です`)
   }
+
+  assert.ok(scripts.test.includes('test:config'), 'npm testから設定テストが実行されません')
+  assert.ok(scripts.test.includes('test:all'), 'npm testからブラウザテスト群が実行されません')
+})
+
+test('GitHub Actionsがブラウザテストを実行する', () => {
+  const workflowPath = join(rootDir, '.github/workflows/nodejs.yml')
+  const workflowText = readFileSync(workflowPath, 'utf8')
+
+  assert.ok(workflowText.includes('working-directory: test-browser'), 'CIの実行ディレクトリにtest-browserがありません')
+  assert.ok(workflowText.includes('playwright install --with-deps chromium'), 'CIでChromiumをインストールしていません')
+  assert.ok(workflowText.includes("if: matrix.node-version == '24.x'"), 'ブラウザテストのNode.jsバージョンが固定されていません')
+  assert.match(workflowText, /working-directory: test-browser\n\s+run: npm test/, 'CIでtest-browserのnpm testを実行していません')
+  assert.ok(workflowText.includes('actions/setup-python@v5'), 'CIでSelenium用のPythonを準備していません')
+  assert.ok(workflowText.includes('test-browser/test/selenium/requirements.txt'), 'CIでSeleniumの依存関係をインストールしていません')
+  assert.match(workflowText, /working-directory: test-browser\n\s+run: npm run test:selenium/, 'CIでSeleniumのsmoke testを実行していません')
 })
 
 test('Playwright設定がheadless Chromium実行になっている', async () => {

--- a/test-browser/test/config_test.mjs
+++ b/test-browser/test/config_test.mjs
@@ -94,9 +94,12 @@ test('test-browser package.jsonにブラウザ系テストスクリプトを集�
 test('GitHub Actionsがブラウザテストを実行する', () => {
   const workflowPath = join(rootDir, '.github/workflows/nodejs.yml')
   const workflow = parse(readFileSync(workflowPath, 'utf8'))
+  assert.equal(workflow.permissions?.contents, 'read', 'workflowの権限が読み取り専用ではありません')
+  assert.equal(workflow.jobs?.build?.['timeout-minutes'], 20, 'buildジョブにタイムアウトが設定されていません')
   const browserJob = workflow.jobs?.['browser-test']
   assert.ok(browserJob, 'browser-testジョブが定義されていません')
   assert.equal(browserJob['timeout-minutes'], 20, 'browser-testジョブにタイムアウトが設定されていません')
+  assert.equal(browserJob.needs, undefined, 'browser-testジョブが他ジョブに依存しています')
 
   const steps = browserJob.steps || []
   const findStep = (predicate, message) => {
@@ -104,8 +107,8 @@ test('GitHub Actionsがブラウザテストを実行する', () => {
     assert.ok(step, message)
     return step
   }
-  assert.equal(findStep((step) => step.uses === 'actions/checkout@v4', 'browser-testでcheckout@v4を使用していません').uses, 'actions/checkout@v4')
-  assert.equal(findStep((step) => step.uses === 'actions/setup-node@v4', 'browser-testでsetup-node@v4を使用していません').with['node-version'], '24.x')
+  assert.equal(findStep((step) => step.uses === 'actions/checkout@v7', 'browser-testでcheckout@v7を使用していません').uses, 'actions/checkout@v7')
+  assert.equal(findStep((step) => step.uses === 'actions/setup-node@v7', 'browser-testでsetup-node@v7を使用していません').with['node-version'], '24.x')
   assert.equal(findStep((step) => step.run === 'npm ci' && !step['working-directory'], 'ルート依存関係をnpm ciでインストールしていません').run, 'npm ci')
   assert.equal(findStep((step) => step.run === 'npm ci' && step['working-directory'] === 'test-browser', 'test-browser依存関係をnpm ciでインストールしていません').run, 'npm ci')
   assert.equal(findStep((step) => step.run === 'npx playwright install --with-deps chromium' && step['working-directory'] === 'test-browser', 'CIでChromiumをインストールしていません').run, 'npx playwright install --with-deps chromium')

--- a/test-browser/test/config_test.mjs
+++ b/test-browser/test/config_test.mjs
@@ -103,6 +103,13 @@ test('GitHub Actionsがブラウザテストを実行する', () => {
   assert.match(workflowText, /working-directory: test-browser\n\s+run: npm run test:selenium/, 'CIでSeleniumのsmoke testを実行していません')
 })
 
+test('Seleniumランナーがルートのreleaseを参照する', () => {
+  const seleniumServerPath = join(testBrowserDir, 'test/selenium/index.php')
+  const seleniumServerText = readFileSync(seleniumServerPath, 'utf8')
+
+  assert.ok(seleniumServerText.includes("dirname($dir, 3).'/release'"), 'Seleniumランナーのrelease参照先が不正です')
+})
+
 test('Playwright設定がheadless Chromium実行になっている', async () => {
   const testBrowserPackagePath = join(testBrowserDir, 'package.json')
   const testBrowserPackage = JSON.parse(readFileSync(testBrowserPackagePath, 'utf8'))

--- a/test-browser/test/config_test.mjs
+++ b/test-browser/test/config_test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import { existsSync, readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
+import { parse } from 'yaml'
 
 const currentDir = dirname(fileURLToPath(import.meta.url))
 const testBrowserDir = resolve(currentDir, '..')
@@ -92,15 +93,31 @@ test('test-browser package.jsonにブラウザ系テストスクリプトを集�
 
 test('GitHub Actionsがブラウザテストを実行する', () => {
   const workflowPath = join(rootDir, '.github/workflows/nodejs.yml')
-  const workflowText = readFileSync(workflowPath, 'utf8')
+  const workflow = parse(readFileSync(workflowPath, 'utf8'))
+  const browserJob = workflow.jobs?.['browser-test']
+  assert.ok(browserJob, 'browser-testジョブが定義されていません')
+  assert.equal(browserJob['timeout-minutes'], 20, 'browser-testジョブにタイムアウトが設定されていません')
 
-  assert.ok(workflowText.includes('working-directory: test-browser'), 'CIの実行ディレクトリにtest-browserがありません')
-  assert.ok(workflowText.includes('playwright install --with-deps chromium'), 'CIでChromiumをインストールしていません')
-  assert.ok(workflowText.includes("if: matrix.node-version == '24.x'"), 'ブラウザテストのNode.jsバージョンが固定されていません')
-  assert.match(workflowText, /working-directory: test-browser\n\s+run: npm test/, 'CIでtest-browserのnpm testを実行していません')
-  assert.ok(workflowText.includes('actions/setup-python@v7'), 'CIでSelenium用のPythonを準備していません')
-  assert.ok(workflowText.includes('test-browser/test/selenium/requirements.txt'), 'CIでSeleniumの依存関係をインストールしていません')
-  assert.match(workflowText, /working-directory: test-browser\n\s+run: npm run test:selenium/, 'CIでSeleniumのsmoke testを実行していません')
+  const steps = browserJob.steps || []
+  const findStep = (predicate, message) => {
+    const step = steps.find(predicate)
+    assert.ok(step, message)
+    return step
+  }
+  assert.equal(findStep((step) => step.uses === 'actions/checkout@v4', 'browser-testでcheckout@v4を使用していません').uses, 'actions/checkout@v4')
+  assert.equal(findStep((step) => step.uses === 'actions/setup-node@v4', 'browser-testでsetup-node@v4を使用していません').with['node-version'], '24.x')
+  assert.equal(findStep((step) => step.run === 'npm ci' && !step['working-directory'], 'ルート依存関係をnpm ciでインストールしていません').run, 'npm ci')
+  assert.equal(findStep((step) => step.run === 'npm ci' && step['working-directory'] === 'test-browser', 'test-browser依存関係をnpm ciでインストールしていません').run, 'npm ci')
+  assert.equal(findStep((step) => step.run === 'npx playwright install --with-deps chromium' && step['working-directory'] === 'test-browser', 'CIでChromiumをインストールしていません').run, 'npx playwright install --with-deps chromium')
+  assert.equal(findStep((step) => step.run === 'npm test' && step['working-directory'] === 'test-browser', 'CIでtest-browserのnpm testを実行していません').run, 'npm test')
+  assert.equal(findStep((step) => step.uses === 'actions/setup-python@v7', 'CIでSelenium用のPythonを準備していません').uses, 'actions/setup-python@v7')
+  assert.equal(findStep((step) => step.run === "python -m pip install -r test-browser/test/selenium/requirements.txt", 'CIでSeleniumの依存関係をインストールしていません').run, "python -m pip install -r test-browser/test/selenium/requirements.txt")
+  assert.equal(findStep((step) => typeof step.run === 'string' && step.run.includes('test_chrome_unit.py'), 'CIでSeleniumランナーの単体テストを実行していません').run.includes('test_chrome_unit.py'), true)
+  assert.equal(findStep((step) => step.run === 'npm run test:selenium' && step['working-directory'] === 'test-browser', 'CIでSeleniumのsmoke testを実行していません').run, 'npm run test:selenium')
+})
+
+test('ブラウザテスト用のlockfileが存在する', () => {
+  assert.equal(existsSync(join(testBrowserDir, 'package-lock.json')), true)
 })
 
 test('Seleniumランナーがルートのreleaseを参照する', () => {

--- a/test-browser/test/config_test.mjs
+++ b/test-browser/test/config_test.mjs
@@ -98,7 +98,7 @@ test('GitHub Actionsがブラウザテストを実行する', () => {
   assert.ok(workflowText.includes('playwright install --with-deps chromium'), 'CIでChromiumをインストールしていません')
   assert.ok(workflowText.includes("if: matrix.node-version == '24.x'"), 'ブラウザテストのNode.jsバージョンが固定されていません')
   assert.match(workflowText, /working-directory: test-browser\n\s+run: npm test/, 'CIでtest-browserのnpm testを実行していません')
-  assert.ok(workflowText.includes('actions/setup-python@v5'), 'CIでSelenium用のPythonを準備していません')
+  assert.ok(workflowText.includes('actions/setup-python@v7'), 'CIでSelenium用のPythonを準備していません')
   assert.ok(workflowText.includes('test-browser/test/selenium/requirements.txt'), 'CIでSeleniumの依存関係をインストールしていません')
   assert.match(workflowText, /working-directory: test-browser\n\s+run: npm run test:selenium/, 'CIでSeleniumのsmoke testを実行していません')
 })

--- a/test-browser/test/html/browser-smoke-runner.html
+++ b/test-browser/test/html/browser-smoke-runner.html
@@ -8,12 +8,15 @@
 <body>
   <script type="module">
     const failures = []
-    const total = 3
+    let total = 0
+    let passes = 0
 
     try {
       const { runBrowserSmokeCases } = await import('/test-browser/test/browser/test/plugin_browser_smoke_test.js')
       const result = await runBrowserSmokeCases()
       failures.push(...result.failures)
+      total = result.total
+      passes = result.passes
     } catch (error) {
       failures.push({
         title: 'browser-smoke-runner bootstrap',
@@ -22,7 +25,7 @@
     } finally {
       window.__playwright_done__ = {
         failures: failures.length,
-        passes: Math.max(0, total - failures.length),
+        passes,
         total,
         failures_detail: failures
       }

--- a/test-browser/test/selenium/index.php
+++ b/test-browser/test/selenium/index.php
@@ -1,7 +1,7 @@
 <?php
 function main(): void {
   $dir = __DIR__;
-  $release = dirname(dirname($dir)).'/release';
+  $release = dirname($dir, 3).'/release';
   $m = empty($_GET['m']) ? '' : $_GET['m'];
   if ($m == 'kill') {
     echo "kill";

--- a/test-browser/test/selenium/requirements.txt
+++ b/test-browser/test/selenium/requirements.txt
@@ -1,1 +1,1 @@
-selenium>=4.6
+selenium==4.48.0

--- a/test-browser/test/selenium/test_chrome.py
+++ b/test-browser/test/selenium/test_chrome.py
@@ -89,6 +89,22 @@ def compare_result(expect_text, real_text):
             return False
     return True
 
+def result_shape_ready(expect_text, real_text):
+    '''return true once text lines or PNG data URLs are ready for final comparison'''
+    if expect_text == real_text:
+        return True
+    expect_lines = expect_text.split('\n')
+    real_lines = real_text.split('\n')
+    if len(expect_lines) != len(real_lines):
+        return False
+    for expect_line, real_line in zip(expect_lines, real_lines):
+        if expect_line == real_line:
+            continue
+        if to_png_data_url(expect_line) and to_png_data_url(real_line):
+            continue
+        return False
+    return True
+
 def create_driver():
     '''create chrome driver'''
     from selenium import webdriver
@@ -101,8 +117,11 @@ def create_driver():
         options.add_argument('--disable-dev-shm-usage')
     chromedriver = os.environ.get('CHROMEDRIVER') or shutil.which('chromedriver')
     if chromedriver and os.path.exists(chromedriver):
-        return webdriver.Chrome(service=Service(chromedriver), options=options)
-    return webdriver.Chrome(options=options)
+        browser = webdriver.Chrome(service=Service(chromedriver), options=options)
+    else:
+        browser = webdriver.Chrome(options=options)
+    browser.set_script_timeout(5)
+    return browser
 
 driver = None
 
@@ -144,34 +163,39 @@ def run_test(fname):
         error_log.append({'file': fname, 'expect': '### 期待値', 'real': '期待値行なし'})
         return
     code_result = '\n'.join(expected_lines).strip()
-    from selenium.common.exceptions import StaleElementReferenceException, TimeoutException
+    from selenium.common.exceptions import StaleElementReferenceException, TimeoutException, WebDriverException
     from selenium.webdriver.common.by import By
     from selenium.webdriver.support.ui import WebDriverWait
 
     # drive server
-    browser = get_driver()
-    browser.get(SERVER_SCRIPT + '?m=code&code=' + code_u)
-
-    def result_matches(_driver):
-        current = _driver.find_element(By.CSS_SELECTOR, '#result').get_attribute('value').strip()
-        return compare_result(code_result, current)
-
     try:
-        WebDriverWait(
-            browser,
-            15,
-            ignored_exceptions=(StaleElementReferenceException,)
-        ).until(result_matches)
-    except TimeoutException:
-        # 不一致時の実値を下の比較処理で報告する。
-        pass
-    result_elem = browser.find_element(By.CSS_SELECTOR, '#result')
-    result = result_elem.get_attribute('value').strip()
-    if compare_result(code_result, result):
-        print('[ok]', os.path.basename(fname))
-    else:
-        print('[ERROR]', os.path.basename(fname))
-        print('>>>', code_result, '!=', result)
+        browser = get_driver()
+        browser.get(SERVER_SCRIPT + '?m=code&code=' + code_u)
+
+        def result_matches(_driver):
+            current = _driver.find_element(By.CSS_SELECTOR, '#result').get_attribute('value').strip()
+            return result_shape_ready(code_result, current)
+
+        try:
+            WebDriverWait(
+                browser,
+                15,
+                ignored_exceptions=(StaleElementReferenceException,)
+            ).until(result_matches)
+        except TimeoutException:
+            # 不一致時の実値を下の比較処理で報告する。
+            pass
+        result_elem = browser.find_element(By.CSS_SELECTOR, '#result')
+        result = result_elem.get_attribute('value').strip()
+        if compare_result(code_result, result):
+            print('[ok]', os.path.basename(fname))
+        else:
+            print('[ERROR]', os.path.basename(fname))
+            print('>>>', code_result, '!=', result)
+            error_log.append({'file': fname, 'expect': code_result, 'real': result})
+    except WebDriverException as error:
+        result = f'{type(error).__name__}: {error}'
+        print('[ERROR]', os.path.basename(fname), result)
         error_log.append({'file': fname, 'expect': code_result, 'real': result})
 
 def report_test(executed_count):

--- a/test-browser/test/selenium/test_chrome.py
+++ b/test-browser/test/selenium/test_chrome.py
@@ -4,7 +4,6 @@ Seleniumを使ってChromeを操作してテストを実行する。
 import os
 import glob
 import shutil
-import time
 import sys
 import urllib.parse
 
@@ -132,23 +131,33 @@ def run_test_all():
 
 def run_test(fname):
     '''test one file'''
-    from selenium.webdriver.common.by import By
-
     with open(fname, 'r', encoding='utf-8') as file:
         code = file.read()
     code_u = urllib.parse.quote(code)
-    code_result = ''
+    expected_lines = []
     for line in code.split('\n'):
         line = line.strip()
         if line[0:3] == '###':
-            code_result += line[3:].strip() + '\n'
-    code_result = code_result.strip()
+            expected_lines.append(line[3:].strip())
+    if len(expected_lines) == 0:
+        print('[ERROR]', os.path.basename(fname), 'に期待値行がありません')
+        error_log.append({'file': fname, 'expect': '### 期待値', 'real': '期待値行なし'})
+        return
+    code_result = '\n'.join(expected_lines).strip()
+    from selenium.common.exceptions import TimeoutException
+    from selenium.webdriver.common.by import By
+    from selenium.webdriver.support.ui import WebDriverWait
+
     # drive server
     browser = get_driver()
     browser.get(SERVER_SCRIPT + '?m=code&code=' + code_u)
-    time.sleep(1)
-    # get result
     result_elem = browser.find_element(By.CSS_SELECTOR, '#result')
+    try:
+        WebDriverWait(browser, 15).until(
+            lambda _driver: result_elem.get_attribute('value').strip() == code_result)
+    except TimeoutException:
+        # 不一致時の実値を下の比較処理で報告する。
+        pass
     result = result_elem.get_attribute('value').strip()
     if compare_result(code_result, result):
         print('[ok]', os.path.basename(fname))

--- a/test-browser/test/selenium/test_chrome.py
+++ b/test-browser/test/selenium/test_chrome.py
@@ -144,20 +144,28 @@ def run_test(fname):
         error_log.append({'file': fname, 'expect': '### 期待値', 'real': '期待値行なし'})
         return
     code_result = '\n'.join(expected_lines).strip()
-    from selenium.common.exceptions import TimeoutException
+    from selenium.common.exceptions import StaleElementReferenceException, TimeoutException
     from selenium.webdriver.common.by import By
     from selenium.webdriver.support.ui import WebDriverWait
 
     # drive server
     browser = get_driver()
     browser.get(SERVER_SCRIPT + '?m=code&code=' + code_u)
-    result_elem = browser.find_element(By.CSS_SELECTOR, '#result')
+
+    def result_matches(_driver):
+        current = _driver.find_element(By.CSS_SELECTOR, '#result').get_attribute('value').strip()
+        return compare_result(code_result, current)
+
     try:
-        WebDriverWait(browser, 15).until(
-            lambda _driver: result_elem.get_attribute('value').strip() == code_result)
+        WebDriverWait(
+            browser,
+            15,
+            ignored_exceptions=(StaleElementReferenceException,)
+        ).until(result_matches)
     except TimeoutException:
         # 不一致時の実値を下の比較処理で報告する。
         pass
+    result_elem = browser.find_element(By.CSS_SELECTOR, '#result')
     result = result_elem.get_attribute('value').strip()
     if compare_result(code_result, result):
         print('[ok]', os.path.basename(fname))

--- a/test-browser/test/selenium/test_chrome.py
+++ b/test-browser/test/selenium/test_chrome.py
@@ -201,7 +201,14 @@ def run_test(fname):
 def report_test(executed_count):
     '''report file'''
     if driver is not None:
-        driver.quit()
+        try:
+            driver.quit()
+        except Exception as error:
+            error_log.append({
+                'file': 'WebDriver終了処理',
+                'expect': '正常終了',
+                'real': f'{type(error).__name__}: {error}'
+            })
     if executed_count == 0:
         print('😭😭😭 実行されたSeleniumテストがありません 😭😭😭')
         return 1

--- a/test-browser/test/selenium/test_chrome.py
+++ b/test-browser/test/selenium/test_chrome.py
@@ -7,9 +7,6 @@ import shutil
 import time
 import sys
 import urllib.parse
-from selenium import webdriver
-from selenium.webdriver.common.by import By
-from selenium.webdriver.chrome.service import Service
 
 SERVER_SCRIPT = 'http://localhost:8887/index.php'
 SCRIPT = os.path.abspath(__file__)
@@ -95,6 +92,9 @@ def compare_result(expect_text, real_text):
 
 def create_driver():
     '''create chrome driver'''
+    from selenium import webdriver
+    from selenium.webdriver.chrome.service import Service
+
     options = webdriver.ChromeOptions()
     if os.environ.get('HEADLESS') == '1' or os.environ.get('CI') or not os.environ.get('DISPLAY'):
         options.add_argument('--headless=new')
@@ -105,17 +105,35 @@ def create_driver():
         return webdriver.Chrome(service=Service(chromedriver), options=options)
     return webdriver.Chrome(options=options)
 
-driver = create_driver()
+driver = None
+
+def get_driver():
+    '''create the browser only when a test is actually executed'''
+    global driver
+    if driver is None:
+        driver = create_driver()
+    return driver
+
+def collect_test_files(test_target=TEST_TARGET, smoke_mode=None):
+    '''return the Selenium test files that will be executed'''
+    if smoke_mode is None:
+        smoke_mode = os.environ.get('NAKO_SELENIUM_MODE') == 'smoke'
+    files = glob.glob(os.path.join(test_target, '*.nako3'))
+    if smoke_mode:
+        files = [fname for fname in files if os.path.basename(fname) not in SMOKE_SKIP_FILES]
+    return sorted(files)
 
 def run_test_all():
     '''test all'''
-    for fname in glob.glob(os.path.join(TEST_TARGET, '*.nako3')):
-        if os.environ.get('NAKO_SELENIUM_MODE') == 'smoke' and os.path.basename(fname) in SMOKE_SKIP_FILES:
-            continue
+    files = collect_test_files()
+    for fname in files:
         run_test(fname)
+    return len(files)
 
 def run_test(fname):
     '''test one file'''
+    from selenium.webdriver.common.by import By
+
     with open(fname, 'r', encoding='utf-8') as file:
         code = file.read()
     code_u = urllib.parse.quote(code)
@@ -126,10 +144,11 @@ def run_test(fname):
             code_result += line[3:].strip() + '\n'
     code_result = code_result.strip()
     # drive server
-    driver.get(SERVER_SCRIPT + '?m=code&code=' + code_u)
+    browser = get_driver()
+    browser.get(SERVER_SCRIPT + '?m=code&code=' + code_u)
     time.sleep(1)
     # get result
-    result_elem = driver.find_element(By.CSS_SELECTOR, '#result')
+    result_elem = browser.find_element(By.CSS_SELECTOR, '#result')
     result = result_elem.get_attribute('value').strip()
     if compare_result(code_result, result):
         print('[ok]', os.path.basename(fname))
@@ -138,9 +157,13 @@ def run_test(fname):
         print('>>>', code_result, '!=', result)
         error_log.append({'file': fname, 'expect': code_result, 'real': result})
 
-def report_test():
+def report_test(executed_count):
     '''report file'''
-    driver.close()
+    if driver is not None:
+        driver.quit()
+    if executed_count == 0:
+        print('😭😭😭 実行されたSeleniumテストがありません 😭😭😭')
+        return 1
     if len(error_log) == 0:
         print('⭐⭐⭐ 全てのテストが成功しました ⭐⭐⭐')
         return 0
@@ -155,7 +178,8 @@ def report_test():
 
 if __name__ == '__main__':
     if len(sys.argv) <= 1:
-        run_test_all()
+        executed_count = run_test_all()
     else:
         run_test(os.path.join(TEST_TARGET, sys.argv[1]))
-    sys.exit(report_test())
+        executed_count = 1
+    sys.exit(report_test(executed_count))

--- a/test-browser/test/selenium/test_chrome_unit.py
+++ b/test-browser/test/selenium/test_chrome_unit.py
@@ -44,6 +44,12 @@ class SeleniumRunnerTest(unittest.TestCase):
             finally:
                 test_chrome.error_log[:] = original_errors
 
+    def test_result_shape_accepts_png_data_after_it_is_ready(self):
+        png_a = 'data:image/png;base64,iVBORw0KGgoAAA'
+        png_b = 'data:image/png;base64,iVBORw0KGgoBBB'
+        self.assertTrue(test_chrome.result_shape_ready(f'ok\n{png_a}', f'ok\n{png_b}'))
+        self.assertFalse(test_chrome.result_shape_ready(f'ok\n{png_a}', 'ok\n'))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test-browser/test/selenium/test_chrome_unit.py
+++ b/test-browser/test/selenium/test_chrome_unit.py
@@ -1,0 +1,34 @@
+'''Seleniumランナーのテスト列挙と空テスト検出を検証する。'''
+import contextlib
+import io
+import os
+import tempfile
+import unittest
+
+import test_chrome
+
+
+class SeleniumRunnerTest(unittest.TestCase):
+    def test_collect_test_files_skips_canvas_in_smoke_mode(self):
+        with tempfile.TemporaryDirectory() as test_target:
+            for filename in ('hello.nako3', 'canvas.nako3'):
+                open(os.path.join(test_target, filename), 'w', encoding='utf-8').close()
+
+            files = test_chrome.collect_test_files(test_target, smoke_mode=True)
+
+            self.assertEqual([os.path.join(test_target, 'hello.nako3')], files)
+
+    def test_empty_test_target_is_reported_as_failure(self):
+        with tempfile.TemporaryDirectory() as test_target:
+            self.assertEqual([], test_chrome.collect_test_files(test_target, smoke_mode=False))
+
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            status = test_chrome.report_test(0)
+
+        self.assertEqual(1, status)
+        self.assertIn('実行されたSeleniumテストがありません', output.getvalue())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test-browser/test/selenium/test_chrome_unit.py
+++ b/test-browser/test/selenium/test_chrome_unit.py
@@ -29,6 +29,21 @@ class SeleniumRunnerTest(unittest.TestCase):
         self.assertEqual(1, status)
         self.assertIn('実行されたSeleniumテストがありません', output.getvalue())
 
+    def test_file_without_expected_result_is_reported_as_failure(self):
+        with tempfile.TemporaryDirectory() as test_target:
+            filename = os.path.join(test_target, 'no_expectation.nako3')
+            with open(filename, 'w', encoding='utf-8') as test_file:
+                test_file.write('「表示だけ」と表示')
+
+            original_errors = list(test_chrome.error_log)
+            try:
+                test_chrome.error_log.clear()
+                test_chrome.run_test(filename)
+                self.assertEqual(1, len(test_chrome.error_log))
+                self.assertEqual('期待値行なし', test_chrome.error_log[0]['real'])
+            finally:
+                test_chrome.error_log[:] = original_errors
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test-browser/test/selenium/test_chrome_unit.py
+++ b/test-browser/test/selenium/test_chrome_unit.py
@@ -50,6 +50,24 @@ class SeleniumRunnerTest(unittest.TestCase):
         self.assertTrue(test_chrome.result_shape_ready(f'ok\n{png_a}', f'ok\n{png_b}'))
         self.assertFalse(test_chrome.result_shape_ready(f'ok\n{png_a}', 'ok\n'))
 
+    def test_driver_quit_failure_is_reported(self):
+        class BrokenDriver:
+            def quit(self):
+                raise RuntimeError('quit failed')
+
+        original_driver = test_chrome.driver
+        original_errors = list(test_chrome.error_log)
+        try:
+            test_chrome.driver = BrokenDriver()
+            test_chrome.error_log.clear()
+            with contextlib.redirect_stdout(io.StringIO()):
+                status = test_chrome.report_test(1)
+            self.assertEqual(1, status)
+            self.assertIn('quit failed', test_chrome.error_log[0]['real'])
+        finally:
+            test_chrome.driver = original_driver
+            test_chrome.error_log[:] = original_errors
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## 概要

`test-browser` に集約されているブラウザテストを、GitHub ActionsのNode.js CIへ再接続します。

従来はブラウザテストの実行入口が存在していても、CIから呼び出されていませんでした。また、ブラウザ内のテスト件数が0件でも成功扱いになる可能性がありました。

Closes #1200

## 変更内容

- Node.js 24.xのCIでPlaywrightとChromiumを準備
- Browser、bundled、Ace Editorの各テストをCIで実行
- PythonとSeleniumの依存関係を準備し、Selenium smoke testを実行
- ブラウザ内のテスト件数が0件の場合は失敗させる
- smoke runnerが実際の実行件数を報告するよう修正
- Seleniumランナーのrelease参照先を修正
- CI接続が外れた場合に検出する設定テストを追加
- ブラウザテストのドキュメントを現在のCI構成に合わせて更新

## 検証

- 設定テスト: 12件成功
- Browser smokeと0件実行防止テスト: 成功
- Node.js 22.x / 24.xの通常CI: 成功
- PlaywrightによるBrowser、bundled、Ace Editorテスト: 成功
- Selenium smoke test: 成功

フォーク上の検証workflow:
https://github.com/soramikan/nadesiko3/actions/runs/33259752540

## 関連PRとの関係

本PRはmasterから独立しており、#2432および#2433への依存はありません。

両PRを積み上げた状態でも、Node.js 24.xの通常テスト、Playwright、Seleniumが成功することを確認しています:
https://github.com/soramikan/nadesiko3/actions/runs/33260042391
