### PR TITLE
関数の引数名にtoString等を使うと字句解析がクラッシュする問題を修正 (#2530)

### DIFF
--- a/core/src/nako_lexer.mts
+++ b/core/src/nako_lexer.mts
@@ -132,7 +132,9 @@ export class NakoLexer {
     let isFuncPointer = false
     const readArgs = () => {
       const args: Token[] = []
-      const keys:{[key:string]: string[]} = {}
+      // #2530: toStringや__proto__等の継承プロパティを引数名として使えるようnullプロトタイプの辞書を使う。
+      // この辞書は関数内だけで使い、なでしこの内部処理へは渡さない。
+      const keys:{[key:string]: string[]} = Object.create(null)
       if (tokens[i].type !== '(') { return [] }
       i++
       while (tokens[i]) {
@@ -153,7 +155,8 @@ export class NakoLexer {
       const varnames: string[] = []
       const funcPointers: any[] = []
       const result: FuncArgs = []
-      const already: {[key: string]: boolean} = {}
+      // #2530: keysと同様に継承プロパティ名の引数を既出と誤判定しないようnullプロトタイプの辞書を使う。
+      const already: {[key: string]: boolean} = Object.create(null)
       for (const arg of args) {
         if (!already[arg.value]) {
           const josi = keys[arg.value]

--- a/core/test/func_test.mjs
+++ b/core/test/func_test.mjs
@@ -152,6 +152,18 @@ describe('func_test', async () => {
     await cmp('●(fでaを)演算処理とは\nf(a)を表示\nここまで\n' +
       '2を演算処理には(a)\nそれはa*2\nここまで\n', '4')
   })
+  it('Object.prototypeのプロパティ名と一致する引数名を使える #2530', async () => {
+    // 字句解析が TypeError でクラッシュしないこと
+    await cmp('●(toStringを)試すとは\nそれは1。\nここまで\n試す。それを表示。', '1')
+    await cmp('●(constructorと__proto__でhasOwnPropertyを)試すBとは\n「{constructor}/{__proto__}/{hasOwnProperty}」を表示。\nここまで\n「あ」と「い」で「う」を試すB。', 'あ/い/う')
+    await cmp('●(valueOfを)試すC\nそれは3。\nここまで\n試すC。それを表示。', '3')
+    // 同名引数の重複登録抑止も従来通り動くこと
+    await cmp('●(toStringをtoStringと)試すD\nそれはtoString。\nここまで\n5を試すD。それを表示。', '5')
+    // 無名関数でも同様に動くこと
+    await cmp('F=関数(toStringを)それはtoString+1;ここまで。\nF(10)を表示。', '11')
+    // 通常の引数名は引き続き使えること(対照)
+    await cmp('●(名前を)普通関数\n名前を表示。\nここまで\n「殿」を普通関数。', '殿')
+  })
   it('**すること #936', async () => {
     await cmp('●(AとBを)加算処理とは\nAとBを足すこと。。。3と5を加算処理して表示。', '8')
     await cmp('●(Nを)二乗処理とは;A=0；N回,AにNを足してAに代入すること。それはA。。。5を二乗処理して表示。', '25')


### PR DESCRIPTION
## 概要

ユーザー定義関数の引数名をキーにした辞書(`keys` / `already`)に通常の `{}` が使われていたため、引数名が `Object.prototype` のプロパティ名と一致すると字句解析が TypeError で失敗していました。#2474 と同じ原因クラスの問題(#2530)を修正します。

```nako3
●(toStringを)試すとは
　それは1。
ここまで。
試す。それを表示。  # 修正前: [エラー]keys[t.value].push is not a function / 修正後: 1
```

Close #2530

## 原因

`core/src/nako_lexer.mts` の `preDefineFunc` 内 `readArgs` で、引数名をキーにした2つの辞書が通常の `{}` でした。

- `keys['toString']` が継承された `Object.prototype.toString`(truthy)を返すため初期化がスキップされ、続く `.push` が `push is not a function` で失敗
- `already['toString']` も truthy になるため、`keys` 側だけ直しても引数が登録されない問題が残る

## 修正内容

- `keys` / `already` の両方を null プロトタイプ辞書(`Object.create(null)`)に変更(#2474 と同方針)
  - どちらも `readArgs` 内のローカル変数で、なでしこの内部処理へは渡りません
  - `Object.hasOwn` は既定 lib が es2021 系で型定義がなく使えないため同方針を採用

## テスト

`core/test/func_test.mjs` に回帰テストを追加しました。

- Issue再現ケース(`toString` を引数名にした関数定義)でクラッシュしないことを検証
- `constructor` / `__proto__` / `hasOwnProperty` / `valueOf` を引数名にした定義・呼び出しを検証
- 同名引数の重複登録抑止(`already` の既出判定)が従来通り動くことを検証
- 無名関数 `関数(toStringを)` でも同様に動くことを検証
- 対照として通常の引数名(`名前`)が引き続き使えることを検証

## 検証

- `npm run test:core` … 全1231件パス
- `npm run test:common` … 全35件パス
- `npm run eslint` … 今回の変更による新規警告なし
- `tsc` … 変更箇所に関する型エラーなし
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kujirahand/nadesiko3/pull/2537" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->