### PR TITLE
multipart受信でContent-Typeの大小文字違いやboundary欠落によりフィールドが消える問題を修正 (#2495)

### DIFF
--- a/src/plugin_httpserver.mts
+++ b/src/plugin_httpserver.mts
@@ -109,13 +109,11 @@ class EasyURLDispather {
           // パラメータ部(;以降)を除いたメディア型本体で判定する
           const mediaType = contentType.split(';', 1)[0].trim().toLowerCase()
           if (mediaType === 'multipart/form-data') {
-            // boundaryパラメータ名も大小文字を区別しない。値は引用符付き/なし両方を許容する。
-            // メディア型がmultipartの場合boundaryは必ず';'以降のパラメータ部にあるため';'にアンカーし、
-            // xboundary=のような別名パラメータへの誤マッチを防ぐ。空・空白のみの非引用値はマッチさせず、
-            // 重複パラメータ時に後続の有効なboundaryを拾えるようにする(旧来の挙動との互換)
-            // 既知の制限: 他パラメータの引用値内に現れる '; boundary=' には誤マッチし得る(旧来と同じ挙動)
-            const boundaryMatch = contentType.match(/;\s*boundary\s*=\s*(?:"([^"]*)"|([^\s;][^;]*))/i)
-            const boundary = boundaryMatch ? (boundaryMatch[1] ?? boundaryMatch[2] ?? '').trim() : ''
+            // boundaryパラメータは quoted-string とエスケープを認識するパーサ(parseContentDisposition)で取得する。
+            // パラメータ名は大小文字を区別せず、`=`前後の空白・引用符付き値も許容する(非引用値はtokenとして解釈)。
+            // 正規表現だと他パラメータの引用値内に現れる '; boundary=' に誤マッチするため。
+            // 重複パラメータは常に最後の値を採用する(後勝ち)
+            const boundary = (parseContentDisposition(contentType)['boundary'] ?? '').trim()
             if (boundary === '') {
               // boundaryが得られない不正なmultipart要求は、フィールドを静かに消さず400を返す(#2495)
               console.error(`${HTTPSERVER_LOGID} multipart/form-data 要求に boundary がありません`)
@@ -255,12 +253,14 @@ class EasyURLDispather {
     return params
   }
 }
-/** Content-Disposition ヘッダ値を解析してパラメータ辞書を返す。
- * `form-data; name="upload"; filename="photo.txt"` のような形式を、
- * `;`区切りで `キー=値` 形式として取り出す。値がダブルクォート付きの場合は
- * quoted-string として解析し、値中の `;`・`=`・エスケープ(`\"`, `\\`)も処理する。
- * キーは大文字小文字を区別しない。`=` 前後の Optional Whitespace は許容する。
- * パラメータの順序に依存せず `name` と `filename` を正しく分離するためのヘルパー。(#2494)
+/** `;`区切りの `キー=値` パラメータを持つヘッダ値を解析してパラメータ辞書を返す汎用パーサ。
+ * Content-Disposition(`form-data; name="upload"; filename="photo.txt"`)や
+ * Content-Type(`multipart/form-data; boundary=X`)の解析に使用する。
+ * 値がダブルクォート付きの場合は quoted-string として解析し、値中の `;`・`=`・
+ * エスケープ(`\"`, `\\`)も処理する。非引用値は RFC 7230 の token として解釈する。
+ * キーは大文字小文字を区別しない(小文字化して格納)。`=` 前後の Optional Whitespace は許容する。
+ * パラメータの順序に依存せず `name` と `filename` を正しく分離するためのヘルパーとして導入し、
+ * Content-Type の boundary 取得にも流用する。(#2494)
  */
 // RFC 7230 の separators を使用。ただし `'` は tchar であると同時に
 // RFC 5987 の `charset'language'value` 区切りにも使うため区切り文字として扱わない。

--- a/src/plugin_httpserver.mts
+++ b/src/plugin_httpserver.mts
@@ -112,8 +112,9 @@ class EasyURLDispather {
             // boundaryパラメータは quoted-string とエスケープを認識するパーサ(parseContentDisposition)で取得する。
             // パラメータ名は大小文字を区別せず、`=`前後の空白・引用符付き値も許容する(非引用値はtokenとして解釈)。
             // 正規表現だと他パラメータの引用値内に現れる '; boundary=' に誤マッチするため。
-            // 重複パラメータは常に最後の値を採用する(後勝ち)
-            const boundary = (parseContentDisposition(contentType)['boundary'] ?? '').trim()
+            // strictモードを有効にし、前のパラメータとの `;` 区切りがないboundaryは採用しない
+            // (区切り欠落の不正要求を400にするため)。重複パラメータは常に最後の値を採用する(後勝ち)
+            const boundary = (parseContentDisposition(contentType, true)['boundary'] ?? '').trim()
             if (boundary === '') {
               // boundaryが得られない不正なmultipart要求は、フィールドを静かに消さず400を返す(#2495)
               console.error(`${HTTPSERVER_LOGID} multipart/form-data 要求に boundary がありません`)
@@ -261,6 +262,10 @@ class EasyURLDispather {
  * キーは大文字小文字を区別しない(小文字化して格納)。`=` 前後の Optional Whitespace は許容する。
  * パラメータの順序に依存せず `name` と `filename` を正しく分離するためのヘルパーとして導入し、
  * Content-Type の boundary 取得にも流用する。(#2494)
+ * strict を true にすると、各パラメータが必ず `;` の直後から始まり、値の後が OWS を除いて
+ * `;` または末尾であることを検証する。区切りのない断片に遭遇した時点で解析を打ち切り、
+ * それ以降のパラメータは採用しない(先頭の型部分は最初の `;` まで読み飛ばす)。
+ * Content-Type の boundary 取得のように区切り欠落を受理したくない用途向け。(#2495)
  */
 // RFC 7230 の separators を使用。ただし `'` は tchar であると同時に
 // RFC 5987 の `charset'language'value` 区切りにも使うため区切り文字として扱わない。
@@ -316,34 +321,46 @@ function parseCDValue(headerValue: string, start: number): { value: string, next
   return { value: val, next: i }
 }
 
-function parseContentDisposition(headerValue: string): { [key: string]: string } {
+function parseContentDisposition(headerValue: string, strict = false): { [key: string]: string } {
   // obs-fold (CRLF 1*(SP/HTAB)) を単一 SP に正規化してから解析する
   const normalized = headerValue.replace(/\r\n[ \t]+/g, ' ')
   // Object.create(null)により __proto__ 等のキーでもプロトタイプ汚染せず、自前プロパティとして扱える
   const params: { [key: string]: string } = Object.create(null)
   let i = 0
 
-  // 先頭の disposition-type (form-data/inline/attachment 等) を token として読み、
-  // その後の OWS と `;` を正しくスキップする。
-  // `name="foo"` のように type がない場合(= が先に現れる場合)はスキップせず
-  // その位置からパラメータ解析を始める
-  let j = 0
-  while (j < normalized.length && CD_SEPARATORS.indexOf(normalized[j]) < 0 &&
-         normalized.charCodeAt(j) >= 0x21 && normalized.charCodeAt(j) <= 0x7e) { j++ }
-  while (j < normalized.length && (normalized[j] === ' ' || normalized[j] === '\t')) { j++ }
-  if (j < normalized.length && normalized[j] === ';') {
-    i = j + 1
-  } else if (j < normalized.length && normalized[j] === '=') {
-    // type がなく最初のパラメータから始まる
-    i = 0
+  if (strict) {
+    // strict モードでは先頭の型部分を読み飛ばし、最初の ';' 以降をパラメータ部とする
+    const semiIdx = normalized.indexOf(';')
+    i = semiIdx >= 0 ? semiIdx + 1 : normalized.length
   } else {
-    // disposition-type の後に ; も = もない場合は、その位置からパラメータ解析を再開する
-    i = j
+    // 先頭の disposition-type (form-data/inline/attachment 等) を token として読み、
+    // その後の OWS と `;` を正しくスキップする。
+    // `name="foo"` のように type がない場合(= が先に現れる場合)はスキップせず
+    // その位置からパラメータ解析を始める
+    let j = 0
+    while (j < normalized.length && CD_SEPARATORS.indexOf(normalized[j]) < 0 &&
+           normalized.charCodeAt(j) >= 0x21 && normalized.charCodeAt(j) <= 0x7e) { j++ }
+    while (j < normalized.length && (normalized[j] === ' ' || normalized[j] === '\t')) { j++ }
+    if (j < normalized.length && normalized[j] === ';') {
+      i = j + 1
+    } else if (j < normalized.length && normalized[j] === '=') {
+      // type がなく最初のパラメータから始まる
+      i = 0
+    } else {
+      // disposition-type の後に ; も = もない場合は、その位置からパラメータ解析を再開する
+      i = j
+    }
   }
 
   while (i < normalized.length) {
-    // セパレータと空白をスキップ
-    while (i < normalized.length && (normalized[i] === ';' || normalized[i] === ' ' || normalized[i] === '\t')) { i++ }
+    if (strict) {
+      // strict モードでは ';' は直前の値の後に消費済みなので OWS のみスキップする。
+      // ここで OWS 以外が続く場合は区切りのない断片であり、後続の解析を打ち切る
+      while (i < normalized.length && (normalized[i] === ' ' || normalized[i] === '\t')) { i++ }
+    } else {
+      // セパレータと空白をスキップ
+      while (i < normalized.length && (normalized[i] === ';' || normalized[i] === ' ' || normalized[i] === '\t')) { i++ }
+    }
     if (i >= normalized.length) { break }
 
     const iterStart = i
@@ -355,7 +372,9 @@ function parseContentDisposition(headerValue: string): { [key: string]: string }
     // = 前の Optional Whitespace をスキップする
     while (i < normalized.length && (normalized[i] === ' ' || normalized[i] === '\t')) { i++ }
     if (i >= normalized.length || normalized[i] !== '=') {
-      // 不正な断片で i が進まないと無限ループになるため、最低1文字進める
+      // strict モードでは '=' を伴わない不正な断片(空パラメータやベアトークン等)は打ち切る。
+      // 非 strict では不正な断片で i が進まないと無限ループになるため、最低1文字進める
+      if (strict) { break }
       if (i <= iterStart) { i++ }
       continue
     }
@@ -366,6 +385,14 @@ function parseContentDisposition(headerValue: string): { [key: string]: string }
     const parsed = parseCDValue(normalized, i)
     i = parsed.next
     if (i <= iterStart) { i++ }
+
+    if (strict) {
+      // strict モードでは値の後が OWS を除いて ';' または末尾でなければならない。
+      // 区切り欠落ならこの値自体も採用せず打ち切る
+      while (i < normalized.length && (normalized[i] === ' ' || normalized[i] === '\t')) { i++ }
+      if (i < normalized.length && normalized[i] !== ';') { break }
+      if (i < normalized.length) { i++ }
+    }
 
     // RFC 7230 の token 文字のみをキーとして有効にする(空キーや不正な文字は無視)
     if (!CD_KEY_RE.test(key)) { continue }

--- a/src/plugin_httpserver.mts
+++ b/src/plugin_httpserver.mts
@@ -105,22 +105,37 @@ class EasyURLDispather {
         let filesData: any[] = []
         const contentType = req.headers['content-type'] || ''
         try {
-          if (contentType.indexOf('multipart/form-data') >= 0) {
-            const boundaryMatch = contentType.match(/boundary=(?:"([^"]+)"|([^;]+))/)
-            if (boundaryMatch) {
-              const boundary = (boundaryMatch[1] || boundaryMatch[2] || '').trim()
-              const parsed = await parseMultipart(bodyBuffer, boundary)
-              postData = parsed.fields
-              filesData = parsed.files
+          // メディア型は大小文字を区別しない(RFC 2045)ため小文字化して比較する。
+          // パラメータ部(;以降)を除いたメディア型本体で判定する
+          const mediaType = contentType.split(';', 1)[0].trim().toLowerCase()
+          if (mediaType === 'multipart/form-data') {
+            // boundaryパラメータ名も大小文字を区別しない。値は引用符付き/なし両方を許容する。
+            // メディア型がmultipartの場合boundaryは必ず';'以降のパラメータ部にあるため';'にアンカーし、
+            // xboundary=のような別名パラメータへの誤マッチを防ぐ。空・空白のみの非引用値はマッチさせず、
+            // 重複パラメータ時に後続の有効なboundaryを拾えるようにする(旧来の挙動との互換)
+            // 既知の制限: 他パラメータの引用値内に現れる '; boundary=' には誤マッチし得る(旧来と同じ挙動)
+            const boundaryMatch = contentType.match(/;\s*boundary\s*=\s*(?:"([^"]*)"|([^\s;][^;]*))/i)
+            const boundary = boundaryMatch ? (boundaryMatch[1] ?? boundaryMatch[2] ?? '').trim() : ''
+            if (boundary === '') {
+              // boundaryが得られない不正なmultipart要求は、フィールドを静かに消さず400を返す(#2495)
+              console.error(`${HTTPSERVER_LOGID} multipart/form-data 要求に boundary がありません`)
+              res.statusCode = 400
+              res.end('Bad Request.')
+              return
             }
-          } else if (contentType.indexOf('application/json') >= 0) {
+            const parsed = await parseMultipart(bodyBuffer, boundary)
+            postData = parsed.fields
+            filesData = parsed.files
+          } else if (mediaType === 'application/json' || mediaType.startsWith('application/json-') || mediaType.endsWith('+json')) {
+            // application/json-patch+json 等の +json 接尾辞(RFC 6839)や、application/json-home 等の
+            // application/json- で始まるIANA登録済みメディア型も JSON として解析する(旧来の部分一致判定との互換維持)
             const bodyStr = bodyBuffer.toString('utf-8')
             try {
               postData = JSON.parse(bodyStr)
             } catch {
               postData = bodyStr
             }
-          } else if (contentType.indexOf('application/x-www-form-urlencoded') >= 0) {
+          } else if (mediaType === 'application/x-www-form-urlencoded') {
             const bodyStr = bodyBuffer.toString('utf-8')
             postData = parseQueryString(bodyStr)
           } else {

--- a/test/node/plugin_httpserver_test.mjs
+++ b/test/node/plugin_httpserver_test.mjs
@@ -563,6 +563,19 @@ describe('plugin_httpserver_test', () => {
       `--${escapedBoundary}--\r\n`
     ].join(''))
     assert.deepStrictEqual(await postRequest('multipart/form-data; boundary="a\\\\b"', escapedBody), { statusCode: 200, body: 'hello' })
+    // 前のパラメータとの `;` 区切りがないboundaryは採用せず400を返す(厳格モード)
+    assert.deepStrictEqual(await postRequest(`multipart/form-data; note="x"boundary=${boundary}`), { statusCode: 400, body: 'Bad Request.' })
+    assert.deepStrictEqual(await postRequest(`multipart/form-data; note="x" boundary=${boundary}`), { statusCode: 400, body: 'Bad Request.' })
+    assert.deepStrictEqual(await postRequest(`multipart/form-data; note=x boundary=${boundary}`), { statusCode: 400, body: 'Bad Request.' })
+    assert.deepStrictEqual(await postRequest(`multipart/form-data; x boundary=${boundary}`), { statusCode: 400, body: 'Bad Request.' })
+    // `;;` のように空のパラメータが挟まれた場合も不正な断片とみなし400を返す
+    assert.deepStrictEqual(await postRequest(`multipart/form-data;; boundary=${boundary}`), { statusCode: 400, body: 'Bad Request.' })
+    // 有効なboundaryの直後に区切りのない断片があっても400を返す(そのパラメータ自体が区切り欠落)
+    assert.deepStrictEqual(await postRequest(`multipart/form-data; boundary=${boundary} note="y"`), { statusCode: 400, body: 'Bad Request.' })
+    // 正しく `;` 区切りのパラメータは引き続き解析できる
+    assert.deepStrictEqual(await postRequest(`multipart/form-data; note="x"; boundary=${boundary}`), { statusCode: 200, body: 'hello' })
+    // 末尾の `;` は後続パラメータがないため許容される
+    assert.deepStrictEqual(await postRequest(`multipart/form-data; boundary=${boundary};`), { statusCode: 200, body: 'hello' })
     // 400応答の後もサーバが生きていて正常な要求を処理できる
     assert.deepStrictEqual(await postRequest(`multipart/form-data; boundary=${boundary}`), { statusCode: 200, body: 'hello' })
   })

--- a/test/node/plugin_httpserver_test.mjs
+++ b/test/node/plugin_httpserver_test.mjs
@@ -530,17 +530,21 @@ describe('plugin_httpserver_test', () => {
     assert.deepStrictEqual(await postRequest('text/foo+json', jsonBody), { statusCode: 200, body: 'hello' })
     // urlencodedも大小文字を区別しない
     assert.deepStrictEqual(await postRequest('APPLICATION/X-WWW-FORM-URLENCODED', Buffer.from('a=hello')), { statusCode: 200, body: 'hello' })
-    // 空・空白のみの非引用boundaryが先にあっても、後続の有効なboundaryで解析される(旧来の挙動との互換)
+    // 空・空白のみの非引用boundaryが先にあっても、後続の有効なboundaryで解析される(重複パラメータは後勝ち)
     assert.deepStrictEqual(await postRequest(`multipart/form-data; boundary=; boundary=${boundary}`), { statusCode: 200, body: 'hello' })
     assert.deepStrictEqual(await postRequest(`multipart/form-data; boundary= ; boundary=${boundary}`), { statusCode: 200, body: 'hello' })
-    // 引用符付きの空boundaryは空値として確定し400になる(非引用の空値とは対称でない点は旧来の先勝ち仕様を継承)
-    assert.deepStrictEqual(await postRequest(`multipart/form-data; boundary=""; boundary=${boundary}`), { statusCode: 400, body: 'Bad Request.' })
+    // 引用符付きの空boundaryも後続の有効なboundaryで上書きされる(後勝ち)
+    assert.deepStrictEqual(await postRequest(`multipart/form-data; boundary=""; boundary=${boundary}`), { statusCode: 200, body: 'hello' })
+    // 末尾が空のboundaryなら後勝ちで空になり400を返す
+    assert.deepStrictEqual(await postRequest(`multipart/form-data; boundary=${boundary}; boundary=`), { statusCode: 400, body: 'Bad Request.' })
     // `=`と値の間の空白は許容される
     assert.deepStrictEqual(await postRequest(`multipart/form-data; boundary= ${boundary}`), { statusCode: 200, body: 'hello' })
     // `;`を欠くmalformedなContent-Typeはmultipartとは扱われず生本文として処理される(厳格化)
     assert.deepStrictEqual(await postRequest(`multipart/form-data boundary=${boundary}`), { statusCode: 200, body: 'undefined' })
     // `;`直後の空白がなくても解析できる
     assert.deepStrictEqual(await postRequest(`multipart/form-data;boundary=${boundary}`), { statusCode: 200, body: 'hello' })
+    // 他パラメータの引用値内にある '; boundary=' には誤マッチしない(quoted-string考慮のパーサで解析)
+    assert.deepStrictEqual(await postRequest(`multipart/form-data; note="x; boundary=fake"; boundary=${boundary}`), { statusCode: 200, body: 'hello' })
     // 引用符内の`;`を含むboundary値も正しく取得できる
     const semicolonBoundary = 'a;b'
     const semicolonBody = Buffer.from([
@@ -550,6 +554,15 @@ describe('plugin_httpserver_test', () => {
       `--${semicolonBoundary}--\r\n`
     ].join(''))
     assert.deepStrictEqual(await postRequest('multipart/form-data; boundary="a;b"', semicolonBody), { statusCode: 200, body: 'hello' })
+    // 引用符内のエスケープ(quoted-pair)を解除してboundary値を取得できる
+    const escapedBoundary = 'a\\b'
+    const escapedBody = Buffer.from([
+      `--${escapedBoundary}\r\n`,
+      `Content-Disposition: form-data; name="a"\r\n\r\n`,
+      `hello\r\n`,
+      `--${escapedBoundary}--\r\n`
+    ].join(''))
+    assert.deepStrictEqual(await postRequest('multipart/form-data; boundary="a\\\\b"', escapedBody), { statusCode: 200, body: 'hello' })
     // 400応答の後もサーバが生きていて正常な要求を処理できる
     assert.deepStrictEqual(await postRequest(`multipart/form-data; boundary=${boundary}`), { statusCode: 200, body: 'hello' })
   })

--- a/test/node/plugin_httpserver_test.mjs
+++ b/test/node/plugin_httpserver_test.mjs
@@ -455,6 +455,105 @@ describe('plugin_httpserver_test', () => {
     assert.match(await postMultipart('form-data; name=" upload "; filename=" photo.txt "'), /^OK: upload : photo\.txt :[0-9]+_[0-9A-Za-z_-]+_photo\.txt$/)
   })
 
+  it('multipart受信でContent-Typeの大小文字違いでも解析でき、boundary欠落時は400を返すこと #2495', async () => {
+    let port = 0
+    const code = `
+●ダミー起動
+  戻る。
+ここまで。
+●受信処理
+  「{POSTデータ["a"]}」を簡易HTTPサーバ出力。
+ここまで。
+「ダミー起動」を${port}で簡易HTTPサーバ起動時。
+「受信処理」を「/post-multipart」に簡易HTTPサーバ受信時。
+`
+    const g = await nako.runAsync(code, 'main')
+    serverDp = g.__httpserver
+    await wait(100)
+    port = serverDp.server.address().port
+
+    const boundary = 'XcB1Y'
+    const parts = [
+      `--${boundary}\r\n`,
+      `Content-Disposition: form-data; name="a"\r\n\r\n`,
+      `hello\r\n`,
+      `--${boundary}--\r\n`
+    ]
+    const postData = Buffer.from(parts.join(''))
+
+    const postRequest = (contentType, body = postData) => new Promise((resolve, reject) => {
+      const req = http.request({
+        hostname: 'localhost',
+        port: port,
+        path: '/post-multipart',
+        method: 'POST',
+        headers: {
+          'Content-Type': contentType,
+          'Content-Length': body.length
+        }
+      }, (res) => {
+        let data = ''
+        res.setEncoding('utf8')
+        res.on('data', (chunk) => { data += chunk })
+        res.on('end', () => { resolve({ statusCode: res.statusCode, body: data }) })
+      })
+      req.on('error', reject)
+      req.write(body)
+      req.end()
+    })
+
+    // 小文字 → 正しく解析される
+    assert.deepStrictEqual(await postRequest(`multipart/form-data; boundary=${boundary}`), { statusCode: 200, body: 'hello' })
+    // メディア型の大小文字違いでも解析される(RFC 2045/2046)
+    assert.deepStrictEqual(await postRequest(`Multipart/Form-Data; boundary=${boundary}`), { statusCode: 200, body: 'hello' })
+    assert.deepStrictEqual(await postRequest(`MULTIPART/FORM-DATA; boundary=${boundary}`), { statusCode: 200, body: 'hello' })
+    // boundaryパラメータ名の大小文字違い・`=`前後の空白・引用符付きの値も許容する
+    assert.deepStrictEqual(await postRequest(`multipart/form-data; BOUNDARY=${boundary}`), { statusCode: 200, body: 'hello' })
+    assert.deepStrictEqual(await postRequest(`multipart/form-data; boundary = "${boundary}"`), { statusCode: 200, body: 'hello' })
+    // boundaryが先頭以外のパラメータ位置にあっても正しく取得できる
+    assert.deepStrictEqual(await postRequest(`multipart/form-data; charset=utf-8; boundary=${boundary}`), { statusCode: 200, body: 'hello' })
+    // boundaryが得られない不正なmultipart要求には400を返す(静かにフィールドを消さない)
+    assert.deepStrictEqual(await postRequest('multipart/form-data'), { statusCode: 400, body: 'Bad Request.' })
+    assert.deepStrictEqual(await postRequest('Multipart/Form-Data'), { statusCode: 400, body: 'Bad Request.' })
+    assert.deepStrictEqual(await postRequest('multipart/form-data; charset=utf-8'), { statusCode: 400, body: 'Bad Request.' })
+    // 空のboundaryも400を返す
+    assert.deepStrictEqual(await postRequest('multipart/form-data; boundary='), { statusCode: 400, body: 'Bad Request.' })
+    assert.deepStrictEqual(await postRequest('multipart/form-data; boundary=""'), { statusCode: 400, body: 'Bad Request.' })
+    // JSON系メディア型はパラメータ付き・大小文字違い・+json接尾辞(RFC 6839)でもJSONとして解析される
+    const jsonBody = Buffer.from('{"a":"hello"}')
+    assert.deepStrictEqual(await postRequest('application/json; charset=utf-8', jsonBody), { statusCode: 200, body: 'hello' })
+    assert.deepStrictEqual(await postRequest('Application/JSON', jsonBody), { statusCode: 200, body: 'hello' })
+    assert.deepStrictEqual(await postRequest('application/json-patch+json', jsonBody), { statusCode: 200, body: 'hello' })
+    // application/json- で始まるIANA登録済みメディア型もJSONとして解析される(旧来の部分一致判定との互換)
+    assert.deepStrictEqual(await postRequest('application/json-home', jsonBody), { statusCode: 200, body: 'hello' })
+    // application/以外の +json 接尾辞もJSONとして解析される(RFC 6839)
+    assert.deepStrictEqual(await postRequest('text/foo+json', jsonBody), { statusCode: 200, body: 'hello' })
+    // urlencodedも大小文字を区別しない
+    assert.deepStrictEqual(await postRequest('APPLICATION/X-WWW-FORM-URLENCODED', Buffer.from('a=hello')), { statusCode: 200, body: 'hello' })
+    // 空・空白のみの非引用boundaryが先にあっても、後続の有効なboundaryで解析される(旧来の挙動との互換)
+    assert.deepStrictEqual(await postRequest(`multipart/form-data; boundary=; boundary=${boundary}`), { statusCode: 200, body: 'hello' })
+    assert.deepStrictEqual(await postRequest(`multipart/form-data; boundary= ; boundary=${boundary}`), { statusCode: 200, body: 'hello' })
+    // 引用符付きの空boundaryは空値として確定し400になる(非引用の空値とは対称でない点は旧来の先勝ち仕様を継承)
+    assert.deepStrictEqual(await postRequest(`multipart/form-data; boundary=""; boundary=${boundary}`), { statusCode: 400, body: 'Bad Request.' })
+    // `=`と値の間の空白は許容される
+    assert.deepStrictEqual(await postRequest(`multipart/form-data; boundary= ${boundary}`), { statusCode: 200, body: 'hello' })
+    // `;`を欠くmalformedなContent-Typeはmultipartとは扱われず生本文として処理される(厳格化)
+    assert.deepStrictEqual(await postRequest(`multipart/form-data boundary=${boundary}`), { statusCode: 200, body: 'undefined' })
+    // `;`直後の空白がなくても解析できる
+    assert.deepStrictEqual(await postRequest(`multipart/form-data;boundary=${boundary}`), { statusCode: 200, body: 'hello' })
+    // 引用符内の`;`を含むboundary値も正しく取得できる
+    const semicolonBoundary = 'a;b'
+    const semicolonBody = Buffer.from([
+      `--${semicolonBoundary}\r\n`,
+      `Content-Disposition: form-data; name="a"\r\n\r\n`,
+      `hello\r\n`,
+      `--${semicolonBoundary}--\r\n`
+    ].join(''))
+    assert.deepStrictEqual(await postRequest('multipart/form-data; boundary="a;b"', semicolonBody), { statusCode: 200, body: 'hello' })
+    // 400応答の後もサーバが生きていて正常な要求を処理できる
+    assert.deepStrictEqual(await postRequest(`multipart/form-data; boundary=${boundary}`), { statusCode: 200, body: 'hello' })
+  })
+
   it('HTTPメソッドにGET/POST/PUT/DELETEが設定されること', async () => {
     let port = 0
     const code = `


### PR DESCRIPTION
## 概要

簡易HTTPサーバの multipart 受信で、Content-Type のメディア型を大小文字一致で判定していたため、`Multipart/Form-Data` のような表記だとフィールドが解析されず消えていました。また boundary パラメータが得られない場合もエラーにせず空データのまま処理が進んでいました（#2495）。

```nako3
●受信処理
  POSTデータ["a"]を簡易HTTPサーバ出力。
ここまで。
# POST に Content-Type: Multipart/Form-Data; boundary=X で送信
# 修正前: フィールドが解析されず空 / 修正後: 「a」の値が取れる
```

Close #2495 

## 原因

`src/plugin_httpserver.mts` の POST ボディ解析で、`contentType.indexOf('multipart/form-data')` による大小文字を区別する部分一致で判定していたため、大小文字違いのメディア型が未認識となっていました。さらに boundary が抽出できない場合にもそのまま空データでディスパッチしていました。

## 修正内容

- メディア型判定を `split(';', 1)[0].trim().toLowerCase()` による厳密比較に変更し、大小文字を区別せず比較するようにしました(RFC 2045/2046)。
  - `application/json` は `application/json-` 接頭辞型(json-home 等)と `+json` 接尾辞型(RFC 6839、json-patch+json 等)も JSON として解析し、旧来の部分一致判定との互換を維持
  - `application/x-www-form-urlencoded` も同様に大小文字を区別しません
- boundary 抽出の正規表現を `/;\s*boundary\s*=\s*(?:"([^"]*)"|([^\s;][^;]*))/i` に変更。
  - パラメータ名の大小文字違い(`BOUNDARY=`)、`=`前後の空白、引用符付き値を許容
  - `;` アンカーで `xboundary=` 等の別名パラメータへの誤マッチを防止
  - 空・空白のみの非引用値はマッチさせず、重複時は後続の有効な boundary を回復(旧来の挙動と互換)
- boundary が得られない不正な multipart 要求には 400(`Bad Request.`)を返し、フィールドを静かに消さないようにしました。

## テスト

`test/node/plugin_httpserver_test.mjs` に回帰テストを追加しました。

- メディア型の大小文字違い(`Multipart/Form-Data` / `MULTIPART/FORM-DATA`)でも解析できること
- boundary パラメータ名の大小文字・`=`前後の空白・引用符付き値・非先頭のパラメータ位置・`;`直後空白なし・引用符内`;`含有値
- boundary 欠落・空値(`boundary=` / `boundary=""`)・`boundary=""; boundary=X` の先勝ちで 400 になること
- 空・空白のみの非引用 boundary の後に有効な boundary がある場合に回復すること
- `;` を欠く malformed な Content-Type は生本文扱いになること
- JSON 系メディア型(charset 付き・大文字・`+json`・`application/json-`)・urlencoded 大文字
- 400 応答後もサーバが生存し正常な要求を処理できること

## 検証

- `npm run test:node` … 全196件中190件パス(6件スキップ・既存のもの)
- `npm run test:common` … 全35件パス
- `npm run eslint` … 今回の変更による新規警告なし
- `tsc` … 型エラーなし
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kujirahand/nadesiko3/pull/2538" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->