### PR TITLE
配列一括挿入の自己挿入で無限ループする問題を修正 (#2470)

### DIFF
--- a/core/src/plugin_system_array.mts
+++ b/core/src/plugin_system_array.mts
@@ -79,13 +79,21 @@ export default {
     type: 'func',
     josi: [['の'], ['に', 'へ'], ['を']],
     pure: true,
-    fn: function(a: any, i: number, b: any) {
+    fn: function(a: any, i: any, b: any) {
       if (a instanceof Array && b instanceof Array) { // 配列ならOK
-        for (let j = 0; j < b.length; j++) { a.splice(i + j, 0, b[j]) }
+        let pos = Number(i) // i が数値文字列でも i + j が文字列連結にならないようにする
+        if (Number.isNaN(pos)) { pos = 0 } // 数値に変換できない場合(「abc」等)は先頭に挿入する
+        // 自己挿入・別名参照でも無限ループしないよう、挿入元の要素列を先に固定する (#2470)
+        const n = b.length
+        const src = Array.from({ length: n })
+        for (let k = 0; k < n; k++) { src[k] = b[k] }
+        // i+j を splice ごとに再評価する既存仕様(負インデックスで結果が変わる)と
+        // 引数個数制限回避のため、要素ごとの splice を維持する
+        for (let j = 0; j < src.length; j++) { a.splice(pos + j, 0, src[j]) }
 
         return a
       }
-      throw new Error('『配列一括挿入』で配列以外の要素への挿入。')
+      throw new Error('『配列一括挿入』の引数が配列ではありません。')
     }
   },
   '配列ソート': { // @配列Aをソートして返す(A自体を変更) // @はいれつそーと

--- a/core/test/array_hang_test.mjs
+++ b/core/test/array_hang_test.mjs
@@ -1,0 +1,169 @@
+/* eslint-disable no-undef */
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+// 実行時に無限ループすると同期処理でイベントループが止まり、
+// node --test のタイムアウトでは検出できずテスト全体が固まってしまう。
+// そのため、子プロセスで実行してタイムアウトを監視する。(#2470)
+
+const testDir = path.dirname(fileURLToPath(import.meta.url))
+const nako3Url = pathToFileURL(path.join(testDir, '../src/nako3.mjs')).href
+
+const runnerScript =
+  'import { NakoCompiler } from ' + JSON.stringify(nako3Url) + '\n' +
+  'const nako = new NakoCompiler()\n' +
+  'try {\n' +
+  '  const res = await nako.runAsync(process.argv[1], \'main.nako3\')\n' +
+  '  process.stdout.write(String(res.log ?? \'\'))\n' +
+  '} catch (err) {\n' +
+  '  process.stderr.write(String(err?.msg ?? err?.message ?? err ?? \'Unknown error\'))\n' +
+  '  process.exitCode = 1\n' +
+  '}\n'
+
+/** 子プロセスでなでしこのコードを実行する */
+function runNako (code) {
+  const result = spawnSync(process.execPath, ['--input-type=module', '--eval', runnerScript, code], {
+    cwd: testDir,
+    encoding: 'utf8',
+    timeout: 10000,
+    killSignal: 'SIGKILL'
+  })
+  assert.notStrictEqual(result.error?.code, 'ETIMEDOUT', `実行がタイムアウトしました: ${code}`)
+  assert.ifError(result.error)
+  assert.strictEqual(result.signal, null, `プロセスがシグナルで終了しました: ${result.signal}`)
+  return result
+}
+
+describe('配列一括挿入の停止防止 (#2470)', () => {
+  it('挿入元と挿入先が同じ配列でも有限回で終了する', () => {
+    const result = runNako('A=[1]。Aの0にAを配列一括挿入。AをJSONエンコードして表示。')
+    assert.strictEqual(result.status, 0, result.stderr)
+    assert.strictEqual(result.stdout.trim(), '[1,1]')
+  })
+
+  it('自己挿入でも元の要素を固定長として挿入する', () => {
+    const result = runNako('A=[1,2]。Aの1にAを配列一括挿入。AをJSONエンコードして表示。')
+    assert.strictEqual(result.status, 0, result.stderr)
+    assert.strictEqual(result.stdout.trim(), '[1,1,2,2]')
+  })
+
+  it('別名参照(B=A)でも有限回で終了する', () => {
+    const result = runNako('A=[1]。B=A。Aの0にBを配列一括挿入。AをJSONエンコードして表示。')
+    assert.strictEqual(result.status, 0, result.stderr)
+    assert.strictEqual(result.stdout.trim(), '[1,1]')
+  })
+
+  it('先頭への複数要素の自己挿入も元の要素を固定長として挿入する', () => {
+    const result = runNako('A=[1,2]。Aの0にAを配列一括挿入。AをJSONエンコードして表示。')
+    assert.strictEqual(result.status, 0, result.stderr)
+    assert.strictEqual(result.stdout.trim(), '[1,2,1,2]')
+  })
+
+  it('末尾ちょうどの自己挿入も有限回で終了する', () => {
+    const result = runNako('A=[1]。Aの1にAを配列一括挿入。AをJSONエンコードして表示。')
+    assert.strictEqual(result.status, 0, result.stderr)
+    assert.strictEqual(result.stdout.trim(), '[1,1]')
+  })
+
+  it('範囲外の位置への自己挿入も有限回で終了する', () => {
+    const result = runNako('A=[1,2]。Aの5にAを配列一括挿入。AをJSONエンコードして表示。')
+    assert.strictEqual(result.status, 0, result.stderr)
+    assert.strictEqual(result.stdout.trim(), '[1,2,1,2]')
+  })
+
+  it('空配列の自己挿入は空のまま終了する', () => {
+    const result = runNako('A=[]。Aの0にAを配列一括挿入。AをJSONエンコードして表示。')
+    assert.strictEqual(result.status, 0, result.stderr)
+    assert.strictEqual(result.stdout.trim(), '[]')
+  })
+
+  it('挿入した要素は浅いコピーで参照を共有する', () => {
+    const result = runNako('A=[0]。B=[{"x":1}]。Aの0にBを配列一括挿入。A[0]$x=2。B[0]$xを表示。')
+    assert.strictEqual(result.status, 0, result.stderr)
+    assert.strictEqual(result.stdout.trim(), '2')
+  })
+
+  it('自己挿入でも要素は浅いコピーで参照を共有する', () => {
+    const result = runNako('A=[{"x":1}]。Aの0にAを配列一括挿入。A[0]$x=2。A[1]$xを表示。')
+    assert.strictEqual(result.status, 0, result.stderr)
+    assert.strictEqual(result.stdout.trim(), '2')
+  })
+
+  it('負のインデックスでも従来どおり動作する', () => {
+    const result = runNako('A=[0,1,2]。Aの-1に[9]を配列一括挿入。AをJSONエンコードして表示。')
+    assert.strictEqual(result.status, 0, result.stderr)
+    assert.strictEqual(result.stdout.trim(), '[0,1,9,2]')
+  })
+
+  it('負のインデックスへの自己挿入も有限回で終了する', () => {
+    // 負のインデックスは splice の都度解釈される既存仕様のため、[2,1,1,2] になる
+    const result = runNako('A=[1,2]。Aの-1にAを配列一括挿入。AをJSONエンコードして表示。')
+    assert.strictEqual(result.status, 0, result.stderr)
+    assert.strictEqual(result.stdout.trim(), '[2,1,1,2]')
+  })
+
+  it('循環参照(Aの要素がA自身)でも有限回で終了する', () => {
+    const result = runNako('A=[]。AにAを配列追加。Aの0にAを配列一括挿入。Aの配列要素数を表示。')
+    assert.strictEqual(result.status, 0, result.stderr)
+    assert.strictEqual(result.stdout.trim(), '2')
+  })
+
+  it('A[0]がA自身でも有限回で終了する', () => {
+    const result = runNako('A=[]。AにAを配列追加。Aの0にA[0]を配列一括挿入。Aの配列要素数を表示。')
+    assert.strictEqual(result.status, 0, result.stderr)
+    assert.strictEqual(result.stdout.trim(), '2')
+  })
+
+  it('インデックスを数値文字列で指定しても数値として扱う', () => {
+    const result = runNako('A=[0,1,2,3]。I=「1」。AのIに[8,9]を配列一括挿入。AをJSONエンコードして表示。')
+    assert.strictEqual(result.status, 0, result.stderr)
+    assert.strictEqual(result.stdout.trim(), '[0,8,9,1,2,3]')
+  })
+
+  it('負の数値文字列インデックスでも数値として扱う', () => {
+    const result = runNako('A=[0,1,2]。I=「-1」。AのIに[9]を配列一括挿入。AをJSONエンコードして表示。')
+    assert.strictEqual(result.status, 0, result.stderr)
+    assert.strictEqual(result.stdout.trim(), '[0,1,9,2]')
+  })
+
+  it('挿入元が配列でない場合はエラーになる', () => {
+    const result = runNako('A=[1]。Aの0に「x」を配列一括挿入。')
+    assert.strictEqual(result.status, 1, `エラーになりませんでした: ${result.stdout}`)
+    assert.match(result.stderr, /『配列一括挿入』の引数が配列ではありません/)
+    assert.strictEqual(result.stdout, '')
+  })
+
+  it('挿入先が配列でない場合はエラーになる', () => {
+    const result = runNako('A=1。Aの0に[1]を配列一括挿入。')
+    assert.strictEqual(result.status, 1, `エラーになりませんでした: ${result.stdout}`)
+    assert.match(result.stderr, /『配列一括挿入』の引数が配列ではありません/)
+    assert.strictEqual(result.stdout, '')
+  })
+
+  it('負のインデックスに複数要素を挿入する既存仕様を維持する', () => {
+    const result = runNako('A=[0,1,2]。Aの-1に[8,9]を配列一括挿入。AをJSONエンコードして表示。')
+    assert.strictEqual(result.status, 0, result.stderr)
+    assert.strictEqual(result.stdout.trim(), '[9,0,1,8,2]')
+  })
+
+  it('数値に変換できないインデックスは先頭への挿入として扱う', () => {
+    const result = runNako('A=[0,1,2]。I=「abc」。AのIに[8,9]を配列一括挿入。AをJSONエンコードして表示。')
+    assert.strictEqual(result.status, 0, result.stderr)
+    assert.strictEqual(result.stdout.trim(), '[8,9,0,1,2]')
+  })
+
+  it('別配列を挿入しても挿入元は変わらない', () => {
+    const result = runNako('A=[0,1,2]。B=[8,9]。Aの1にBを配列一括挿入。BをJSONエンコードして表示。')
+    assert.strictEqual(result.status, 0, result.stderr)
+    assert.strictEqual(result.stdout.trim(), '[8,9]')
+  })
+
+  it('挿入元と挿入先が別の配列では従来どおり動作する', () => {
+    const result = runNako('A=[0,1,2,3]。Aの1に[8,9]を配列一括挿入。AをJSONエンコードして表示。')
+    assert.strictEqual(result.status, 0, result.stderr)
+    assert.strictEqual(result.stdout.trim(), '[0,8,9,1,2,3]')
+  })
+})


### PR DESCRIPTION
## 概要

`配列一括挿入` で挿入元と挿入先に同じ配列を渡すと、挿入のたびに挿入元の長さも増えるため、ループの終了条件 `j < b.length` が進展せず、処理が終了しない（環境によってはハングする）問題（#2470）を修正します。

```nako3
A=[1]
Aの0にAを配列一括挿入。
```

Close #2470 

## 原因

`core/src/plugin_system_array.mts` の `配列一括挿入` が、ループの終了条件に挿入元 `b.length` を使ったまま挿入先 `a` へ `splice` していました。挿入元と挿入先が同じ配列（`a === b`）のとき、`splice` のたびに `b.length` も1増えるため、`j < b.length` が進展せず無限ループします。

## 修正内容

- 挿入前に挿入元の要素列を固定長のスナップショットへ複製し、その長さ・要素で反復するようにしました。
  - `b.length` を一度だけ取得し、`Array.from({ length: n })` + インデックスコピーで複製します。
  - 自己挿入（`a === b`）・別名参照（`B=A`）・循環参照（`A[0] === A`）でも有限回で終了します。
- インデックスを `Number(i)` で数値化し、数値文字列（`「1」` など）を渡しても `i + j` が文字列連結にならないようにしました。数値に変換できない場合は先頭（0）への挿入として扱います。
- 要素ごとの `splice(pos + j, 0, ...)` は、既存仕様（負インデックスで挿入位置を `splice` の都度再評価する）と引数個数制限の回避のため維持しています。
- 非配列引数時のエラーメッセージを「『配列一括挿入』の引数が配列ではありません。」へ改善しました。
- 型注釈を実行時の実態に合わせて更新: `i: number` → `i: any`（隣接命令と同じ）

## テスト

`core/test/array_hang_test.mjs` に回帰テストを追加しました。無限ループを親プロセスごと固めないよう、子プロセス＋タイムアウトで検出する方式（`core/test/parser_hang_test.mjs` と同様）です。

- 自己挿入（先頭/途中/先頭複数/末尾ちょうど/範囲外）で有限回に終了し、期待どおりの結果になることを検証
- 別名参照（`B=A`）、空配列、循環参照、`A[0]` が A 自身
- 浅いコピーによる参照共有（別配列/自己挿入）
- 負インデックス（通常/自己挿入/複数要素の既存仕様維持）
- 数値文字列・NaN インデックス、非配列エラー（挿入元/挿入先）、挿入元の非破壊、別配列の既存動作

## 検証

- `npm run test:core` … 全1207件パス
- `npm run eslint` … 今回の変更による新規警告なし
- `tsc` … 変更箇所に関する型エラーなし