### PR TITLE
簡易HTTPサーバで未登録経路へのリクエスト時に404を返すように修正 #2496

### DIFF
--- a/src/plugin_httpserver.mts
+++ b/src/plugin_httpserver.mts
@@ -64,6 +64,7 @@ class EasyURLDispather {
         this.sys.__setSysVar('POSTデータ', postData)
         // URLの一致を調べてアクションを実行
         const filtered = this.items.filter(v => url.startsWith(v.url)).sort((a, b) => { return b.url.length - a.url.length })
+        let matched = false
         for (const it of filtered) {
           let isBreak = false
           if (it.action === 'static') {
@@ -71,7 +72,13 @@ class EasyURLDispather {
           } else if (it.action === 'callback') {
             isBreak = this.doRequestCallback(req, res, it)
           }
-          if (isBreak) { break }
+          if (isBreak) {
+            matched = true
+            break
+          }
+        }
+        if (!matched) {
+          this.return404(res)
         }
       } catch (err: any) {
         // ここで捕まえないとサーバのプロセスごと落ちてしまう
@@ -156,8 +163,14 @@ class EasyURLDispather {
 
   return404(res: any) {
     console.error(HTTPSERVER_LOGID, 404, '見当たりません。')
-    res.statusCode = 404
-    res.end('<html><meta charset="utf-8"><body><h1>404 見当たりません。</h1></body></html>')
+    try {
+      if (!res.writableEnded) {
+        res.statusCode = 404
+        res.end('<html><meta charset="utf-8"><body><h1>404 見当たりません。</h1></body></html>')
+      }
+    } catch {
+      // 応答済みなどで書き込めない場合は何もしない
+    }
   }
 
   doRequestStatic(req: any, res: any, it: EasyURLItem): boolean {

--- a/test/node/plugin_httpserver_test.mjs
+++ b/test/node/plugin_httpserver_test.mjs
@@ -543,4 +543,76 @@ describe('plugin_httpserver_test', () => {
     })
     assert.strictEqual(status2, 500)
   })
+
+  it('未登録経路にリクエストしたときに404が返ること #2496', async () => {
+    let port = 0
+    const code = `
+●ダミー起動
+  戻る。
+ここまで。
+●受信処理
+  「hello」を簡易HTTPサーバ出力。
+ここまで。
+「ダミー起動」を${port}で簡易HTTPサーバ起動時。
+「受信処理」を「/hello」に簡易HTTPサーバ受信時。
+`
+    const g = await nako.runAsync(code, 'main')
+    serverDp = g.__httpserver
+    await wait(100)
+    port = serverDp.server.address().port
+
+    // 登録済み経路 /hello は 200 と hello を返す
+    const helloRes = await new Promise((resolve, reject) => {
+      const req = http.request({
+        hostname: 'localhost',
+        port: port,
+        path: '/hello',
+        method: 'GET'
+      }, (res) => {
+        let data = ''
+        res.on('data', (chunk) => { data += chunk })
+        res.on('end', () => { resolve({ statusCode: res.statusCode, body: data }) })
+      })
+      req.on('error', reject)
+      req.end()
+    })
+    assert.strictEqual(helloRes.statusCode, 200)
+    assert.strictEqual(helloRes.body, 'hello')
+
+    // 未登録経路 /zzz はハングせず 404 が返ること
+    const notFoundRes = await new Promise((resolve, reject) => {
+      const req = http.request({
+        hostname: 'localhost',
+        port: port,
+        path: '/zzz',
+        method: 'GET'
+      }, (res) => {
+        let data = ''
+        res.on('data', (chunk) => { data += chunk })
+        res.on('end', () => { resolve({ statusCode: res.statusCode, body: data }) })
+      })
+      req.on('error', reject)
+      req.end()
+    })
+    assert.strictEqual(notFoundRes.statusCode, 404)
+    assert.match(notFoundRes.body, /404/)
+
+    // 未登録経路の後でもサーバが生きていて正常経路にアクセスできること
+    const helloRes2 = await new Promise((resolve, reject) => {
+      const req = http.request({
+        hostname: 'localhost',
+        port: port,
+        path: '/hello',
+        method: 'GET'
+      }, (res) => {
+        let data = ''
+        res.on('data', (chunk) => { data += chunk })
+        res.on('end', () => { resolve({ statusCode: res.statusCode, body: data }) })
+      })
+      req.on('error', reject)
+      req.end()
+    })
+    assert.strictEqual(helloRes2.statusCode, 200)
+    assert.strictEqual(helloRes2.body, 'hello')
+  })
 })


### PR DESCRIPTION
## 概要
簡易HTTPサーバにおいて、登録していないURLパスへのリクエストがあった場合に一致するハンドラがなく応答が返らないままハング（クライアント側でタイムアウト）する問題を修正しました。

Closes #2496

## 変更点
- [src/plugin_httpserver.mts](file:///Users/kujirahand/repos/nadesiko3go/nadesiko3/src/plugin_httpserver.mts): `runDispatcher` 内で一致するルートが存在しない場合（`!matched`）に404レスポンスを返すフォールバック処理を追加
- [test/node/plugin_httpserver_test.mjs](file:///Users/kujirahand/repos/nadesiko3go/nadesiko3/test/node/plugin_httpserver_test.mjs): 未登録経路へのアクセス時にハングせず404が返ること、および登録済み経路へのアクセスやその後のリクエストが正常に動作することを確認するテストを追加
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kujirahand/nadesiko3/pull/2521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->