### PR TITLE
AJAX内容取得の未知形式エラーを修正 #2498

### DIFF
--- a/src/plugin_browser_ajax.mts
+++ b/src/plugin_browser_ajax.mts
@@ -333,7 +333,7 @@ export default {
               if (type === 'BODY' || type === '本体') {
                 return res.body
               }
-      return res.body()
+      throw new Error(`『AJAX内容取得』で未対応の形式「${type}」が指定されました。TEXT、JSON、BLOB、ARRAY、BODYのいずれかを指定してください。`)
     },
     return_none: false
   },

--- a/src/plugin_node.mts
+++ b/src/plugin_node.mts
@@ -1449,7 +1449,7 @@ export default {
               if (type === 'BODY' || type === '本体') {
                 return res.body
               }
-      return res.body()
+      throw new Error(`『AJAX内容取得』で未対応の形式「${type}」が指定されました。TEXT、JSON、BLOB、ARRAY、BODYのいずれかを指定してください。`)
     },
     return_none: false
   },

--- a/test/node/ajax_content_test.mjs
+++ b/test/node/ajax_content_test.mjs
@@ -1,0 +1,43 @@
+import assert from 'assert'
+
+import PluginNode from '../../src/plugin_node.mjs'
+import PluginBrowserAjax from '../../src/plugin_browser_ajax.mjs'
+
+const plugins = [
+  ['Node.js版', PluginNode],
+  ['ブラウザ版', PluginBrowserAjax]
+]
+
+describe('AJAX内容取得', () => {
+  for (const [runtime, plugin] of plugins) {
+    const ajaxContent = plugin['AJAX内容取得'].fn
+
+    it(`${runtime}で指定形式の内容を取得できる`, async () => {
+      const body = { name: 'body' }
+      const response = {
+        body,
+        text: async () => 'text',
+        json: async () => ({ name: 'json' }),
+        blob: async () => ({ name: 'blob' }),
+        arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer
+      }
+
+      assert.strictEqual(await ajaxContent(response, 'TEXT'), 'text')
+      assert.deepStrictEqual(await ajaxContent(response, 'JSON'), { name: 'json' })
+      assert.deepStrictEqual(await ajaxContent(response, 'BLOB'), { name: 'blob' })
+      assert.deepStrictEqual(
+        new Uint8Array(await ajaxContent(response, 'ARRAY')),
+        new Uint8Array([1, 2, 3])
+      )
+      assert.strictEqual(ajaxContent(response, 'BODY'), body)
+    })
+
+    it(`${runtime}で未知の形式を指定すると入力エラーになる`, () => {
+      const response = { body: {} }
+      assert.throws(
+        () => ajaxContent(response, 'UNKNOWN'),
+        /『AJAX内容取得』で未対応の形式「UNKNOWN」が指定されました/
+      )
+    })
+  }
+})


### PR DESCRIPTION
## 概要

- AJAX内容取得で未知の形式を指定した際、Response.bodyを関数として呼び出さないよう修正
- Node.js版とブラウザ版で、対応形式を案内する明示的な入力エラーを返すよう統一
- TEXT / JSON / BLOB / ARRAY / BODYと未知形式の回帰テストを追加

## テスト

- npm run build:tsc
- npm run test:node（723件成功、1件スキップ、失敗0件）
- npm run test:common（35件成功）
- npm run eslint
- npx oxlint test/node/ajax_content_test.mjs

Closes #2498
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kujirahand/nadesiko3/pull/2525" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->