### PR TITLE
ver3.8.1

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nadesiko3core",
-  "version": "3.7.25",
+  "version": "3.8.1",
   "description": "Japanese Programming Language Nadesiko v3 core",
   "main": "index.mjs",
   "type": "module",

--- a/core/src/nako_core_version.mts
+++ b/core/src/nako_core_version.mts
@@ -11,9 +11,9 @@ export interface NakoCoreVersion {
 }
 // 実際のバージョン定義 (自動生成されるので以下を編集しない)
 const coreVersion: NakoCoreVersion = {
-  version: '3.7.25',
+  version: '3.8.1',
   major: 3,
-  minor: 7,
-  patch: 25
+  minor: 8,
+  patch: 1
 }
 export default coreVersion

--- a/doc/release.md
+++ b/doc/release.md
@@ -1,10 +1,42 @@
-# なでしこv3のリリース手順
+# なでしこ3のリリース手順
 
-なでしこv3の最新版を、Webにアップするまでの備忘録です。いつも、手順飛ばしてしまうので、忘れないようにメモ。特に、npm publishの部分とか。
+なでしこ3の新しいバージョンを公開する手順をまとめます。以下の例では、公開するバージョンを`X.Y.Z`、関連するIssue番号を`ISSUE_NUMBER`と表記します。
 
-## 1.GitHubのリリース機能を使う
+## 1. リリース用のPRを作成
 
-ただし、リリース前（コミット前）には必ずビルドとテストを実行して、テストが成功するか確認する。
+最初に`master`を最新にし、作業ツリーに別の変更がないことを確認します。
+
+```sh
+git switch master
+git pull --ff-only origin master
+git status --short
+git switch -c verX_Y_Z
+```
+
+ルートの`package.json`にある`version`を`X.Y.Z`へ変更します。その後、リリース用ファイルを生成します。
+
+```sh
+npm run build
+```
+
+`npm run build`によって、次の4ファイルのバージョンが同期されます。
+
+- `package.json`
+- `core/package.json`
+- `src/nako_version.mts`
+- `core/src/nako_core_version.mts`
+
+意図しないファイルが変更されていないことを確認します。
+
+```sh
+git status --short
+git diff --check
+git diff -- package.json core/package.json src/nako_version.mts core/src/nako_core_version.mts
+```
+
+## 2. ビルドとテスト
+
+リリース前には、必ずビルドとテストを実行します。
 
 ```sh
 npm run build
@@ -12,75 +44,80 @@ npm test
 npm run test:all
 ```
 
-## 2.ファイルのビルドについて
-
-リリース用にesbuildでパックしたソースを生成する(/releaseに生成物が作られる)。
+すべて成功したら、対象ファイルだけを明示してコミットします。リリースに無関係なファイルは含めないでください。
 
 ```sh
+git add package.json core/package.json src/nako_version.mts core/src/nako_core_version.mts
+git commit -m "verX.Y.Z"
+git push -u origin verX_Y_Z
+```
+
+`master`向けのPRを作成します。PRの本文には、必ず関連するIssue番号を記載します。
+
+```sh
+gh pr create \
+  --base master \
+  --head verX_Y_Z \
+  --title "verX.Y.Z" \
+  --body "verX.Y.Z
+
+Refs #ISSUE_NUMBER"
+```
+
+PRでは、差分が意図したファイルだけであることと、CIがすべて成功したことを確認してからマージします。
+
+## 3. GitHub Releaseを作成
+
+PRをマージしたら、[GitHubのReleases](https://github.com/kujirahand/nadesiko3/releases)で`vX.Y.Z`のリリースを作成します。変更点と関連Issueをリリースノートに記載します。
+
+## 4. npmへ公開
+
+`master`を最新にし、`package.json`のバージョンとテスト結果を再確認してから公開します。
+
+```sh
+git switch master
+git pull --ff-only origin master
 npm run build
-```
-
-自動生成されるファイルを削除する場合には、以下のコマンドを実行する。
-
-```sh
-npm run clean
-```
-
-
-必要に応じて対応ブラウザを更新する。
-(以前は`npm run build`に含めていた。しかし、OSによって異なる値を出力するため手動に変更した。 #1211)
-
-```sh
-npm run build:browsers
-```
-
-## 3.npmにpublish
-
-package.jsonのバージョン番号を更新したことを確認する。npm publishでnpmに公開する。
-
-```sh
+npm test
 npm publish
 ```
 
-## 4.Webにアップロード
+公開後、npm上のバージョンを確認します。
 
-Webの簡易エディタを最新版に更新する。
+```sh
+npm view nadesiko3 version
+```
+
+## 5. Webサイトを更新
+
+Webの簡易エディタを最新版に更新します。
 
 - [なでしこ3のサイト](https://nadesi.com/doc3/)
 - [マニュアル](https://nadesi.com/doc3/)
 - [貯蔵庫](https://n3s.nadesi.com/)
 
-## 5.Windowsバイナリ版のアップロード
+必要に応じて対応ブラウザを更新します。`npm run build:browsers`はOSによって異なる値を生成するため、通常のビルドには含まれていません（#1211）。
 
-Windows用のリポジトリ生成のためにファイルをnadesiko3win32へコピーする。ただし、事前準備として、 `git clone` でnadesiko3win32のリポジトリを取得しておく必要がある。
+```sh
+npm run build:browsers
+```
+
+## 6. Windowsバイナリ版を更新
+
+Windows用リポジトリを生成するため、ファイルを`nadesiko3win32`へコピーします。事前に同リポジトリを隣のディレクトリへcloneしておきます。
 
 ```sh
 npm run build:win32
 bash ./win32.bash
-```
-
-nadesiko3win32のフォルダに移動。
-
-```sh
 cd ../nadesiko3win32
 ```
 
-なお、Windowsで実行してモジュールの最新版を取得。
+Windowsで依存モジュールを更新し、7-Zipで固めます。
 
-```sh
+```bat
 nodejs\npm install --production
 nodejs\npm audit fix
+bin\7z -mx=9 a node_modules.7z node_modules
 ```
 
-次に、7zipでモジュールを固める。
-
-```sh
-bin\7z  -mx=9 a node_modules.7z node_modules
-```
-
-最後にGitへアップする。
-
-```sh
-git commit -a
-git push
-```
+生成内容を確認してから、`nadesiko3win32`リポジトリへコミットしてpushします。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nadesiko3",
-  "version": "3.7.25",
+  "version": "3.8.1",
   "description": "Japanese Programming Language",
   "type": "module",
   "main": "src/index.mjs",

--- a/src/nako_version.mts
+++ b/src/nako_version.mts
@@ -11,9 +11,9 @@ export interface NakoVersion {
 }
 // 実際のバージョン定義 (自動生成されるので以下を編集しない)
 const nakoVersion: NakoVersion = {
-  version: '3.7.25',
+  version: '3.8.1',
   major: 3,
-  minor: 7,
-  patch: 25
+  minor: 8,
+  patch: 1
 }
 export default nakoVersion


### PR DESCRIPTION
## 概要

- なでしこ3とコアのバージョンを3.8.1へ更新
- `doc/release.md`にリリース用PR、GitHub Release、npm公開、Web・Windows版更新の手順を集約

## テスト

- `npm run build`
- `npm test`
- `npm run test:async`
- `npm run test:e`

## 関連Issue

Refs #2104, #2234, #2436, #1332, #1334, #1200