### PR TITLE
数列判定が符号のみで真になり整数の指数表記を拒否する問題を修正

### DIFF
--- a/core/src/plugin_system_string.mts
+++ b/core/src/plugin_system_string.mts
@@ -695,7 +695,7 @@ export default {
     josi: [['を', 'が']],
     pure: true,
     fn: function(s: any): boolean {
-      const checkerRE = /^[+\-＋－]?([0-9０-９]*)(([.．][0-9０-９]+)?|([.．][0-9０-９]+[eEｅＥ][+\-＋－]?[0-9０-９]+)?)$/
+      const checkerRE = /^[+\-＋－]?(([0-9０-９]+([.．][0-9０-９]+)?)|([.．][0-9０-９]+))([eEｅＥ][+\-＋－]?[0-9０-９]+)?$/
       if (s === '') { return false } // 空文字列はfalse
       return String(s).match(checkerRE) !== null
     }

--- a/core/src/plugin_system_string.mts
+++ b/core/src/plugin_system_string.mts
@@ -695,7 +695,7 @@ export default {
     josi: [['を', 'が']],
     pure: true,
     fn: function(s: any): boolean {
-      const checkerRE = /^[+\-＋－]?(([0-9０-９]+([.．][0-9０-９]+)?)|([.．][0-9０-９]+))([eEｅＥ][+\-＋－]?[0-9０-９]+)?$/
+      const checkerRE = /^[+\-＋－]?(([0-9０-９]+([.．][0-9０-９]*)?)|([.．][0-9０-９]+))([eEｅＥ][+\-＋－]?[0-9０-９]+)?$/
       if (s === '') { return false } // 空文字列はfalse
       return String(s).match(checkerRE) !== null
     }

--- a/core/test/plugin_system_test.mjs
+++ b/core/test/plugin_system_test.mjs
@@ -411,6 +411,11 @@ describe('plugin_system_test', async () => {
     await cmp('「1.234E-5」が数列か判定して表示。', 'true')
     // #2143 数列判定で空文字列を指定した時の問題
     await cmp('「」を数列判定して表示。', 'false')
+    // #2483 符号だけを受理し、整数仮数の指数表記を拒否する問題の修正
+    await cmp('「+」を数列判定して表示。', 'false')
+    await cmp('「-」を数列判定して表示。', 'false')
+    await cmp('「1e3」を数列判定して表示。', 'true')
+    await cmp('「1.0e3」を数列判定して表示。', 'true')
   })
   it('XOR', async () => {
     await cmp('XOR(0xFF, 0xF)を表示。', '240')

--- a/core/test/plugin_system_test.mjs
+++ b/core/test/plugin_system_test.mjs
@@ -416,6 +416,7 @@ describe('plugin_system_test', async () => {
     await cmp('「-」を数列判定して表示。', 'false')
     await cmp('「1e3」を数列判定して表示。', 'true')
     await cmp('「1.0e3」を数列判定して表示。', 'true')
+    await cmp('「123.e1」を数列判定して表示。', 'true')
   })
   it('XOR', async () => {
     await cmp('XOR(0xFF, 0xF)を表示。', '240')


### PR DESCRIPTION
## 概要

`数列判定` が `+` / `-` / `＋` / `－` のように符号だけで数字を含まない文字列に対して `true` を返してしまう問題と、`1e3` のような整数部の指数表記を `false` と判定してしまう問題を修正しました。

## 修正内容

- `core/src/plugin_system_string.mts` の `数列判定` で使用している正規表現を整理し、以下を満たすようにしました。
  - 数字を1文字以上必須にする(符号のみ・空文字は `false`)
  - 整数部・小数部どちらにも指数表記(`e`/`E`)を許可する
  - `.12345` のような先頭ドットの小数表記は引き続き許可する(既存の仕様を維持)
  - `#1423` / `#2143` で修正済みの符号対応・空文字対応は維持

## 修正前後の挙動

| 入力 | 修正前 | 修正後 |
| --- | --- | --- |
| `+` | true | false |
| `-` | true | false |
| `1e3` | false | true |
| `1.0e3` | true | true |
| `` (空文字) | false | false |

## テスト

- `core/test/plugin_system_test.mjs` の `数列か判定` テストに回帰テストを追加
- `npm test` / `npm run doctest` がすべて成功することを確認

Fixes #2483

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014C8jyQSKd17PnynbzE3z1i
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kujirahand/nadesiko3/pull/2532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->