### PR TITLE
字句解析で助詞「もの〜」の正規化順序を統一 (#2453)

### DIFF
--- a/core/src/nako_josi_list.mts
+++ b/core/src/nako_josi_list.mts
@@ -40,6 +40,22 @@ removeJosiList.forEach(josi => {
 })
 
 // 「もの」構文 (#1614)
+/**
+ * 助詞を正規化する
+ * 「もの」構文の除去 (#1614) を行ってから、意味のない助詞の削除 (#936 #939 #974) を行う (#2453)。
+ */
+export function normalizeJosi (josi: string): string {
+  // 「もの」構文 (#1614)
+  if (josi.substring(0, 2) === 'もの') {
+    josi = josi.substring(2)
+  }
+  // 助詞「こと」「である」「です」などは「＊＊すること」のように使うので削除 #936 #939 #974
+  if (removeJosiMap[josi]) {
+    josi = ''
+  }
+  return josi
+}
+
 const josiListMono = []
 for (const jo of josiList) {
   josiListMono.push('もの' + jo)

--- a/core/src/nako_lex_rules.mts
+++ b/core/src/nako_lex_rules.mts
@@ -3,7 +3,7 @@
  * なでしこ3字句解析のためのルール
  */
 
-import { josiRE, removeJosiMap } from './nako_josi_list.mjs'
+import { josiRE, normalizeJosi } from './nako_josi_list.mjs'
 import { TokenType } from './nako_token.mjs'
 
 const kanakanji = /^[\u3005\u4E00-\u9FCF_a-zA-Z0-9ァ-ヶー\u2460-\u24FF\u2776-\u277F\u3251-\u32BF]+/
@@ -226,12 +226,8 @@ function cbWordParser(src: string, isTrimOkurigana = true): NakoLexParseResult {
     josi = ''
     res = res.substring(0, res.length - ii[1].length)
   }
-  // 「もの」構文 #1614
-  if (josi.substring(0, 2) === 'もの') {
-    josi = josi.substring(2)
-  }
-  // 助詞「こと」「である」「です」などは「＊＊すること」のように使うので削除 #936 #939 #974
-  if (removeJosiMap[josi]) { josi = '' }
+  // 助詞の正規化 #1614 #936 #939 #974 #2453
+  josi = normalizeJosi(josi)
 
   // 送り仮名の省略ルール
   // 漢字カタカナ英語から始まる語句 --- 送り仮名を省略
@@ -276,12 +272,8 @@ function cbString(beginTag: string, closeTag: string, src: string): NakoLexParse
     // 助詞の後のカンマ #877
     if (src.charAt(0) === ',') { src = src.substring(1) }
   }
-  // 助詞「こと」「である」「です」などは「＊＊すること」のように使うので削除 #936 #939 #974
-  if (removeJosiMap[josi]) { josi = '' }
-  // 「もの」構文 (#1614)
-  if (josi.substring(0, 2) === 'もの') {
-    josi = josi.substring(2)
-  }
+  // 助詞の正規化 #1614 #936 #939 #974 #2453
+  josi = normalizeJosi(josi)
 
   // 改行を数える
   for (let i = 0; i < res.length; i++) { if (res.charAt(i) === '\n') { numEOL++ } }

--- a/core/src/nako_lexer.mts
+++ b/core/src/nako_lexer.mts
@@ -11,7 +11,7 @@ import { NakoLogger } from './nako_logger.mjs'
 import { isIndentChars } from './nako_indent_chars.mjs'
 
 // 助詞の一覧
-import { josiRE, removeJosiMap, tararebaMap, josiListExport } from './nako_josi_list.mjs'
+import { josiRE, normalizeJosi, tararebaMap, josiListExport } from './nako_josi_list.mjs'
 
 // 字句解析ルールの一覧
 import { rules, unitRE, cssUnitRE, NakoLexParseResult } from './nako_lex_rules.mjs'
@@ -712,12 +712,8 @@ export class NakoLexer {
             if (src.charAt(0) === ',') {
               src = src.substring(1)
             }
-            // 「＊＊である」なら削除 #939 #974
-            if (removeJosiMap[josi]) { josi = '' }
-            // 「もの」構文 (#1614)
-            if (josi.substring(0, 2) === 'もの') {
-              josi = josi.substring(2)
-            }
+            // 助詞の正規化 #1614 #936 #939 #974 #2453
+            josi = normalizeJosi(josi)
           }
         }
 

--- a/core/test/lex_test.mjs
+++ b/core/test/lex_test.mjs
@@ -175,4 +175,34 @@ describe('lex_test', async () => {
   it('絵文字の四則演算を認識する #1183', async () => {
     await cmp('リンゴ🟰3✖5;ミカン🟰9➗3;リンゴ+ミカンを表示', '18')
   })
+  it('助詞「もの〜」の正規化順序テスト #2453', () => {
+    const nako = new NakoCompiler()
+    // 単語
+    const tWord = nako.lex('Aものである').tokens
+    assert.strictEqual(tWord[0].type, 'word')
+    assert.strictEqual(tWord[0].josi, '')
+
+    // 文字列
+    const tStr = nako.lex('「あ」ものである').tokens
+    assert.strictEqual(tStr[0].type, 'string')
+    assert.strictEqual(tStr[0].josi, '')
+
+    // 数値
+    const tNum = nako.lex('100ものである').tokens
+    assert.strictEqual(tNum[0].type, 'number')
+    assert.strictEqual(tNum[0].josi, '')
+
+    // 意味のない助詞（こと、である、です、します、でした、にゃん）との組み合わせで全て空文字になること
+    const meaninglessJosiList = ['こと', 'である', 'です', 'します', 'でした', 'にゃん']
+    for (const j of meaninglessJosiList) {
+      assert.strictEqual(nako.lex(`Aもの${j}`).tokens[0].josi, '')
+      assert.strictEqual(nako.lex(`「あ」もの${j}`).tokens[0].josi, '')
+      assert.strictEqual(nako.lex(`100もの${j}`).tokens[0].josi, '')
+    }
+
+    // 「もの」＋通常の助詞の場合は「もの」が除去され助詞が残ること
+    assert.strictEqual(nako.lex('Aものから').tokens[0].josi, 'から')
+    assert.strictEqual(nako.lex('「あ」ものから').tokens[0].josi, 'から')
+    assert.strictEqual(nako.lex('100ものから').tokens[0].josi, 'から')
+  })
 })


### PR DESCRIPTION
Fixes #2453

## 概要
字句解析における助詞正規化処理において、「もの」構文の除去 (#1614) と意味のない助詞の削除 (#936 #939 #974) の順序が `cbWordParser` と `cbString` / `NakoLexer.tokenize` の間で食い違っていた問題を修正しました。

共通関数 `normalizeJosi` を `core/src/nako_josi_list.mts` に定義し、単語・文字列・数値や括弧等の助詞読み取り部すべてで同じ順序（「もの」除去後に不要な助詞を削除）で正規化されるように統一しました。

## 変更点
- `core/src/nako_josi_list.mts`: `normalizeJosi` 関数を追加・エクスポート
- `core/src/nako_lex_rules.mts`: `cbWordParser` および `cbString` で `normalizeJosi` を利用するよう修正
- `core/src/nako_lexer.mts`: `tokenize` 内の `readJosi` 処理で `normalizeJosi` を利用するよう修正
- `core/test/lex_test.mjs`: 単語・文字列・数値における「もの〜」助詞の正規化テストを追加