### PR TITLE
TSV取得で末尾の空列が失われないよう修正 (#2477)

### DIFF
--- a/core/src/nako_csv.mts
+++ b/core/src/nako_csv.mts
@@ -28,14 +28,17 @@ export function parse(txt: string, delimiter: string|undefined = undefined): (st
   if (delimiter === undefined) {
     delimiter = options.delimiter
   }
+  // 区切り文字は単一文字（, や \t など）を想定する
   // check txt
   txt = '' + txt + '\n'
   // convert CRLF to LF, and CR to LF
   txt = txt.replace(/(\r\n|\r)/g, '\n')
-  // trim right
-  txt = txt.replace(/\s+$/, '') + '\n'
+  // trim right (末尾の空白は除去する。ただし区切り文字は空セルを表すため残す #2477)
+  // [^\S<区切り文字>] は「\s（空白文字）から区切り文字を除いた集合」。末尾の区切り文字は残し、それ以外の空白を除去する
+  const escDelim = delimiter.replace(/[-.*+?^${}()|[\]\\]/g, '\\$&')
+  txt = txt.replace(new RegExp('[^\\S' + escDelim + ']+$'), '') + '\n'
   // set pattern
-  const patToDelim = '^(.*?)([\\' + delimiter + '\\n])'
+  const patToDelim = '^(.*?)([' + escDelim + '\\n])'
   const reToDelim = new RegExp(patToDelim)
   // if value is number then convert to float
   const convType = function(v: string) {
@@ -142,7 +145,7 @@ export function parse(txt: string, delimiter: string|undefined = undefined): (st
       s += c1
       i++
     }
-    txt = txt.substr(i)
+    txt = txt.substring(i)
   }
   if (cells.length > 0) res.push(cells)
   return res

--- a/core/test/plugin_csv_test.mjs
+++ b/core/test/plugin_csv_test.mjs
@@ -2,7 +2,7 @@
 import { beforeEach, describe, it } from 'node:test'
 import assert from 'assert'
 import { NakoCompiler } from '../src/nako3.mjs'
-import { stringify, resetEnv } from '../src/nako_csv.mjs'
+import { stringify, resetEnv, parse } from '../src/nako_csv.mjs'
 
 /** 密な2次元配列を stringify し、結果と、入力の表が書き換わらないこと・反復変換の安定性を検証する */
 const assertStringify = (/** @type {(string|number)[][]} */ ary, /** @type {string} */ expected, /** @type {string|undefined} */ delimiter = undefined) => {
@@ -39,6 +39,36 @@ describe('plugin_csv_test', () => {
     await cmp('a=「1\t"a""a"\t2」のTSV取得。a[0][1]を表示', 'a"a')
     await cmp('a=「1\t"2""2"\t3\n4\t5\t6」のTSV取得。a[0][1]を表示', '2"2')
     await cmp('a=「1\t\t3\n4\t5\t6」のTSV取得。a[0][2]を表示', '3')
+  })
+  it('CSV/TSV取得で末尾の空列が失われない #2477', async () => {
+    // 行末の空セル(タブ)が保存される
+    await cmp('a=「1\t\t」のTSV取得。aをJSONエンコードして表示', '[[1,"",""]]')
+    await cmp('a=「1\t2\t」のTSV取得。aをJSONエンコードして表示', '[[1,2,""]]')
+    // 全空セル
+    await cmp('a=「\t\t」のTSV取得。aをJSONエンコードして表示', '[["","",""]]')
+    // 複数行
+    await cmp('a=「1\t\t\n2\t\t」のTSV取得。aをJSONエンコードして表示', '[[1,"",""],[2,"",""]]')
+    // CRLF混在
+    await cmp('a=「1\t2\t\r\n3\t4\t」のTSV取得。aをJSONエンコードして表示', '[[1,2,""],[3,4,""]]')
+    // 末尾の改行の後に空白があっても余分な空行を作らない
+    await cmp('a=「1,2,3\n 」のCSV取得。aをJSONエンコードして表示', '[[1,2,3]]')
+    await cmp('a=「1\t\t\n 」のTSV取得。aをJSONエンコードして表示', '[[1,"",""]]')
+    // 単一の末尾タブ・連続する末尾タブ
+    await cmp('a=「1\t」のTSV取得。aをJSONエンコードして表示', '[[1,""]]')
+    await cmp('a=「1\t\t\t」のTSV取得。aをJSONエンコードして表示', '[[1,"","",""]]')
+    // CSVは末尾の空セル(カンマ)が従来どおり保存される
+    await cmp('a=「1,,」のCSV取得。aをJSONエンコードして表示', '[[1,"",""]]')
+    await cmp('a=「1,2,3,」のCSV取得。aをJSONエンコードして表示', '[[1,2,3,""]]')
+    await cmp('a=「1,2,,」のCSV取得。aをJSONエンコードして表示', '[[1,2,"",""]]')
+    // CSVでは末尾のタブ・スペースは従来どおりトリムされる
+    await cmp('a=「1,2,3\t」のCSV取得。aをJSONエンコードして表示', '[[1,2,3]]')
+  })
+  it('parseは正規表現メタ文字の区切り文字でも末尾の空列を扱える #2477', () => {
+    // 区切り文字の正規表現エスケープと末尾の空列保持を直接検証する
+    assert.deepStrictEqual(parse('1|2|', '|'), [[1, 2, '']])
+    assert.deepStrictEqual(parse('1]2]', ']'), [[1, 2, '']])
+    assert.deepStrictEqual(parse('1\\2\\', '\\'), [[1, 2, '']])
+    assert.deepStrictEqual(parse('1-2-', '-'), [[1, 2, '']])
   })
   it('表CSV変換', async () => {
     await cmp('[[1,2,3],[4,5,6]]を表CSV変換して表示', '1,2,3\r\n4,5,6')


### PR DESCRIPTION
## 概要

`TSV取得` が、行末に空セル（タブ）があるTSVを読むと末尾の空列を失う問題（#2477）を修正します。

```nako3
S=「1<TAB><TAB>」  ※ <TAB> は実際のタブ文字
SをTSV取得して表示。
```

- 修正前: `"1\t\t"` が `[[1]]` になる（空列2つが消失）。`"1\t2\t"` も `[[1,2]]`。
- 修正後: `"1\t\t"` は `[[1,"",""]]`、`"1\t2\t"` は `[[1,2,""]]` として列数を保存する。

Close #2477

## 原因

`core/src/nako_csv.mts` の `parse()` の事前トリム `txt.replace(/\s+$/, '') + '\n'` が、レコード終端の改行だけでなく末尾の区切りタブまで除去していました。

## 修正内容

- 末尾トリムを「区切り文字以外の空白のみ除去」する形に変更しました。
  ```ts
  // 末尾の空白は除去する。ただし区切り文字は空セルを表すため残す #2477
  const escDelim = delimiter.replace(/[-.*+?^${}()|[\]\\]/g, '\\$&')
  txt = txt.replace(new RegExp('[^\\S' + escDelim + ']+$'), '') + '\n'
  ```
  - TSV（区切り `\t`）: 末尾のタブ（空セル）を保持し、改行・スペース等の空白のみ除去。
  - CSV（区切り `,`）: `,` は空白でないため従来どおり末尾のカンマ（空セル）が保存され、末尾のタブ・スペースも従来どおりトリムされます。
- 区切り文字の正規表現エスケープを `reToDelim` にも流用し、`|`・`]`・`\`・`-` などのメタ文字を区切りに使っても安全になりました。

## テスト

`core/test/plugin_csv_test.mjs` に回帰テストを追加しました。

- 行末の空セル: `1\t\t`（2空列）・`1\t2\t`（1空列）・`1\t`・`1\t\t\t`
- 全空セル: `\t\t`
- 複数行: `1\t\t\n2\t\t`
- CRLF混在: `1\t2\t\r\n3\t4\t`
- 末尾改行後の空白による余分な空行ができないこと: `1,2,3\n ` / `1\t\t\n `
- CSVの回帰がないこと: `1,,` / `1,2,3,` / `1,2,,` / `1,2,3\t`（従来どおりトリム）
- 正規表現メタ文字を区切りにした場合: `|` / `]` / `\` / `-`

## 検証

- `npm run test:core` … 全1211件パス
- `npm run test:common` … 全35件パス
- `npm run eslint` … 今回の変更による新規警告なし
- `tsc` … 変更箇所に関する型エラーなし
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kujirahand/nadesiko3/pull/2517" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->