### PR TITLE
CSV/TSV変換が入力の表を書き換えないよう修正 (#2475)

### DIFF
--- a/core/src/nako_csv.mts
+++ b/core/src/nako_csv.mts
@@ -17,8 +17,8 @@ export function resetEnv(): void {
   options.auto_convert_number = true
 }
 
-/// 文字列が数値化どうか判定する関数
- 
+/** 文字列が数値かどうか判定する関数 */
+
 function is_numeric(str: string): boolean {
   return /^-?\d+(\.\d+)?([eE][-+]?\d+)?$/.test(str)
 }
@@ -149,7 +149,8 @@ export function parse(txt: string, delimiter: string|undefined = undefined): (st
 }
 
 // convert 2D array to CSV string
-export function stringify(ary: string[][], delimiter: string|undefined = undefined, eol: string|undefined = undefined): string {
+export function stringify(ary: (string|number)[][]|undefined, delimiter: string|undefined = undefined, eol: string|undefined = undefined): string {
+  if (ary === undefined) return ''
   // check arguments
   if (delimiter === undefined) {
     delimiter = options.delimiter
@@ -158,17 +159,15 @@ export function stringify(ary: string[][], delimiter: string|undefined = undefin
     eol = options.eol
   }
   const valueConv = genValueConverter(delimiter)
-  if (ary === undefined) return ''
   let r = ''
   for (let i = 0; i < ary.length; i++) {
     const cells = ary[i]
     if (cells === undefined) {
       r += eol; continue
     }
-    for (let j = 0; j < cells.length; j++) {
-      cells[j] = valueConv(cells[j])
-    }
-    r += cells.join(delimiter) + eol
+    // map では疎配列の穴がスキップされるため Array.from を使用する（元配列は書き換えない）
+    const converted = Array.from(cells, valueConv)
+    r += converted.join(delimiter) + eol
   }
   // replace return code
   r = r.replace(/(\r\n|\r|\n)/g, eol)
@@ -182,17 +181,17 @@ export function replaceEolMark(eol: string): string {
   return eol
 }
 
-function genValueConverter(delimiter: string) {
-  return function(s: string) {
-    s = '' + s
-    let fQuot = false
-    if (s.indexOf('\n') >= 0 || s.indexOf('\r') >= 0) { fQuot = true }
-    if (s.indexOf(delimiter) >= 0) { fQuot = true }
-    if (s.indexOf('"') >= 0) {
-      fQuot = true
-      s = s.replace(/"/g, '""')
+function genValueConverter(delimiter: string): (s: string|number|undefined) => string {
+  return function(s: string|number|undefined) {
+    let v = '' + s
+    let needsQuote = false
+    if (v.indexOf('\n') >= 0 || v.indexOf('\r') >= 0) { needsQuote = true }
+    if (v.indexOf(delimiter) >= 0) { needsQuote = true }
+    if (v.indexOf('"') >= 0) {
+      needsQuote = true
+      v = v.replace(/"/g, '""')
     }
-    if (fQuot) s = '"' + s + '"'
-    return s
+    if (needsQuote) v = '"' + v + '"'
+    return v
   }
 }

--- a/core/test/plugin_csv_test.mjs
+++ b/core/test/plugin_csv_test.mjs
@@ -1,7 +1,16 @@
 /* eslint-disable no-undef */
-import { describe, it } from 'node:test'
+import { beforeEach, describe, it } from 'node:test'
 import assert from 'assert'
 import { NakoCompiler } from '../src/nako3.mjs'
+import { stringify, resetEnv } from '../src/nako_csv.mjs'
+
+/** 密な2次元配列を stringify し、結果と、入力の表が書き換わらないこと・反復変換の安定性を検証する */
+const assertStringify = (/** @type {(string|number)[][]} */ ary, /** @type {string} */ expected, /** @type {string|undefined} */ delimiter = undefined) => {
+  const before = ary.map((row) => [...row])
+  assert.strictEqual(stringify(ary, delimiter), expected)
+  assert.deepStrictEqual(ary, before, '入力の表が書き換えられていない')
+  assert.strictEqual(stringify(ary, delimiter), expected, '反復変換で結果が変わらない')
+}
 
 // eslint-disable-next-line no-undef
 describe('plugin_csv_test', () => {
@@ -11,6 +20,9 @@ describe('plugin_csv_test', () => {
     const g = await nako.runAsync(code)
     assert.strictEqual(g.log, res)
   }
+
+  // グローバルオプション(options)の状態がテスト順序に依存しないよう初期化する
+  beforeEach(() => { resetEnv() })
 
   // --- test ---
   it('CSV取得', async () => {
@@ -46,8 +58,52 @@ describe('plugin_csv_test', () => {
     await cmp('a=「3.14,200,300\n4,5,6」のCSV取得。TYPEOF(a[0][0])を表示', 'number')
     await cmp('a=「2010.1.5,200,300\n4,5,6」のCSV取得。TYPEOF(a[0][0])を表示', 'string')
   })
-  it('「2024.01.01」のような日付形式が実数として誤判定する #1910', async () => {
+  it('「2024.01.01」のような日付形式が実数として誤判定する #1910（auto_convert_numberをOFF）', async () => {
     await cmp('{"auto_convert_number": FALSE}をCSVオプション設定;a=「2024.01,200,300\n4,5,6」のCSV取得。TYPEOF(a[0][0])を表示', 'string')
     await cmp('{"auto_convert_number": FALSE}をCSVオプション設定;a=「2024.01,200,300\n4,5,6」のCSV取得。a[0][0]を表示', '2024.01')
+  })
+  it('CSV/TSV変換が入力の表を書き換えない #2475', async () => {
+    // 変換しても元の表が変化しない
+    await cmp('A=[["a,b"]]。AをCSV変換。AをJSONエンコードして表示', '[["a,b"]]')
+    await cmp('A=[["a,b"]]。Aを表CSV変換。AをJSONエンコードして表示', '[["a,b"]]')
+    await cmp('A=[["a\tb"]]。AをTSV変換。AをJSONエンコードして表示', '[["a\\tb"]]')
+    await cmp('A=[["a\tb"]]。Aを表TSV変換。AをJSONエンコードして表示', '[["a\\tb"]]')
+    // 引用符を含むセル
+    await cmp('A=[[「a"b」]]。AをCSV変換。AをJSONエンコードして表示', '[["a\\"b"]]')
+    await cmp('A=[[「a"b」]]。Aを表CSV変換。AをJSONエンコードして表示', '[["a\\"b"]]')
+    await cmp('A=[[「a"b」]]。AをTSV変換。AをJSONエンコードして表示', '[["a\\"b"]]')
+    await cmp('A=[[「a"b」]]。Aを表TSV変換。AをJSONエンコードして表示', '[["a\\"b"]]')
+    // 2回変換しても結果が変わらない
+    await cmp('A=[["a,b"]]。AをCSV変換。AをCSV変換して表示', '"a,b"')
+    await cmp('A=[["a,b"]]。Aを表CSV変換。Aを表CSV変換して表示', '"a,b"')
+    await cmp('A=[[「a"b」]]。AをCSV変換。AをCSV変換して表示', '"a""b"')
+    await cmp('A=[["a\tb"]]。AをTSV変換。AをTSV変換して表示', '"a\tb"')
+    await cmp('A=[["a\tb"]]。Aを表TSV変換。Aを表TSV変換して表示', '"a\tb"')
+  })
+  it('stringifyは入力の表を書き換えず、反復変換しても結果が変わらない #2475', () => {
+    // 引用符を含むセル
+    assertStringify([['a"b']], '"a""b"\r\n')
+    // 区切り文字を含むセル
+    assertStringify([['a,b']], '"a,b"\r\n')
+    // 改行を含むセル
+    assertStringify([['a\nb']], '"a\r\nb"\r\n')
+    // 空セル
+    assertStringify([['', 'a']], ',a\r\n')
+    // 数値セル
+    assertStringify([[1, 2.5]], '1,2.5\r\n')
+    // 引用符・改行・区切り文字が混在するセル
+    assertStringify([['a,"b\nc', 'x']], '"a,""b\r\nc",x\r\n')
+    // TSV区切り
+    assertStringify([['a\tb']], '"a\tb"\r\n', '\t')
+    // 疎配列の穴は従来どおり 'undefined' として変換され、入力は書き換わらない
+    const sparseRow = []
+    sparseRow[1] = 'b'
+    assert.strictEqual(stringify([sparseRow], ','), 'undefined,b\r\n')
+    assert.strictEqual(0 in sparseRow, false, '入力の表が書き換えられていない')
+    assert.strictEqual(stringify([sparseRow], ','), 'undefined,b\r\n', '反復変換で結果が変わらない')
+    // 引数が undefined のときは空文字列を返す
+    assert.strictEqual(stringify(undefined), '')
+    // 空配列
+    assertStringify([], '')
   })
 })


### PR DESCRIPTION
## 概要

`CSV変換` / `表CSV変換` / `TSV変換` / `表TSV変換` のシリアライズが、変換対象のセルを書き換えていました。同じ表を2回変換すると引用符が累積して増える問題（#2475）を修正します。

```nako3
A=[["a,b"]]
AをCSV変換して表示。      # "a,b"
AをJSONエンコードして表示。 # 修正前: [["\"a,b\""]] / 修正後: [["a,b"]]
```

Close #2475 

## 原因

`core/src/nako_csv.mts` の `stringify()` が、入力行 `cells` を直接上書き（`cells[j] = valueConv(cells[j])`）していたため、1回目の変換で元のセルが引用符付き文字列へ書き換わっていました。

## 修正内容

- `stringify()` で変換用の新規配列を作成し、入力の表を書き換えないようにしました。
  - `Array.from(cells, valueConv)` を使用（`map` では疎配列の穴がスキップされるため）。
  - 疎配列の穴は従来どおり `'undefined'` として出力され、入力側は書き換わりません。
- 型注釈を実行時の実態に合わせて更新:
  - `stringify(ary: (string|number)[][]|undefined)`
  - `valueConv: (s: string|number|undefined) => string`

## テスト

`core/test/plugin_csv_test.mjs` に回帰テストを追加しました。

- 4命令（`CSV変換`/`表CSV変換`/`TSV変換`/`表TSV変換`）で「入力の表が書き換わらない」「2回変換しても結果が変わらない」ことを検証
- `stringify` 単体で空セル・引用符・改行・数値・区切り文字・引用符+改行+区切り文字の混在・TSV区切り・疎配列・`undefined` 引数・空配列・反復変換の安定性を検証
- テストのグローバルオプション順序依存を避けるため `beforeEach(resetEnv)` を導入

## 検証

- `npm run test:core` … 全1188件パス
- `npm run eslint` … 今回の変更による新規警告なし
- `tsc` … 変更箇所に関する型エラーなし