### PR TITLE
内部ヘルパー__formatTimeの分と秒の順序を修正 #2489

### DIFF
--- a/core/src/plugin_system.mts
+++ b/core/src/plugin_system.mts
@@ -111,7 +111,7 @@ const PluginSystem = {
         return String(t.getFullYear()) + '/' + z2(t.getMonth() + 1) + '/' + z2(t.getDate())
       }
       sys.__formatTime = (t: Date): string => {
-        return z2(t.getHours()) + ':' + z2(t.getSeconds()) + ':' + z2(t.getMinutes())
+        return z2(t.getHours()) + ':' + z2(t.getMinutes()) + ':' + z2(t.getSeconds())
       }
       sys.__formatDateTime = (t: Date, fmt: string): string => {
         const dateStr = String(t.getFullYear()) + '/' + z2(t.getMonth() + 1) + '/' + z2(t.getDate())

--- a/core/src/plugin_system_datetime.mts
+++ b/core/src/plugin_system_datetime.mts
@@ -13,13 +13,8 @@ export default {
     type: 'func',
     josi: [],
     pure: true,
-    fn: function() {
-      const z2 = (n: number): string => {
-        const ns = '00' + String(n)
-        return ns.substring(ns.length - 2, ns.length)
-      }
-      const t = new Date()
-      return z2(t.getHours()) + ':' + z2(t.getMinutes()) + ':' + z2(t.getSeconds())
+    fn: function(sys: NakoSystem) {
+      return sys.__formatTime(new Date())
     }
   },
   'システム時間': { // @現在のUNIX時間 (UTC(1970/1/1)からの経過秒数) を返す // @しすてむじかん

--- a/core/test/plugin_system_test.mjs
+++ b/core/test/plugin_system_test.mjs
@@ -1017,7 +1017,15 @@ describe('plugin_system_test', async () => {
   })
   it('今 #2489', async () => {
     const nako = new NakoCompiler()
-    const g = await nako.runAsync('今を表示', 'main.nako3')
-    assert.match(g.log, /^\d{2}:\d{2}:\d{2}$/)
+    const g = await nako.runAsync('')
+    // sys.__formatTime に委譲されていることを検証するため固定値に差し替える
+    g.__formatTime = () => '11:22:33'
+    const res = await g.runAsync('今を表示', 'main.nako3', {})
+    assert.strictEqual(res.log, '11:22:33')
+
+    // 実環境での出力形式も確認
+    const nako2 = new NakoCompiler()
+    const g2 = await nako2.runAsync('今を表示', 'main.nako3')
+    assert.match(g2.log, /^\d{2}:\d{2}:\d{2}$/)
   })
 })

--- a/core/test/plugin_system_test.mjs
+++ b/core/test/plugin_system_test.mjs
@@ -1009,4 +1009,15 @@ describe('plugin_system_test', async () => {
     await cmp('「/a/b/c」からパス抽出して表示。', '/a/b')
     await cmp('「c:/a/b/c」からパス抽出して表示。', 'c:/a/b')
   })
+  it('__formatTime #2489', async () => {
+    const nako = new NakoCompiler()
+    const g = await nako.runAsync('')
+    const t = new Date(2026, 8, 10, 12, 34, 56)
+    assert.strictEqual(g.__formatTime(t), '12:34:56')
+  })
+  it('今 #2489', async () => {
+    const nako = new NakoCompiler()
+    const g = await nako.runAsync('今を表示', 'main.nako3')
+    assert.match(g.log, /^\d{2}:\d{2}:\d{2}$/)
+  })
 })


### PR DESCRIPTION
## 概要

Issue #2489 の修正です。

ランタイムの内部ヘルパー `sys.__formatTime` において、`getSeconds()` と `getMinutes()` の順序が逆になっていたため、`HH:mm:ss` ではなく `HH:ss:mm` が返る不具合を修正しました。

また、命令「今」の実装が `sys.__formatTime` を利用するように共通化し、`core/test/plugin_system_test.mjs` に単体テストを追加しました。

Closes #2489
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kujirahand/nadesiko3/pull/2520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->