### PR TITLE
一時フォルダ作成を指定フォルダの配下に作成するよう修正 (#2490)

### DIFF
--- a/doc/command_list.json
+++ b/doc/command_list.json
@@ -10928,7 +10928,7 @@
     ],
     "category": "フォルダ取得",
     "url": "https://github.com/kujirahand/nadesiko3/tree/master/src/plugin_node.mts#L945",
-    "description": "指定のフォルダに作業用の一時フォルダを作成して取得して返す"
+    "description": "指定のフォルダ(省略または空白時はOSのテンポラリフォルダ)の配下に作業用の一時フォルダを作成して取得して返す"
   },
   {
     "type": "関数",

--- a/src/plugin_node.mts
+++ b/src/plugin_node.mts
@@ -938,16 +938,20 @@ export default {
       return os.tmpdir()
     }
   },
-  '一時フォルダ作成': { // @指定のフォルダに作業用の一時フォルダを作成して取得して返す // @いちじふぉるださくせい
+  '一時フォルダ作成': { // @指定のフォルダ(省略または空白時はOSのテンポラリフォルダ)の配下に作業用の一時フォルダを作成して取得して返す // @いちじふぉるださくせい
     type: 'func',
     josi: [['に', 'へ']],
     pure: true,
     fn: function(dir: string, _sys: NakoSystem) {
-      if (dir === '' || !dir) {
+      // 空白のみの指定は既定(OSのテンポラリフォルダ)として扱う
+      if (typeof dir !== 'string' || dir.trim() === '') {
         dir = os.tmpdir()
+      } else {
+        dir = dir.trim()
       }
-      // 環境変数からテンポラリフォルダを取得
-      return fs.mkdtempSync(dir)
+      // fs.mkdtempSyncの引数は「親ディレクトリ」ではなく「作成する名前のprefix」であるため、
+      // 指定したフォルダの配下に作成されるようprefixを組み立てる
+      return fs.mkdtempSync(path.join(dir, 'nako-'))
     }
   },
   // @環境変数

--- a/test/node/plugin_node_test.mjs
+++ b/test/node/plugin_node_test.mjs
@@ -16,17 +16,6 @@ const __filename = url.fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 const testFileMe = path.join(__dirname, 'plugin_node_test.mjs')
 
-async function cmp(/** @type {string} */code, /** @type {string} */res, /** @type {number} */ms=10) {
-  // (原則) EvalやFunctionの中で行う非同期処理は、その中で行うこと！
-  // @see https://qiita.com/kujirahand/items/880917172bb0de8d30b9
-  const nako = new NakoCompiler()
-  nako.addPluginFile('PluginNode', 'plugin_node.js', PluginNode)
-  nako.addPluginFile('PluginCSV', 'plugin_csv.js', PluginCSV)
-  const g = await nako.runAsync(code, 'main')
-  await forceWait(ms)
-  assert.strictEqual(g.log, res) // 強制的に指定ミリ秒待つ
-  return g
-}
 // 強制的にミリ秒待機
 function forceWait(/** @type {number} */ms) {
   return /** @type {Promise<void>} */(new Promise((resolve, reject) => {
@@ -34,11 +23,26 @@ function forceWait(/** @type {number} */ms) {
   }));
 }
 
-const cmd = async (/** @type {string} */ code) => {
+// コードを実行して実行結果(g)を返す
+async function run(/** @type {string} */code, /** @type {number} */ms=10) {
+  // (原則) EvalやFunctionの中で行う非同期処理は、その中で行うこと！
+  // @see https://qiita.com/kujirahand/items/880917172bb0de8d30b9
   const nako = new NakoCompiler()
   nako.addPluginFile('PluginNode', 'plugin_node.js', PluginNode)
   nako.addPluginFile('PluginCSV', 'plugin_csv.js', PluginCSV)
-  await nako.runAsync(code, 'main')
+  const g = await nako.runAsync(code, 'main')
+  await forceWait(ms)
+  return g
+}
+
+async function cmp(/** @type {string} */code, /** @type {string} */res, /** @type {number} */ms=10) {
+  const g = await run(code, ms)
+  assert.strictEqual(g.log, res)
+  return g
+}
+
+const cmd = async (/** @type {string} */ code) => {
+  await run(code)
 }
 function get7zPath() {
   if (process.platform === 'linux') { // Linuxならパスを調べる
@@ -59,16 +63,6 @@ function get7zPath() {
 
 function makeTmpDir(/** @type {string} */prefix) {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix))
-}
-
-// コードを実行して表示結果(文字列)を返す
-async function run(/** @type {string} */code, /** @type {number} */ms=10) {
-  const nako = new NakoCompiler()
-  nako.addPluginFile('PluginNode', 'plugin_node.js', PluginNode)
-  nako.addPluginFile('PluginCSV', 'plugin_csv.js', PluginCSV)
-  const g = await nako.runAsync(code, 'main')
-  await forceWait(ms)
-  return g.log
 }
 
 describe('plugin_node_test', () => {
@@ -135,29 +129,29 @@ describe('plugin_node_test', () => {
       // 指定したフォルダの配下に作成されること (#2490)
       const base = makeTmpDir('nako3-ichiji-')
       created.push(base)
-      let result = await run(`「${base}」へ一時フォルダ作成して表示。`)
+      let result = (await run(`「${base}」へ一時フォルダ作成して表示。`)).log
       created.push(result)
       assert.ok(fs.existsSync(result), `作成されたフォルダが存在する: ${result}`)
       assert.ok(fs.statSync(result).isDirectory(), `作成されたのはフォルダ: ${result}`)
       assert.ok(path.basename(result).startsWith('nako-'), `作成名のprefixはnako-: ${result}`)
       assert.strictEqual(fs.realpathSync(path.dirname(result)), fs.realpathSync(base))
       // 末尾に区切り文字があっても同じフォルダの配下に作成されること
-      result = await run(`「${base}${path.sep}」へ一時フォルダ作成して表示。`)
+      result = (await run(`「${base}${path.sep}」へ一時フォルダ作成して表示。`)).log
       created.push(result)
       assert.ok(fs.existsSync(result), `作成されたフォルダが存在する: ${result}`)
       assert.strictEqual(fs.realpathSync(path.dirname(result)), fs.realpathSync(base))
       // 引数を省略した場合はOSのテンポラリフォルダの配下に作成されること
-      result = await run('一時フォルダ作成して表示。')
+      result = (await run('一時フォルダ作成して表示。')).log
       created.push(result)
       assert.ok(fs.existsSync(result), `作成されたフォルダが存在する: ${result}`)
       assert.strictEqual(fs.realpathSync(path.dirname(result)), fs.realpathSync(os.tmpdir()))
       // 空白だけのパスは既定(OSのテンポラリフォルダ)として扱うこと
-      result = await run('「   」へ一時フォルダ作成して表示。')
+      result = (await run('「   」へ一時フォルダ作成して表示。')).log
       created.push(result)
       assert.ok(fs.existsSync(result), `作成されたフォルダが存在する: ${result}`)
       assert.strictEqual(fs.realpathSync(path.dirname(result)), fs.realpathSync(os.tmpdir()))
       // 前後に空白があるパスは空白を除いて扱うこと
-      result = await run(`「  ${base}  」へ一時フォルダ作成して表示。`)
+      result = (await run(`「  ${base}  」へ一時フォルダ作成して表示。`)).log
       created.push(result)
       assert.ok(fs.existsSync(result), `作成されたフォルダが存在する: ${result}`)
       assert.strictEqual(fs.realpathSync(path.dirname(result)), fs.realpathSync(base))

--- a/test/node/plugin_node_test.mjs
+++ b/test/node/plugin_node_test.mjs
@@ -61,6 +61,16 @@ function makeTmpDir(/** @type {string} */prefix) {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix))
 }
 
+// コードを実行して表示結果(文字列)を返す
+async function run(/** @type {string} */code, /** @type {number} */ms=10) {
+  const nako = new NakoCompiler()
+  nako.addPluginFile('PluginNode', 'plugin_node.js', PluginNode)
+  nako.addPluginFile('PluginCSV', 'plugin_csv.js', PluginCSV)
+  const g = await nako.runAsync(code, 'main')
+  await forceWait(ms)
+  return g.log
+}
+
 describe('plugin_node_test', () => {
   // --- test ---
   it('表示', async () => {
@@ -119,25 +129,71 @@ describe('plugin_node_test', () => {
     await cmp('F=「{テンポラリフォルダ}/test.txt」;「abc」をFに保存。S=Fを読む。Sを表示。', 'abc', 100)
     // await cmp('F=「{テンポラリフォルダ}/test.txt」;「abc」をFに保存。Fを読んでトリムして表示。', 'abc')
   })
+  it('一時フォルダ作成', async () => {
+    const created = []
+    try {
+      // 指定したフォルダの配下に作成されること (#2490)
+      const base = makeTmpDir('nako3-ichiji-')
+      created.push(base)
+      let result = await run(`「${base}」へ一時フォルダ作成して表示。`)
+      created.push(result)
+      assert.ok(fs.existsSync(result), `作成されたフォルダが存在する: ${result}`)
+      assert.ok(fs.statSync(result).isDirectory(), `作成されたのはフォルダ: ${result}`)
+      assert.ok(path.basename(result).startsWith('nako-'), `作成名のprefixはnako-: ${result}`)
+      assert.strictEqual(fs.realpathSync(path.dirname(result)), fs.realpathSync(base))
+      // 末尾に区切り文字があっても同じフォルダの配下に作成されること
+      result = await run(`「${base}${path.sep}」へ一時フォルダ作成して表示。`)
+      created.push(result)
+      assert.ok(fs.existsSync(result), `作成されたフォルダが存在する: ${result}`)
+      assert.strictEqual(fs.realpathSync(path.dirname(result)), fs.realpathSync(base))
+      // 引数を省略した場合はOSのテンポラリフォルダの配下に作成されること
+      result = await run('一時フォルダ作成して表示。')
+      created.push(result)
+      assert.ok(fs.existsSync(result), `作成されたフォルダが存在する: ${result}`)
+      assert.strictEqual(fs.realpathSync(path.dirname(result)), fs.realpathSync(os.tmpdir()))
+      // 空白だけのパスは既定(OSのテンポラリフォルダ)として扱うこと
+      result = await run('「   」へ一時フォルダ作成して表示。')
+      created.push(result)
+      assert.ok(fs.existsSync(result), `作成されたフォルダが存在する: ${result}`)
+      assert.strictEqual(fs.realpathSync(path.dirname(result)), fs.realpathSync(os.tmpdir()))
+      // 前後に空白があるパスは空白を除いて扱うこと
+      result = await run(`「  ${base}  」へ一時フォルダ作成して表示。`)
+      created.push(result)
+      assert.ok(fs.existsSync(result), `作成されたフォルダが存在する: ${result}`)
+      assert.strictEqual(fs.realpathSync(path.dirname(result)), fs.realpathSync(base))
+      // 指定したフォルダが存在しない場合はエラーになること
+      const missing = path.join(base, 'not-exist')
+      await assert.rejects(
+        async () => { await run(`「${missing}」へ一時フォルダ作成して表示。`) },
+        (err) => {
+          const msg = String(err.message)
+          assert.match(msg, /ENOENT|no such file or directory|mkdtemp/)
+          assert.ok(msg.includes(missing), `エラーメッセージに指定したパスが含まれる: ${msg}`)
+          return true
+        }
+      )
+    } finally {
+      for (const p of created) { fs.rmSync(p, { recursive: true, force: true }) }
+    }
+  })
   it('圧縮解凍', async function () {
     let path7z = get7zPath()
     if (path7z === '') { return this.skip() }
-    let tmp = '/tmp'
-    if (process.platform === 'linux') {
-      tmp = path.join(os.tmpdir(), 'nadesiko3test')
-    } else {
-      tmp = makeTmpDir('nadesiko3test-')
+    // 一時フォルダ作成は指定フォルダの配下に作成するため、予め存在するフォルダを渡す (#2490)
+    const tmp = makeTmpDir('nadesiko3test-')
+    try {
+      const code = 'FIN=「' + testFileMe + '」;' +
+        `TMP=「${tmp}」へ一時フォルダ作成。` +
+        '『' + path7z + '』に圧縮解凍ツールパス変更;' +
+        'FZIP=「{TMP}/test.zip」;\n' +
+        'FINをFZIPへ圧縮。FZIPを「{TMP}/」に解凍。\n' +
+        'S1=「{TMP}/plugin_node_test.mjs」を読む。\n' +
+        'S2=FINを読む。\n' +
+        'もし(S1＝S2)ならば、"OK"と表示。\n'
+      await cmp(code, 'OK', 300)
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
     }
-    const code = 'FIN=「' + testFileMe + '」;' +
-      `TMP=「${tmp}」へ一時フォルダ作成。` +
-      '『' + path7z + '』に圧縮解凍ツールパス変更;' +
-      'もし、TMPが存在しないならば、TMPのフォルダ作成。' +
-      'FZIP=「{TMP}/test.zip」;\n' +
-      'FINをFZIPへ圧縮。FZIPを「{TMP}/」に解凍。\n' +
-      'S1=「{TMP}/plugin_node_test.mjs」を読む。\n' +
-      'S2=FINを読む。\n' +
-      'もし(S1＝S2)ならば、"OK"と表示。\n'
-    await cmp(code, 'OK', 300)
   })
   it('圧縮/解凍', async function () {
     // 7zip がない環境ではテストを飛ばす


### PR DESCRIPTION
## 概要

`一時フォルダ作成` が、指定したフォルダの**兄弟**として `targetXXXXXX` を作成していました。`fs.mkdtempSync` の引数は「親ディレクトリ」ではなく「作成する名前の prefix」であるため、指定した `target` の配下に作成されませんでした。

```nako3
「target」へ一時フォルダ作成して表示。
# 修正前: targetと同じ階層に targetXXXXXX が作成される
# 修正後: targetの配下に target/nako-XXXXXX が作成される
```

Close #2490

## 原因

`src/plugin_node.mts` の `一時フォルダ作成` が、`fs.mkdtempSync(dir)` を直接呼び出していました。`fs.mkdtempSync` の第1引数は親ディレクトリではなく prefix であるため、`dir` をそのまま渡すと `dir` の配下ではなく `dirXXXXXX` という兄弟ディレクトリが作られていました。

## 修正内容

- `fs.mkdtempSync(path.join(dir, 'nako-'))` とし、指定したフォルダの配下に `nako-XXXXXX` を作成するようにしました。
- 引数が省略・空白のみ・非文字列の場合は、既定として OS のテンポラリフォルダ配下に作成します。
- 前後空白は `trim()` して扱います。

## テスト

`test/node/plugin_node_test.mjs` に回帰テストを追加しました。

- 指定したフォルダの配下に作成されること（`realpathSync` で比較）
- 末尾区切り文字（`path.sep`）があっても同じフォルダ配下に作成されること
- 引数省略時は OS のテンポラリフォルダ配下に作成されること
- 空白のみ・前後空白の扱い
- 存在しないフォルダを指定した場合はエラーになること
- 既存の `圧縮解凍` テストを新仕様（存在する親を渡す）に合わせて修正し、クリーンアップを追加

## 検証

- `npm run build:tsc` … 成功
- `npm run eslint` … 今回の変更による新規警告なし
- `test/node/plugin_node_test.mjs` … 27件パス / 0件失敗
