### PR TITLE
ファイル列挙・全ファイル列挙のワイルドカード照合で先頭アンカー付与および正規表現メタ文字をエスケープするように修正 #2492

### DIFF
--- a/src/plugin_node.mts
+++ b/src/plugin_node.mts
@@ -244,6 +244,27 @@ async function copyMergeWithProgress(src: string, dest: string, overwrite: boole
   }
 }
 
+/**
+ * ワイルドカード文字列を正規表現に変換する (#2492)
+ * 「*」を「.*」に変換し、それ以外の正規表現メタ文字をエスケープして「^...$」で囲む
+ * 「;」で区切られた複数パターンの指定にも対応
+ */
+function wildcardToRegExp(pattern: string): RegExp {
+  const patterns = pattern
+    .split(';')
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0)
+    .map((p) => {
+      // 正規表現メタ文字をエスケープ (ただし * は後で .* に変換)
+      const escaped = p.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&')
+      return escaped.replace(/\\\*/g, '.*')
+    })
+  if (patterns.length === 0) {
+    return /^.*$/i
+  }
+  return new RegExp(`^(?:${patterns.join('|')})$`, 'i')
+}
+
 // Denoのためのラッパー
 if (typeof (globalThis as any).Deno !== 'undefined') {
   nodeProcess = {
@@ -626,13 +647,7 @@ export default {
     fn: function(s: string) {
       if (s.indexOf('*') >= 0) { // ワイルドカードがある場合
         const searchPath = path.dirname(s)
-        const mask1 = path.basename(s)
-          .replace(/\./g, '\\.')
-          .replace(/\*/g, '.*')
-        const mask2 = (mask1.indexOf(';') < 0)
-          ? mask1 + '$'
-          : '(' + mask1.replace(/;/g, '|') + ')$'
-        const maskRE = new RegExp(mask2, 'i')
+        const maskRE = wildcardToRegExp(path.basename(s))
         const list = fs.readdirSync(searchPath)
         return list.filter((n) => maskRE.test(n))
       } else { return fs.readdirSync(s) }
@@ -646,19 +661,13 @@ export default {
       /** @type {string[]} */
       const result: string[] = []
       // ワイルドカードの有無を確認
-      let mask = '.*'
+      let maskRE: RegExp | null = null
       let basepath = s
       if (s.indexOf('*') >= 0) {
         basepath = path.dirname(s)
-        const mask1 = path.basename(s)
-          .replace(/\./g, '\\.')
-          .replace(/\*/g, '.*')
-        mask = (mask1.indexOf(';') < 0)
-          ? mask1 + '$'
-          : '(' + mask1.replace(/;/g, '|') + ')$'
+        maskRE = wildcardToRegExp(path.basename(s))
       }
       basepath = path.resolve(basepath)
-      const maskRE = new RegExp(mask, 'i')
       // 再帰関数を定義
       const enumR = (base: any) => {
         const list = fs.readdirSync(base)
@@ -676,7 +685,7 @@ export default {
             enumR(fullpath)
             continue
           }
-          if (maskRE.test(f)) { result.push(fullpath) }
+          if (!maskRE || maskRE.test(f)) { result.push(fullpath) }
         }
       }
       // 検索実行

--- a/test/node/plugin_node_test.mjs
+++ b/test/node/plugin_node_test.mjs
@@ -612,4 +612,81 @@ CNTを表示
     assert.strictEqual(r2.status, 0)
     assert.strictEqual(r2.stdout.trim(), 'A')
   })
+  // --- ファイル列挙 / 全ファイル列挙 (#2492) ---
+  describe('ファイル列挙のワイルドカード #2492', () => {
+    let tmpDir = ''
+    let tmpDirSlash = ''
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nako3-enum-test-'))
+      tmpDirSlash = tmpDir.replace(/\\/g, '/')
+      // テスト用ファイル作成
+      fs.writeFileSync(path.join(tmpDir, 'a.txt'), '')
+      fs.writeFileSync(path.join(tmpDir, 'za.txt'), '')
+      fs.writeFileSync(path.join(tmpDir, 'a+.txt'), '')
+      fs.writeFileSync(path.join(tmpDir, '[file.txt'), '')
+      fs.writeFileSync(path.join(tmpDir, 'test.jpg'), '')
+      fs.writeFileSync(path.join(tmpDir, 'image.png'), '')
+      fs.writeFileSync(path.join(tmpDir, 'data.csv'), '')
+      // サブディレクトリとその中身
+      const subDir = path.join(tmpDir, 'sub')
+      fs.mkdirSync(subDir)
+      fs.writeFileSync(path.join(subDir, 'a.txt'), '')
+      fs.writeFileSync(path.join(subDir, 'za.txt'), '')
+      fs.writeFileSync(path.join(subDir, 'test.jpg'), '')
+    })
+    afterEach(() => {
+      if (tmpDir && fs.existsSync(tmpDir)) {
+        fs.rmSync(tmpDir, { recursive: true, force: true })
+      }
+    })
+
+    it('先頭アンカーにより部分一致しない (a*.txt で za.txt は一致しない)', async () => {
+      const g = await run(`「${tmpDirSlash}/a*.txt」のファイル列挙をJSONエンコードして表示。`)
+      const list = JSON.parse(g.log).sort()
+      assert.deepStrictEqual(list, ['a+.txt', 'a.txt'])
+    })
+
+    it('正規表現メタ文字がエスケープされる ([*.txt でSyntaxErrorにならず一致)', async () => {
+      const g = await run(`「${tmpDirSlash}/[*.txt」のファイル列挙をJSONエンコードして表示。`)
+      const list = JSON.parse(g.log).sort()
+      assert.deepStrictEqual(list, ['[file.txt'])
+    })
+
+    it('+ 記号が通常文字として扱われる (a+*.txt)', async () => {
+      const g = await run(`「${tmpDirSlash}/a+*.txt」のファイル列挙をJSONエンコードして表示。`)
+      const list = JSON.parse(g.log).sort()
+      assert.deepStrictEqual(list, ['a+.txt'])
+    })
+
+    it('*.txt で全てのtxtファイルに一致し、末尾が異なるファイルには一致しない', async () => {
+      fs.writeFileSync(path.join(tmpDir, 'a.txt.bak'), '')
+      const g = await run(`「${tmpDirSlash}/*.txt」のファイル列挙をJSONエンコードして表示。`)
+      const list = JSON.parse(g.log).sort()
+      assert.deepStrictEqual(list, ['[file.txt', 'a+.txt', 'a.txt', 'za.txt'])
+    })
+
+    it('ワイルドカードなしの場合は全ファイル・フォルダを列挙する', async () => {
+      const g = await run(`「${tmpDirSlash}」のファイル列挙をJSONエンコードして表示。`)
+      const list = JSON.parse(g.log).sort()
+      assert.deepStrictEqual(list, ['[file.txt', 'a+.txt', 'a.txt', 'data.csv', 'image.png', 'sub', 'test.jpg', 'za.txt'])
+    })
+
+    it('複数パターンの指定 (*.jpg;*.png)', async () => {
+      const g = await run(`「${tmpDirSlash}/*.jpg;*.png」のファイル列挙をJSONエンコードして表示。`)
+      const list = JSON.parse(g.log).sort()
+      assert.deepStrictEqual(list, ['image.png', 'test.jpg'])
+    })
+
+    it('複数パターンの指定 (空白混じり *.jpg; *.png)', async () => {
+      const g = await run(`「${tmpDirSlash}/*.jpg; *.png」のファイル列挙をJSONエンコードして表示。`)
+      const list = JSON.parse(g.log).sort()
+      assert.deepStrictEqual(list, ['image.png', 'test.jpg'])
+    })
+
+    it('全ファイル列挙でも同様にワイルドカード照合される', async () => {
+      const g = await run(`「${tmpDirSlash}/a*.txt」の全ファイル列挙をJSONエンコードして表示。`)
+      const list = JSON.parse(g.log).map((p) => path.relative(tmpDir, p).replace(/\\/g, '/')).sort()
+      assert.deepStrictEqual(list, ['a+.txt', 'a.txt', 'sub/a.txt'])
+    })
+  })
 })


### PR DESCRIPTION
## 概要
#2492 の修正です。

`ファイル列挙` および `全ファイル列挙` において、ワイルドカード照合用の正規表現生成に先頭アンカー `^` がなく、また `.` や `*` 以外の正規表現メタ文字がエスケープされていなかったため、部分一致や不正正規表現エラー（SyntaxError）が発生していました。

## 変更内容
- `src/plugin_node.mts` に `wildcardToRegExp` ヘルパー関数を追加し、ワイルドカード照合を正規表現化するロジックを共通化
  - 各パターン（`*` を除く）に含まれる正規表現メタ文字（`[`, `+`, `(`, `?` 等）を安全にエスケープ
  - `*` を `.*` に変換
  - パターン全体を `^(?:...)$` で囲み、ファイル名全体に完全一致するように修正
  - `;` 区切りによる複数パターン指定や前後の空白トリムに対応
- `ファイル列挙` および `全ファイル列挙` で `wildcardToRegExp` を適用
- `test/node/plugin_node_test.mjs` に回帰テストを追加
  - 先頭アンカーによる部分一致防止（`a*.txt` で `za.txt` に一致しないこと）
  - 正規表現メタ文字のエスケープ（`[*.txt` で SyntaxError にならず一致すること）
  - `+` 記号の通常文字扱い（`a+*.txt`）
  - 末尾不一致の除外確認（`*.txt` で `a.txt.bak` に一致しないこと）
  - 複数パターン（`*.jpg;*.png`、空白混じり `*.jpg; *.png`）
  - `全ファイル列挙` でのワイルドカード照合
  - ワイルドカード未指定時の全列挙

## テスト結果
- `npm test` （全テストスイート 731 tests pass）
- `npm run test:doctest` （全 541 tests pass）
- `npm run eslint` （0 errors）
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kujirahand/nadesiko3/pull/2527" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->