### PR TITLE
配列切取で辞書型のfalsy値も削除できるように修正 (#2471)

### DIFF
--- a/core/src/plugin_system_array.mts
+++ b/core/src/plugin_system_array.mts
@@ -198,7 +198,8 @@ export default {
       // 辞書型変数のとき
       if (a instanceof Object && typeof (i) === 'string') { // 辞書型変数も許容
         // 値が falsy でもキーが存在すれば削除する。継承プロパティは対象外。(#2471)
-        if (Object.hasOwn(a, i)) {
+        // Object.hasOwn は既定 lib が es2021 系のため型定義がなく、hasOwnProperty を使う
+        if (Object.prototype.hasOwnProperty.call(a, i)) {
           const old = a[i]
           delete a[i]
           return old

--- a/core/src/plugin_system_array.mts
+++ b/core/src/plugin_system_array.mts
@@ -197,7 +197,8 @@ export default {
       }
       // 辞書型変数のとき
       if (a instanceof Object && typeof (i) === 'string') { // 辞書型変数も許容
-        if (a[i]) {
+        // 値が falsy でもキーが存在すれば削除する。継承プロパティは対象外。(#2471)
+        if (Object.hasOwn(a, i)) {
           const old = a[i]
           delete a[i]
           return old

--- a/core/test/plugin_system_test.mjs
+++ b/core/test/plugin_system_test.mjs
@@ -226,6 +226,26 @@ describe('plugin_system_test', async () => {
       'Aから"aaa"を配列削除;' +
       'AをJSONエンコードして表示。', '{"bbb":2}')
   })
+  it('配列切取で辞書型のfalsy値も削除する #2471', async () => {
+    await cmp('A={"key":0};Aから「key」を配列切取。AをJSONエンコードして表示。', '{}')
+    await cmp('A={"key":0};B=Aから「key」を配列切取。Bを表示。', '0')
+    await cmp('A={"key":false};Aから「key」を配列切取。AをJSONエンコードして表示。', '{}')
+    await cmp('A={"key":false};B=Aから「key」を配列切取。Bを表示。', 'false')
+    await cmp('A={"key":""};Aから「key」を配列切取。AをJSONエンコードして表示。', '{}')
+    await cmp('A={"key":""};B=Aから「key」を配列切取。Bを表示。', '')
+    await cmp('A={"key":NULL};Aから「key」を配列切取。AをJSONエンコードして表示。', '{}')
+    await cmp('A={"key":NULL};B=Aから「key」を配列切取。Bを表示。', 'null')
+    await cmp('A={"key":未定義};Aから「key」を配列切取。Aの要素数を表示。', '0')
+    await cmp('A={"key":未定義};B=Aから「key」を配列切取。Bを表示。', 'undefined')
+    await cmp('A={"key":非数};Aから「key」を配列切取。AをJSONエンコードして表示。', '{}')
+    await cmp('A={"key":非数};B=Aから「key」を配列切取。Bを表示。', 'NaN')
+    await cmp('A={"key":1};Aから「key」を配列切取。AをJSONエンコードして表示。', '{}')
+    await cmp('A={"key":0};Aから「key」を配列削除。AをJSONエンコードして表示。', '{}')
+    await cmp('A={"ok":1};Aから「toString」を配列切取。AをJSONエンコードして表示。', '{"ok":1}')
+    await cmp('A={"ok":1};B=Aから「toString」を配列切取。Bを表示。', 'undefined')
+    await cmp('A={"ok":1};B=Aから「missing」を配列切取。Bを表示。AをJSONエンコードして表示。', 'undefined\n{"ok":1}')
+    await cmp('A={"toString":"x","ok":1};B=Aから「toString」を配列切取。Bを表示。AをJSONエンコードして表示。', 'x\n{"ok":1}')
+  })
   it('配列切り取りで範囲を指定 #1704', async () => {
     await cmp('A=[0,1,2,3,4,5]; B=Aの1…3を配列切り取り;' +
       'BをJSONエンコードして表示;AをJSONエンコードして表示。', '[1,2,3]\n[0,4,5]')


### PR DESCRIPTION
## 概要

辞書型変数に対して `配列切取`（および `配列削除`）を使うと、値が `0` / `false` / `""` / `null` / `undefined` / `NaN` のキーが削除されない問題（#2471）を修正します。値が `1` などの truthy のときだけ削除されていました。

```nako3
A={"key":0}
Aから「key」を配列切取。
AをJSONエンコードして表示。
# 修正前: {"key":0} / 修正後: {}
```

Close #2471 

## 原因

`core/src/plugin_system_array.mts` の `配列切取` が、辞書型経路でキーの存在を `if (a[i])` の truthy 判定で確認していたため、falsy な値を持つキーが「存在しない」と扱われ、削除されませんでした。

## 修正内容

- 辞書型経路の存在判定を `Object.hasOwn(a, i)` に変更し、値の真偽にかかわらず自身のキーを削除して元の値を返すようにしました。
- 継承プロパティ（`toString` など）は対象外です。自身のキーとして定義されている場合のみ削除します。
- `配列削除` は `配列切取` を呼び出すため、同じ修正が適用されます。

## テスト

`core/test/plugin_system_test.mjs` に回帰テストを追加しました。

- falsy 各値（`0` / `false` / `""` / `NULL` / `未定義` / `非数`）と truthy 値で、削除後の辞書と戻り値を検証
- `配列削除` 経由でも falsy キーが削除されることを検証
- 継承プロパティ `toString` は削除せず `undefined` を返すこと、自身の `toString` キーは削除できること、存在しないキーは辞書を変えず `undefined` を返すことを検証

## 検証

- `npm run test:core` … 全1189件パス
- `npm run eslint` … 今回の変更による新規警告なし
- `tsc` … 変更箇所に関する型エラーなし
