### PR TITLE
*.mtsファイルの総行数と文字数をカウントするスクリプトを追加 #2523

### DIFF
--- a/batch/analize-code-line.nako3
+++ b/batch/analize-code-line.nako3
@@ -1,0 +1,39 @@
+ROOT_DIR = 母艦パスを「../」で相対パス展開。
+
+FILES = 「{ROOT_DIR}/*.mts」の全ファイル列挙。
+TOTAL_FILES = 0
+TOTAL_LINES = 0
+TOTAL_CHARS = 0
+
+FILESを反復
+    # node_modules を除外
+    対象を『node_modules』で正規表現マッチ。
+    もし、そうならば、続ける。
+
+    F = 対象
+    S = Fを開く。
+    CHARS = Sの文字数。
+
+    # 行末の改行を取り除いてから改行で区切る
+    S_TRIM = Sの「/\r?\n$/」を「」に正規表現置換。
+    もし、S_TRIM == ""ならば
+        LINES = 0
+    違えば
+        LINES = (S_TRIMを改行で区切る)の要素数
+    ここまで。
+
+    TOTAL_FILES = TOTAL_FILES + 1
+    TOTAL_LINES = TOTAL_LINES + LINES
+    TOTAL_CHARS = TOTAL_CHARS + CHARS
+
+    # 相対パス表示
+    REL_PATH = Fの「{ROOT_DIR}」を「」に置換。
+    REL_PATH = REL_PATHの「/^[\\\/]/」を「」に正規表現置換。
+    「{REL_PATH}: {LINES}行, {CHARS}文字」を表示。
+ここまで。
+
+「----------------------------------------」を表示。
+「対象ファイル数: {TOTAL_FILES}」を表示。
+「総行数: {TOTAL_LINES} 行」を表示。
+「総文字数: {TOTAL_CHARS} 文字」を表示。
+「----------------------------------------」を表示。

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "extlib:clean": "rm -f -r demo/extlib/*",
     "extlib:install": "node src/cnako3.mjs batch/download-extlib.nako3",
     "check_new_version": "node src/cnako3.mjs tools/check_new_version.nako3",
-    "hello": "node src/cnako3.mjs -e \"「hello」と表示\""
+    "hello": "node src/cnako3.mjs -e \"「hello」と表示\"",
+    "analize-code-line": "node src/cnako3.mjs batch/analize-code-line.nako3"
   },
   "repository": {
     "type": "git",

--- a/test/node/analize_code_line_test.mjs
+++ b/test/node/analize_code_line_test.mjs
@@ -1,0 +1,48 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const testRoot = path.dirname(fileURLToPath(import.meta.url))
+const projectRoot = path.resolve(testRoot, '../..')
+const cnako3Path = path.join(projectRoot, 'src/cnako3.mjs')
+const scriptPath = path.join(projectRoot, 'batch/analize-code-line.nako3')
+const packageJsonPath = path.join(projectRoot, 'package.json')
+
+describe('analize-code-line (#2523)', () => {
+  it('package.json に analize-code-line スクリプトが定義されている', () => {
+    const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+    assert.strictEqual(pkg.scripts['analize-code-line'], 'node src/cnako3.mjs batch/analize-code-line.nako3')
+  })
+
+  it('batch/analize-code-line.nako3 が正常に実行され、行数と文字数を集計する', () => {
+    const result = spawnSync(process.execPath, [cnako3Path, scriptPath], {
+      cwd: projectRoot,
+      encoding: 'utf8',
+      timeout: 30000
+    })
+    assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`)
+
+    const stdout = result.stdout
+    assert.match(stdout, /対象ファイル数: \d+/)
+    assert.match(stdout, /総行数: \d+ 行/)
+    assert.match(stdout, /総文字数: \d+ 文字/)
+
+    const fileCountMatch = stdout.match(/対象ファイル数: (\d+)/)
+    assert.ok(fileCountMatch, '対象ファイル数が出力されている')
+    const fileCount = parseInt(fileCountMatch[1], 10)
+    assert.ok(fileCount > 0, `対象ファイル数が0より大きい (実際: ${fileCount})`)
+
+    const linesMatch = stdout.match(/総行数: (\d+) 行/)
+    assert.ok(linesMatch, '総行数が出力されている')
+    const totalLines = parseInt(linesMatch[1], 10)
+    assert.ok(totalLines > 0, `総行数が0より大きい (実際: ${totalLines})`)
+
+    const charsMatch = stdout.match(/総文字数: (\d+) 文字/)
+    assert.ok(charsMatch, '総文字数が出力されている')
+    const totalChars = parseInt(charsMatch[1], 10)
+    assert.ok(totalChars > 0, `総文字数が0より大きい (実際: ${totalChars})`)
+  })
+})


### PR DESCRIPTION
## 概要
*.mtsファイルの総行数と文字数をカウントするスクリプト `batch/analize-code-line.nako3` を作成し、`npm run analize-code-line` で実行できるようにしました。

Closes #2523

## 変更内容
- `batch/analize-code-line.nako3`: プロジェクト内の `*.mts` ファイル（`node_modules` 除外）の行数・文字数をカウントし、集計結果を出力するスクリプトを追加
- `package.json`: scripts に `"analize-code-line": "node src/cnako3.mjs batch/analize-code-line.nako3"` を追加
- `test/node/analize_code_line_test.mjs`: スクリプトの実行とpackage.jsonの定義を検証するテストを追加
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kujirahand/nadesiko3/pull/2524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->