### PR TITLE
エクスプローラー起動がmacOS/Linuxで起動後に必ず「対応していないOSです」エラーになる問題を修正 (#2491)

### DIFF
--- a/doc/command_list.json
+++ b/doc/command_list.json
@@ -10432,8 +10432,8 @@
       "phpnako"
     ],
     "category": "ファイル入出力",
-    "url": "https://github.com/kujirahand/nadesiko3/tree/master/src/plugin_node.mts#L570",
-    "description": "Windowsでエクスプローラー、macOSでFinderを使って、fnameを起動する"
+    "url": "https://github.com/kujirahand/nadesiko3/tree/master/src/plugin_node.mts#L583",
+    "description": "Windowsでエクスプローラー、macOSでFinder、Linuxでxdg-openを使って、fnameを起動する(非同期関数)"
   },
   {
     "type": "関数",

--- a/src/plugin_node.mts
+++ b/src/plugin_node.mts
@@ -4,7 +4,7 @@
  * node.js のためのプラグイン
  */
 import fs from 'node:fs'
-import { exec, execSync, spawn, spawnSync } from 'node:child_process'
+import { exec, execSync, spawn } from 'node:child_process'
 import path from 'node:path'
 import assert from 'node:assert'
 // ハッシュ関数で利用
@@ -45,12 +45,24 @@ function isDir(f: string): boolean {
 }
 
 function commandExists(command: string): boolean {
-  try {
-    const r = spawnSync('which', [command], { stdio: 'ignore' })
-    return r.status === 0
-  } catch {
-    return false
+  // PATH上の各ディレクトリに通常ファイルとして実行可能なものが存在するかを確認する
+  // (`which`に依存しないため、minimalなLinux環境でも誤検知しない) (#2491)
+  const dirs = (getEnv('PATH') || '').split(path.delimiter)
+  for (const dir of dirs) {
+    if (dir === '') { continue }
+    // command にパス区切り文字が混入してもPATH外を参照しないようにする
+    const full = path.join(dir, path.basename(command))
+    try {
+      const st = fs.statSync(full)
+      if (st.isFile()) {
+        fs.accessSync(full, fs.constants.X_OK)
+        return true
+      }
+    } catch {
+      // 次のPATHディレクトリを確認する
+    }
   }
+  return false
 }
 
 function pickLinuxTerminal(): { cmd: string, args: string[] } | null {
@@ -563,33 +575,47 @@ export default {
       opener(url)
     }
   },
-  'エクスプローラー起動': { // @Windowsでエクスプローラー、macOSでFinderを使って、fnameを起動する // @えくすぷろーらーきどう
+  'エクスプローラー起動': { // @Windowsでエクスプローラー、macOSでFinder、Linuxでxdg-openを使って、fnameを起動する // @えくすぷろーらーきどう
     type: 'func',
     josi: [['を', 'で', 'の']],
     pure: true,
+    asyncFn: true,
     fn: function(fname: string, sys: NakoSystem) {
-      // windows
-      if (sys.tags.isWin) {
-        if (isDir(fname)) { // ディレクトリを起動
-          spawn('explorer', [fname], { detached: true })
-        } else { // ファイルを選択した状態で起動
-          spawn('explorer', ['/select,', fname], { detached: true })
+      return new Promise<void>((resolve, reject) => {
+        // 起動するコマンドと引数をOSごとに決める (#2491)
+        let command = ''
+        let args: string[] = []
+        if (sys.tags.isWin) {
+          // ディレクトリを起動 / ファイルを選択した状態で起動
+          command = 'explorer'
+          args = isDir(fname) ? [fname] : ['/select,', fname]
+        } else if (sys.tags.isMac) {
+          command = 'open'
+          args = isDir(fname) ? [fname] : ['-R', fname]
+        } else if (nodeProcess.platform === 'linux') {
+          command = 'xdg-open'
+          args = isDir(fname) ? [fname] : [path.dirname(fname)]
         }
-        return
-      }
-      // macOS
-      if (sys.tags.isMac) {
-        if (isDir(fname)) {
-          spawn('open', [fname], { detached: true })
-        } else {
-          spawn('open', ['-R', fname], { detached: true })
+        // 対応していないOS
+        if (command === '') {
+          reject(new Error('対応していないOSです'))
+          return
         }
-      }
-      // linux
-      if (nodeProcess.platform === 'linux') {
-        spawn('xdg-open', [path.dirname(fname)], { detached: true })
-      }
-      throw new Error('対応していないOSです')
+        // 起動コマンドが無い場合はエラーにする (#2491)
+        if (!sys.tags.isWin && !commandExists(command)) {
+          reject(new Error(`エクスプローラー起動に失敗しました: ${command}が見つかりません`))
+          return
+        }
+        // 起動に失敗した場合のみエラーを報告する (#2491)
+        const child = spawn(command, args, { detached: true, stdio: 'ignore' })
+        child.on('error', (err) => {
+          reject(new Error(`エクスプローラー起動に失敗しました: ${err.message}`))
+        })
+        child.on('spawn', () => {
+          child.unref()
+          resolve()
+        })
+      })
     },
     return_none: true
   },

--- a/test/node/plugin_node_test.mjs
+++ b/test/node/plugin_node_test.mjs
@@ -61,14 +61,24 @@ function makeTmpDir(/** @type {string} */prefix) {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix))
 }
 
-// 指定したファイルが生成されるまで待つ (detachedな子プロセスの起動を待つため)
+// フェイクコマンド差し替えで検証できるOSか (実装はWindowsも対応するがexplorerは差し替え不能)
+function canTestExplorerLaunch() {
+  return process.platform === 'darwin' || process.platform === 'linux'
+}
+
+// 指定したファイルの書き込み完了(末尾改行)まで待つ (detachedな子プロセスの起動を待つため)
 async function waitForFile(/** @type {string} */p, /** @type {number} */timeoutMs=5000) {
   const start = Date.now()
   while (Date.now() - start < timeoutMs) {
-    if (fs.existsSync(p)) { return }
+    try {
+      const s = fs.readFileSync(p, 'utf8')
+      if (s.endsWith('\n')) { return }
+    } catch {
+      // まだ無い / 書き込み途中
+    }
     await new Promise((resolve) => setTimeout(resolve, 50))
   }
-  throw new Error(`ファイルが生成されませんでした: ${p}`)
+  throw new Error(`ファイルの書き込み完了（末尾改行）を確認できませんでした: ${p}`)
 }
 
 describe('plugin_node_test', () => {
@@ -97,8 +107,8 @@ describe('plugin_node_test', () => {
     await cmp('「PATH」の環境変数取得して表示。', path || '')
   })
   it('エクスプローラー起動', async function () {
-    // Windowsのexplorerは組み込みのため差し替えできないので省略 (#2491)
-    if (process.platform === 'win32') { return this.skip() }
+    // フェイクコマンドをPATHに差し替えて検証できるdarwin/linux以外は対象外 (#2491)
+    if (!canTestExplorerLaunch()) { return this.skip() }
     // 実際のGUIを起動しないよう、フェイクコマンドをPATHに差し替える (#2491)
     const cmdName = process.platform === 'darwin' ? 'open' : 'xdg-open'
     const binDir = makeTmpDir('nako3-explorer-')
@@ -137,8 +147,8 @@ describe('plugin_node_test', () => {
     }
   })
   it('エクスプローラー起動-コマンドが見つからない場合', async function () {
-    // Windowsのexplorerは組み込みのため対象外 (#2491)
-    if (process.platform === 'win32') { return this.skip() }
+    // フェイクコマンドをPATHに差し替えて検証できるdarwin/linux以外は対象外 (#2491)
+    if (!canTestExplorerLaunch()) { return this.skip() }
     const emptyDir = makeTmpDir('nako3-explorer-nocmd-')
     const origPath = process.env.PATH
     process.env.PATH = emptyDir
@@ -160,6 +170,33 @@ describe('plugin_node_test', () => {
     } finally {
       process.env.PATH = origPath
       fs.rmSync(emptyDir, { recursive: true, force: true })
+    }
+  })
+  it('エクスプローラー起動-spawn失敗', async function () {
+    // xdg-open経路のspawn失敗はlinuxでのみ検証する
+    // (macOSではPATH先頭の壊れたopenがあっても実openへフォールバックしうるため #2491)
+    if (process.platform !== 'linux') { return this.skip() }
+    const binDir = makeTmpDir('nako3-explorer-spawnerr-')
+    // 実行ビットはあるが起動できないコマンド (errorイベント経路の回帰テスト #2491)
+    fs.writeFileSync(path.join(binDir, 'xdg-open'), '#!/no/such/interpreter\n', { mode: 0o755 })
+    const origPath = process.env.PATH
+    process.env.PATH = binDir
+    try {
+      const fn = PluginNode['エクスプローラー起動'].fn
+      await assert.rejects(
+        () => fn('/tmp', { tags: { isWin: false, isMac: false } }),
+        (err) => {
+          assert.match(String(err.message), /エクスプローラー起動に失敗しました/)
+          return true
+        }
+      )
+      const nako = new NakoCompiler()
+      nako.addPluginFile('PluginNode', 'plugin_node.js', PluginNode)
+      const g = await nako.runAsync('「/tmp」をエクスプローラー起動。', 'main')
+      assert.strictEqual(g.numFailures > 0, true, 'spawn失敗はエラーになるべき')
+    } finally {
+      process.env.PATH = origPath
+      fs.rmSync(binDir, { recursive: true, force: true })
     }
   })
   it('ファイルサイズ取得', async () => {

--- a/test/node/plugin_node_test.mjs
+++ b/test/node/plugin_node_test.mjs
@@ -61,6 +61,16 @@ function makeTmpDir(/** @type {string} */prefix) {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix))
 }
 
+// 指定したファイルが生成されるまで待つ (detachedな子プロセスの起動を待つため)
+async function waitForFile(/** @type {string} */p, /** @type {number} */timeoutMs=5000) {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    if (fs.existsSync(p)) { return }
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+  throw new Error(`ファイルが生成されませんでした: ${p}`)
+}
+
 describe('plugin_node_test', () => {
   // --- test ---
   it('表示', async () => {
@@ -85,6 +95,72 @@ describe('plugin_node_test', () => {
   it('環境変数取得', async () => {
     const path = process.env.PATH
     await cmp('「PATH」の環境変数取得して表示。', path || '')
+  })
+  it('エクスプローラー起動', async function () {
+    // Windowsのexplorerは組み込みのため差し替えできないので省略 (#2491)
+    if (process.platform === 'win32') { return this.skip() }
+    // 実際のGUIを起動しないよう、フェイクコマンドをPATHに差し替える (#2491)
+    const cmdName = process.platform === 'darwin' ? 'open' : 'xdg-open'
+    const binDir = makeTmpDir('nako3-explorer-')
+    const marker = path.join(binDir, 'marker.txt')
+    const script = `#!/usr/bin/env sh\nprintf '%s\\n' "$@" >> "${marker}"\n`
+    fs.writeFileSync(path.join(binDir, cmdName), script, { mode: 0o755 })
+    const origPath = process.env.PATH
+    process.env.PATH = binDir + path.delimiter + origPath
+    const tmpDirs = []
+    try {
+      // ディレクトリを指定して起動してもエラーにならないこと
+      // (macOS/Linuxで起動後に必ず「対応していないOSです」になる問題の回帰テスト #2491)
+      const dir = makeTmpDir('nako3-explorer-target-')
+      tmpDirs.push(dir)
+      await cmp(`「${dir}」をエクスプローラー起動。「OK」と表示。`, 'OK')
+      await waitForFile(marker)
+      const args1 = fs.readFileSync(marker, 'utf8').trim()
+      assert.strictEqual(args1, dir, `起動コマンドに指定ディレクトリが渡される: ${args1}`)
+      // ファイルを指定して起動してもエラーにならないこと
+      fs.rmSync(marker, { force: true })
+      const file = path.join(dir, 'a.txt')
+      fs.writeFileSync(file, 'x')
+      await cmp(`「${file}」をエクスプローラー起動。「OK」と表示。`, 'OK')
+      await waitForFile(marker)
+      const args2 = fs.readFileSync(marker, 'utf8').trim()
+      if (process.platform === 'darwin') {
+        assert.ok(args2.includes('-R'), `macOSではファイルを選択状態で開く: ${args2}`)
+        assert.ok(args2.includes(file), `macOSでは対象ファイルが指定される: ${args2}`)
+      } else {
+        assert.strictEqual(args2, path.dirname(file), `Linuxでは親フォルダを開く: ${args2}`)
+      }
+    } finally {
+      process.env.PATH = origPath
+      for (const d of tmpDirs) { fs.rmSync(d, { recursive: true, force: true }) }
+      fs.rmSync(binDir, { recursive: true, force: true })
+    }
+  })
+  it('エクスプローラー起動-コマンドが見つからない場合', async function () {
+    // Windowsのexplorerは組み込みのため対象外 (#2491)
+    if (process.platform === 'win32') { return this.skip() }
+    const emptyDir = makeTmpDir('nako3-explorer-nocmd-')
+    const origPath = process.env.PATH
+    process.env.PATH = emptyDir
+    try {
+      // プラグイン関数が起動失敗をエラーとして報告すること
+      const fn = PluginNode['エクスプローラー起動'].fn
+      await assert.rejects(
+        () => fn('/tmp', { tags: { isWin: false, isMac: process.platform === 'darwin' } }),
+        (err) => {
+          assert.match(String(err.message), /エクスプローラー起動に失敗しました/)
+          return true
+        }
+      )
+      // なでしこランタイムでもエラーとして記録されること
+      const nako = new NakoCompiler()
+      nako.addPluginFile('PluginNode', 'plugin_node.js', PluginNode)
+      const g = await nako.runAsync('「/tmp」をエクスプローラー起動。', 'main')
+      assert.strictEqual(g.numFailures > 0, true, '起動コマンドが見つからない場合はエラーになるべき')
+    } finally {
+      process.env.PATH = origPath
+      fs.rmSync(emptyDir, { recursive: true, force: true })
+    }
   })
   it('ファイルサイズ取得', async () => {
     await cmp('「' + testFileMe + '」のファイルサイズ取得;もし、それが2000以上ならば;「OK」と表示。違えば「NG」と表示。', 'OK')


### PR DESCRIPTION
## 概要

`エクスプローラー起動` は、macOS(`open`)・Linux(`xdg-open`)を呼び出した後、必ず `対応していないOSです` を throw していました（#2491）。対応OSで起動に成功しても必ずエラーになる問題を修正します。

Close #2491 

## 原因

`src/plugin_node.mts` の `エクスプローラー起動` で、Windows 分岐のみ `return` していました。macOS と Linux の分岐は `spawn` を呼び出した後も `return` せず、分岐末尾の `throw new Error('対応していないOSです')` が常に実行されていました。

## 修正内容

- OSごとの分岐を `else if` 構造に変更し、起動コマンドと引数を先に決定するようにしました。
  - Windows: `explorer`（ディレクトリはそのまま、ファイルは `/select,` で選択状態）
  - macOS: `open`（ディレクトリはそのまま、ファイルは `-R` で選択状態）
  - Linux: `xdg-open`（ディレクトリはそのまま、ファイルは親フォルダを開く）
  - 対応していないOSのみ `対応していないOSです` を throw します。
- `asyncFn: true` 化し、spawn の起動失敗（`error` イベント）を Promise の reject としてなでしこランタイムへ報告するようにしました。
- 起動コマンドが PATH 上に無い場合も同期でエラー報告します。
- `commandExists()` を `which` 依存から PATH スキャン（`fs.statSync().isFile()` + `X_OK`）に変更し、minimal な Linux 環境やディレクトリの誤判定を回避しました。
- `doc/command_list.json` の `エクスプローラー起動` の説明を Linux 対応に合わせて更新しました。

## テスト

`test/node/plugin_node_test.mjs` に回帰テストを追加しました。

- フェイクコマンドを PATH に差し替えて GUI を起動せず、macOS/Linux で `エクスプローラー起動` がエラーにならず、正しいコマンド・引数で起動されることを検証
  - ディレクトリ指定時: そのディレクトリが渡されること
  - ファイル指定時: macOS は `-R`+ファイルパス、Linux は親フォルダが渡されること
- 起動コマンドが PATH 上に無い場合、`エクスプローラー起動に失敗しました` として報告され、なでしこランタイムにも `numFailures` で記録されることを検証
- Windows は組み込みの `explorer` のためテスト対象外（skip）

## 検証

- `npm run test:core` … 全1188件パス
- `npm run test:node` … 全183件中178件パス（5件は7zip等の環境依存でスキップ）
- `npm run test:common` … 全35件パス
- `npm run eslint` … 今回の変更による新規警告なし
- `tsc` … 変更箇所に関する型エラーなし