### PR TITLE
配列逆順に配列以外を渡した際のエラーメッセージを修正 #2473

### DIFF
--- a/core/src/plugin_system_array.mts
+++ b/core/src/plugin_system_array.mts
@@ -160,7 +160,7 @@ export default {
     pure: true,
     fn: function(a: any) {
       if (a instanceof Array) { return a.reverse() } // 配列ならOK
-      throw new Error('『配列ソート』で配列以外が指定されました。')
+      throw new Error('『配列逆順』で配列以外が指定されました。')
     }
   },
   '配列シャッフル': { // @配列Aをシャッフルして返す。Aを書き換える // @はいれつしゃっふる

--- a/core/test/plugin_system_test.mjs
+++ b/core/test/plugin_system_test.mjs
@@ -230,6 +230,7 @@ describe('plugin_system_test', async () => {
   })
   it('配列逆順', async () => {
     await cmp('A=[1,2,3];Aを配列逆順。Aを「:」で配列結合。表示。', '3:2:1')
+    await cmpex('A=1;Aを配列逆順。', { name: 'NakoError', message: '『配列逆順』で配列以外が指定されました。' }) // #2473
   })
   it('配列切取/配列削除', async () => {
     await cmp('A=[0,1,2,3];Aの2を配列切り取る。C=それ。Aを「:」で配列結合。表示。Cを表示', '0:1:3\n2')


### PR DESCRIPTION
## 概要
#2473 の修正です。

`配列逆順` に配列以外を指定した際のエラーメッセージがコピー元の `『配列ソート』で配列以外が指定されました。` になっていたため、`『配列逆順』で配列以外が指定されました。` に修正しました。

## 変更内容
- [core/src/plugin_system_array.mts](file:///Users/kujirahand/repos/nadesiko3go/nadesiko3/core/src/plugin_system_array.mts): `配列逆順` の例外メッセージを `『配列逆順』` に修正
- [core/test/plugin_system_test.mjs](file:///Users/kujirahand/repos/nadesiko3go/nadesiko3/core/test/plugin_system_test.mjs): 配列逆順に配列以外を渡した際の回帰テストを追加
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kujirahand/nadesiko3/pull/2522" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->