### PR TITLE
表重複削除でtoString等のキーの行が消える問題を修正 (#2474)

### DIFF
--- a/core/src/plugin_system_array.mts
+++ b/core/src/plugin_system_array.mts
@@ -635,7 +635,9 @@ export default {
     fn: function(a: any, i: any) {
       if (!(a instanceof Array)) { throw new Error('『表重複削除』には配列を指定する必要があります。') }
       const res: any[] = []
-      const keys:{[key: string]: boolean} = {}
+      // #2474: toStringや__proto__等の継承プロパティを既出と誤判定しないようnullプロトタイプの辞書を使う。
+      // この辞書は関数内だけで使い、なでしこの内部処理へは渡さない。
+      const keys:{[key: string]: boolean} = Object.create(null)
       for (let n = 0; n < a.length; n++) {
         const k = a[n][i]
         if (undefined === keys[k]) {

--- a/core/test/plugin_system_test.mjs
+++ b/core/test/plugin_system_test.mjs
@@ -331,6 +331,15 @@ describe('plugin_system_test', async () => {
   })
   it('表重複削除', async () => {
     await cmp('A=[[1,2,3],[1,1,1],[4,5,6]];Aの0を表重複削除してJSONエンコードして表示。', '[[1,2,3],[4,5,6]]')
+    // #2474: Object.prototypeのプロパティ名と一致するキーが最初から消えないこと
+    await cmp('A=[["toString"],["constructor"],["ok"]];Aの0を表重複削除してJSONエンコードして表示。', '[["toString"],["constructor"],["ok"]]')
+    await cmp('A=[["__proto__"],["hasOwnProperty"],["valueOf"],["__proto__"]];Aの0を表重複削除してJSONエンコードして表示。', '[["__proto__"],["hasOwnProperty"],["valueOf"]]')
+    // 継承プロパティ名のキーでも重複は正しく除去される
+    await cmp('A=[["toString"],["toString"],["ok"]];Aの0を表重複削除してJSONエンコードして表示。', '[["toString"],["ok"]]')
+    // 従来通りキーは文字列化して比較する(数値の1と文字列の"1"は同一視)
+    await cmp('A=[[1],["1"],[2]];Aの0を表重複削除してJSONエンコードして表示。', '[[1],[2]]')
+    // キー列が存在しない行は"undefined"キーとして扱われる(従来契約の固定)
+    await cmp('A=[["a"],["b"]];Aの1を表重複削除してJSONエンコードして表示。', '[["a"]]')
   })
   it('表列取得', async () => {
     await cmp('A=[[1,2,3],[4,5,6]];Aの1を表列取得してJSONエンコードして表示。', '[2,5]')


### PR DESCRIPTION
## 概要

`表重複削除` の重複判定に通常の `{}` を使っていたため、キーが `Object.prototype` のプロパティ名と一致する行が「既出」と誤判定され、結果から失われる問題 (#2474) を修正します。

```nako3
A=[["toString"],["constructor"],["ok"]]
B=Aの0を表重複削除。
BをJSONエンコードして表示。 # 修正前: [["ok"]] / 修正後: [["toString"],["constructor"],["ok"]]
```

Close #2474

## 原因

`core/src/plugin_system_array.mts` の `表重複削除` が、既出キー管理に通常のオブジェクト `{}` を使い `undefined === keys[k]` で未出判定していました。`toString` や `constructor` など `Object.prototype` 上のプロパティは `keys[k]` が `undefined` にならないため初出の行が捨てられ、また `keys['__proto__'] = true` の代入は setter に吸われて記録されませんでした。

## 修正内容

- 既出キー管理の辞書を `Object.create(null)` (nullプロトタイプ) に変更しました。
  - 継承プロパティが `keys[k]` に現れないため、既存の `undefined === keys[k]` 判定が正しく機能します。
  - `keys['__proto__'] = true` も通常の own property として記録され、読み書き両面で正しく動作します。
  - この辞書は関数内だけで使い、なでしこの内部処理へは渡しません (`url_util.mts` が null プロトタイプを避ける理由には該当しません)。
- `Set`/`Map` は不採用: SameValueZero 比較になり、数値 `1` と文字列 `"1"` を同一視する従来のキー文字列化契約が変わるため。
- `Object.hasOwn` は `target: es2021` で型定義がないため不使用 (同ファイル `#2471` の対応と同じ理由)。

## テスト

`core/test/plugin_system_test.mjs` の `表重複削除` テストに回帰ケースを追加しました。

- `toString` / `constructor` を含む行が消えず全行保持されること
- `__proto__` / `hasOwnProperty` / `valueOf` の保持と `__proto__` の重複除去 (読み書き両面)
- 継承プロパティ名のキーでも重複が正しく除去されること
- キー文字列化契約の維持 (数値 `1` と文字列 `"1"` を同一視)
- キー列が存在しない行は `"undefined"` キーとして扱われる従来契約の固定

## 検証

- `npm run test:core` … 全1230件パス
- `npm run eslint` … 今回の変更による新規警告なし
- `tsc` … 変更箇所に関する型エラーなし

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kujirahand/nadesiko3/pull/2531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->