### PR TITLE
一致と不一致の比較を左右対称に修正 #2487

### DIFF
--- a/core/src/plugin_system_math.mts
+++ b/core/src/plugin_system_math.mts
@@ -198,8 +198,8 @@ export default {
     josi: [['が'], ['と']],
     pure: true,
     fn: function(a: any, b: any) {
-      // オブジェクトの場合、JSONに変換して比較
-      if (typeof (a) === 'object') {
+      // 両者がオブジェクトの場合、JSONに変換して比較
+      if (typeof (a) === 'object' && typeof (b) === 'object') {
         const jsonA = JSON.stringify(a)
         const jsonB = JSON.stringify(b)
         return jsonA === jsonB
@@ -212,8 +212,8 @@ export default {
     josi: [['が'], ['と']],
     pure: true,
     fn: function(a: any, b: any) {
-      // オブジェクトの場合、JSONに変換して比較
-      if (typeof (a) === 'object') {
+      // 両者がオブジェクトの場合、JSONに変換して比較
+      if (typeof (a) === 'object' && typeof (b) === 'object') {
         const jsonA = JSON.stringify(a)
         const jsonB = JSON.stringify(b)
         return jsonA !== jsonB

--- a/core/test/plugin_system_test.mjs
+++ b/core/test/plugin_system_test.mjs
@@ -620,6 +620,10 @@ describe('plugin_system_test', async () => {
     await cmp('[1,2,3]と[2,3]が一致。もしそうなら"NG"を表示。違えば"OK"を表示。', 'OK')
     await cmp('["a",2,3]と["a",2,3]が一致。もしそうなら"OK"を表示。違えば"NG"を表示。', 'OK')
   })
+  it('一致と不一致の比較は左右対称 #2487', async () => {
+    await cmp('NULLと非数が一致を表示。非数とNULLが一致を表示。', 'false\nfalse')
+    await cmp('NULLと非数が不一致を表示。非数とNULLが不一致を表示。', 'true\ntrue')
+  })
   it('「ナデシコ」が空白行を出力してしまう問題の修正', async () => {
     let lineCount = 0
     const nako = new NakoCompiler()


### PR DESCRIPTION
## 概要

`一致`と`不一致`で比較対象の左右を入れ替えると、結果が変わる問題を修正します。

## 原因

左辺が`object`の場合だけJSON比較へ切り替えていたため、`typeof null === "object"`かつ`JSON.stringify(null) === JSON.stringify(NaN)`となる組み合わせで比較が非対称になっていました。

## 修正内容

- 両者がともに`object`の場合だけJSON化して比較
- それ以外は従来どおり`===` / `!==`で比較
- `NULL`と`非数`を左右入れ替えて確認する回帰テストを追加

配列・辞書の構造比較は維持し、キー順や`undefined`の省略などJSON比較自体の仕様は変更しません。

## テスト

- `npm run build:tsc`
- `node --test core/test/plugin_system_test.mjs`
- `npm run eslint`
- `npm test`

Closes #2487
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kujirahand/nadesiko3/pull/2536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->