### PR TITLE
POSTフォーム送信時にmultipart boundaryを付与する #2497

### DIFF
--- a/src/plugin_node.mts
+++ b/src/plugin_node.mts
@@ -1326,9 +1326,6 @@ export default {
 
       const options = {
         method: 'POST',
-        headers: {
-          'Content-Type': 'multipart/form-data'
-        },
         body: fd
       }
       fetch(url, options).then((res: any) => {

--- a/test/node/plugin_node_test.mjs
+++ b/test/node/plugin_node_test.mjs
@@ -2,6 +2,7 @@
 import os from 'os'
 import fs from 'node:fs'
 import assert from 'assert'
+import http from 'node:http'
 import path from 'path'
 import { spawnSync } from 'node:child_process'
 
@@ -87,6 +88,41 @@ async function waitForFile(/** @type {string} */p, /** @type {number} */timeoutM
 
 describe('plugin_node_test', () => {
   // --- test ---
+  it('POSTフォーム送信時-multipart boundary', async () => {
+    let receivedBody = ''
+    let receivedContentType = ''
+    const server = http.createServer((req, res) => {
+      receivedContentType = req.headers['content-type'] || ''
+      req.setEncoding('utf8')
+      req.on('data', (chunk) => { receivedBody += chunk })
+      req.on('end', () => {
+        res.writeHead(200, { 'Content-Type': 'text/plain' })
+        res.end('OK')
+      })
+    })
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+    try {
+      const address = server.address()
+      assert.notStrictEqual(address, null)
+      assert.strictEqual(typeof address, 'object')
+      const url = `http://127.0.0.1:${address.port}/`
+      const response = await new Promise((resolve, reject) => {
+        const sys = {
+          __setSysVar: () => {},
+          __getSysVar: () => reject
+        }
+        PluginNode['POSTフォーム送信時'].fn(resolve, url, { name: 'なでしこ' }, sys)
+      })
+      assert.strictEqual(response, 'OK')
+      const boundary = receivedContentType.match(/^multipart\/form-data; boundary=(.+)$/)?.[1]
+      assert.ok(boundary, `Content-Typeにboundaryが必要です: ${receivedContentType}`)
+      assert.ok(receivedBody.includes(`--${boundary}`), '本文とContent-Typeのboundaryが一致する必要があります')
+      assert.ok(receivedBody.includes('name="name"'))
+      assert.ok(receivedBody.includes('なでしこ'))
+    } finally {
+      await new Promise((resolve, reject) => server.close((err) => err ? reject(err) : resolve()))
+    }
+  })
   it('表示', async () => {
     await cmp('3を表示', '3')
     await cmp('1+2*3を表示', '7')


### PR DESCRIPTION
## 概要

`POSTフォーム送信時` で送信される `Content-Type` に、本文と一致する multipart boundary が付かない問題を修正します。

Fixes #2497

## 原因

`FormData` を送信するときに `Content-Type: multipart/form-data` を手動指定していたため、`fetch` による boundary の自動付加が抑止されていました。

## 修正内容

- 固定の `Content-Type` ヘッダーを削除し、`fetch` に boundary の生成を任せる
- 実HTTP往復で次を確認する回帰テストを追加
  - `Content-Type` に `boundary=` が含まれる
  - ヘッダーと本文の boundary が一致する
  - フォームの名前と値が本文に含まれる

## テスト

- `npm run build:tsc`
- Issue #2497 の回帰テスト
- `npm run test:node`（189 pass、既存 skip 2）
- `npm run test:common`（35 pass）
- `npm run eslint`（成功、既存の `eval` 警告1件のみ）
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kujirahand/nadesiko3/pull/2526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->